### PR TITLE
docs: add Factory Droid to setup and agent references

### DIFF
--- a/website/content/docs/cli/setup.mdx
+++ b/website/content/docs/cli/setup.mdx
@@ -30,6 +30,7 @@ The interactive wizard performs these steps:
     Scans for available AI coding agents:
     - **Claude Code** - Looks for `claude` CLI
     - **OpenCode** - Looks for `opencode` CLI
+    - **Factory Droid** - Looks for `droid` CLI
 
     Prompts you to select which agent to use as the default.
   </Step>
@@ -74,10 +75,12 @@ Welcome to Ralph TUI Setup!
 Detecting installed agents...
 ✓ Found: claude (Claude Code)
 ✓ Found: opencode (OpenCode)
+✓ Found: droid (Factory Droid)
 
 ? Which agent should be the default?
 ❯ claude - Claude Code (recommended)
   opencode - OpenCode
+  droid - Factory Droid
 
 ? Default tracker type?
 ❯ json - Simple JSON file (no dependencies)
@@ -182,9 +185,13 @@ which claude
 # Check for OpenCode
 which opencode
 
+# Check for Factory Droid
+which droid
+
 # If not found, install one:
 # Claude Code: https://docs.anthropic.com/en/docs/claude-code
 # OpenCode: https://github.com/opencode-ai/opencode
+# Factory Droid: https://docs.factory.ai/reference/cli-reference
 ```
 
 ### "Permission denied" for skills

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -65,7 +65,7 @@ ralph-tui setup
 ```
 
 This interactive command will:
