### PR TITLE
fix: Shift+Enter not inserting newline in chat input

### DIFF
--- a/src/tui/components/ChatView.tsx
+++ b/src/tui/components/ChatView.tsx
@@ -186,8 +186,12 @@ export function ChatView({
         return;
       }
 
-      // Check for Ctrl+J or Shift+Enter - allow default behavior (newline)
-      // These don't need special handling, just let them through
+      // Shift+Enter or Ctrl+J = insert newline
+      if ((key.shift && key.name === 'return') || (key.ctrl && key.name === 'j')) {
+        key.preventDefault?.();
+        textarea.newLine();
+        return;
+      }
 
       // === Option + Arrow Keys (word navigation) ===
       if (key.option && !key.shift && !key.meta && !key.ctrl) {


### PR DESCRIPTION
## Summary
- Fixed Shift+Enter not inserting newlines in the text input after launching `create-prd` command
- The textarea was relying on "default behavior" which doesn't exist in OpenTUI - now explicitly calls `textarea.newLine()`
- Also fixes Ctrl+J which had the same issue

## Test plan
- [ ] Launch `ralph create-prd` command
- [ ] Type some text in the input
- [ ] Press Shift+Enter to verify a newline is inserted
- [ ] Press Ctrl+J to verify a newline is inserted
- [ ] Press Enter to verify the message is still submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed keyboard shortcut handling in chat input. Shift+Enter and Ctrl+J now reliably insert newlines as intended.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->