### PR TITLE
docs: fix bv repo URL and install instructions

### DIFF
--- a/website/content/docs/plugins/trackers/beads-bv.mdx
+++ b/website/content/docs/plugins/trackers/beads-bv.mdx
@@ -5,7 +5,7 @@ description: Smart task selection using PageRank, critical path, and graph analy
 
 ## Beads-BV Tracker
 
-The Beads-BV tracker extends the standard Beads tracker with intelligent task selection powered by [bv](https://github.com/steveyegge/bv) (Beads Viewer). It uses graph algorithms like PageRank and critical path analysis to pick tasks that unblock the most downstream work.
+The Beads-BV tracker extends the standard Beads tracker with intelligent task selection powered by [bv](https://github.com/Dicklesworthstone/beads_viewer) (Beads Viewer). It uses graph algorithms like PageRank and critical path analysis to pick tasks that unblock the most downstream work.
 
 <Callout type="tip">
 Beads-BV is ideal for large projects with complex dependency graphs. It automatically prioritizes bottleneck tasks.
@@ -20,7 +20,7 @@ Install both the Beads CLI and Beads Viewer:
 bun install -g beads-cli
 
 # Install bv (Beads Viewer)
-bun install -g beads-viewer
+curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh" | bash
 ```
 
 Initialize Beads in your project:
@@ -261,7 +261,7 @@ Use Beads for simple projects, Beads-BV for complex dependency graphs.
 Install Beads Viewer:
 
 ```bash
-bun install -g beads-viewer
+curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh" | bash
 ```
 
 ### "Falling back to basic beads"


### PR DESCRIPTION
## Summary
- Fixed incorrect bv GitHub URL (was `steveyegge/bv`, now `Dicklesworthstone/beads_viewer`)
- Fixed bv install instructions (was `bun install -g beads-viewer`, now curl script since bv is a Go binary)

## Test plan
- [x] Verify links work correctly on docs site
- [x] Confirm install command works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Beads-BV plugin documentation with the new Beads Viewer repository reference and revised installation instructions for improved clarity.
  * Installation method has been changed from bun package manager commands to a curl-based installation script. Updates have been consistently applied across all relevant documentation sections, including Prerequisites, Troubleshooting guides, and installation references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->