-1. Detect installed agents (Claude Code, OpenCode)
+1. Detect installed agents (Claude Code, OpenCode, Factory Droid)
 2. Create `.ralph-tui/config.toml` with your choices
 3. Install bundled skills for PRD creation
 4. Optionally configure trackers

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -47,6 +47,7 @@ Ralph TUI orchestrates AI coding agents. You'll need at least one installed:
 
 - **[Claude Code](https://code.claude.com/docs/en/overview)** - Anthropic's official CLI for Claude
 - **[OpenCode](https://opencode.ai/docs)** - Open-source alternative supporting multiple AI providers
+- **[Factory Droid](https://docs.factory.ai/reference/cli-reference)** - Factory Droid CLI with JSONL tracing
 
 ## Installation Methods
 
@@ -136,7 +137,7 @@ ralph-tui setup
 
 The setup wizard will:
 
-1. **Detect agents** - Find installed AI coding agents (Claude Code, OpenCode)
+1. **Detect agents** - Find installed AI coding agents (Claude Code, OpenCode, Factory Droid)
 2. **Create configuration** - Generate `.ralph-tui/config.toml` with your preferences
 3. **Install skills** - Add bundled skills for PRD creation and task conversion
 4. **Detect trackers** - Optionally find existing prd.json or Beads setups

--- a/website/content/docs/getting-started/introduction.mdx
+++ b/website/content/docs/getting-started/introduction.mdx
@@ -5,10 +5,10 @@ description: Ralph TUI is an AI Agent Loop Orchestrator - a terminal UI for runn
 
 ## What is Ralph TUI?
 
-Ralph TUI is an **AI Agent Loop Orchestrator** that automates the cycle of selecting tasks, building prompts, running AI agents, and detecting completion. Instead of manually copying task details into Claude Code or OpenCode, Ralph does it for you in a continuous loop.
+Ralph TUI is an **AI Agent Loop Orchestrator** that automates the cycle of selecting tasks, building prompts, running AI agents, and detecting completion. Instead of manually copying task details into Claude Code, OpenCode, or Factory Droid, Ralph does it for you in a continuous loop.
 
 <Callout type="tip">
-Ralph TUI connects your AI coding assistant (Claude Code, OpenCode) to your task tracker (prd.json, Beads) and runs them in an autonomous loop, completing tasks one-by-one with intelligent selection, error handling, and full visibility.
+Ralph TUI connects your AI coding assistant (Claude Code, OpenCode, Factory Droid) to your task tracker (prd.json, Beads) and runs them in an autonomous loop, completing tasks one-by-one with intelligent selection, error handling, and full visibility.
 </Callout>
 
 ## The Autonomous Loop
@@ -49,6 +49,7 @@ The AI CLI that executes tasks. Currently supported:
 
 - **Claude Code** - Anthropic's Claude with the `claude` CLI
 - **OpenCode** - Open-source alternative using the `opencode` CLI
+- **Factory Droid** - Factory Droid CLI using `droid`
 
 ### Prompt Template
 

--- a/website/content/docs/getting-started/quick-start.mdx
+++ b/website/content/docs/getting-started/quick-start.mdx
@@ -33,7 +33,7 @@ JSON mode uses a simple `prd.json` file for task tracking. It's perfect for gett
     ```
 
     The interactive wizard will:
-    - Detect installed agents (Claude Code, OpenCode)
+    - Detect installed agents (Claude Code, OpenCode, Factory Droid)
     - Create a `.ralph-tui/config.toml` configuration file
     - Install bundled skills for PRD creation and task conversion
     - Optionally detect existing trackers

--- a/website/content/docs/plugins/overview.mdx
+++ b/website/content/docs/plugins/overview.mdx
@@ -28,6 +28,7 @@ Agent plugins connect to AI coding assistants that execute tasks. They handle:
 **Built-in agents:**
 - **[Claude Code](/docs/plugins/agents/claude)** - Anthropic's Claude CLI with subagent tracing
 - **[OpenCode](/docs/plugins/agents/opencode)** - Open-source multi-provider agent
+- **[Factory Droid](/docs/plugins/agents/droid)** - Factory Droid CLI with JSONL tracing
 
 ### Tracker Plugins
 
@@ -77,14 +78,14 @@ The execution engine orchestrates plugins:
 
 ### Agents
 
-| Feature | Claude Code | OpenCode |
-|---------|-------------|----------|
-| Provider | Anthropic | Multi-provider |
-| Models | sonnet, opus, haiku | Any via provider/model format |
-| Subagent Tracing | Yes (JSONL) | No |
-| File Context | Yes (--add-dir) | Yes (--file) |
-| Streaming | Yes | Yes |
-| Installation | `npm i -g @anthropic-ai/claude-code` | `curl -fsSL https://opencode.ai/install \| bash` |
+| Feature | Claude Code | OpenCode | Factory Droid |
+|---------|-------------|----------|--------------|
+| Provider | Anthropic | Multi-provider | Factory |
+| Models | sonnet, opus, haiku | Any via provider/model format | Factory model list |
+| Subagent Tracing | Yes (JSONL) | No | Yes (JSONL) |
+| File Context | Yes (--add-dir) | Yes (--file) | No (uses `--cwd`) |
+| Streaming | Yes | Yes | Yes |
+| Installation | `npm i -g @anthropic-ai/claude-code` | `curl -fsSL https://opencode.ai/install \| bash` | [Factory Droid CLI](https://docs.factory.ai/reference/cli-reference) |
 
 ### Trackers
 
@@ -203,5 +204,5 @@ Key methods for trackers:
 
 Learn about specific plugins:
 
-- **Agents**: [Claude Code](/docs/plugins/agents/claude) | [OpenCode](/docs/plugins/agents/opencode)
+- **Agents**: [Claude Code](/docs/plugins/agents/claude) | [OpenCode](/docs/plugins/agents/opencode) | [Factory Droid](/docs/plugins/agents/droid)
 - **Trackers**: [JSON](/docs/plugins/trackers/json) | [Beads](/docs/plugins/trackers/beads) | [Beads-BV](/docs/plugins/trackers/beads-bv)

--- a/website/content/docs/templates/overview.mdx
+++ b/website/content/docs/templates/overview.mdx
@@ -5,7 +5,7 @@ description: Learn how Ralph TUI uses Handlebars templates to build prompts for 
 
 ## What Are Prompt Templates?
 
-Prompt templates are [Handlebars](https://handlebarsjs.com) templates that transform task data into structured prompts for AI agents. When Ralph picks a task from your tracker, it uses a template to build the prompt that gets sent to Claude Code or OpenCode.
+Prompt templates are [Handlebars](https://handlebarsjs.com) templates that transform task data into structured prompts for AI agents. When Ralph picks a task from your tracker, it uses a template to build the prompt that gets sent to Claude Code, OpenCode, or Factory Droid.
 
 <Callout type="info">
 Handlebars is a simple templating language that uses `{{variable}}` syntax for variable substitution and `{{#if condition}}...{{/if}}` for conditional blocks.
@@ -32,7 +32,7 @@ Templates give you control over how your AI agent receives task information:
 │                                                                 │
 │   {                    ## User Story          Structured        │
 │     id: "US-001",      **ID**: US-001   →    markdown sent      │
-│     title: "Add..."    **Title**: Add...     to Claude/OpenCode │
+│     title: "Add..."    **Title**: Add...     to Claude/OpenCode/Droid │
 │   }                                                             │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
@@ -54,7 +54,7 @@ When Ralph executes a task:
   </Step>
 
   <Step title="Execute Agent">
-    The rendered prompt is passed to your AI agent (Claude Code or OpenCode).
+    The rendered prompt is passed to your AI agent (Claude Code, OpenCode, or Factory Droid).
   </Step>
 </Steps>
 


### PR DESCRIPTION
## Summary
Updates documentation to include Factory Droid (droid) in setup wizard steps and other agent references. Detection is already plugin-driven via the registry.

## Changes
- Setup wizard docs: detect/install/"no agents found" now include Factory Droid
- Getting started and configuration docs updated to list Factory Droid
- Plugins overview updated with Factory Droid list + comparison table
- Templates overview updated to mention Factory Droid in agent references

## Files Updated
- `website/content/docs/cli/setup.mdx`
- `website/content/docs/getting-started/quick-start.mdx`
- `website/content/docs/getting-started/installation.mdx`
- `website/content/docs/configuration/overview.mdx`
- `website/content/docs/plugins/overview.mdx`
- `website/content/docs/templates/overview.mdx`
- `website/content/docs/getting-started/introduction.mdx`