### PR TITLE
fix: use correct --reason flag for bd close

### DIFF
--- a/src/plugins/trackers/builtin/beads.ts
+++ b/src/plugins/trackers/builtin/beads.ts
@@ -431,7 +431,7 @@ export class BeadsTrackerPlugin extends BaseTrackerPlugin {
     const args = ['update', id, '--status', 'closed'];
 
     if (reason) {
-      args.push('--close_reason', reason);
+      args.push('--reason', reason);
     }
 
     const { exitCode, stderr, stdout } = await execBd(args, this.workingDir);


### PR DESCRIPTION
## Bug

Agents were failing when trying to complete tasks because the beads plugin used `--close_reason` instead of `--reason`.

## Fix

Cherry-picked only commit `2d125678e24f4fe5a1854932666257e25ebabf3b` onto clean `origin/main`.

```diff
- args.push('--close_reason', reason);
+ args.push('--reason', reason);
```