### PR TITLE
fix: include stderr in error messages for failed agent executions

### DIFF
--- a/src/chat/engine.ts
+++ b/src/chat/engine.ts
@@ -228,14 +228,17 @@ export class ChatEngine {
 
       if (result.status !== 'completed') {
         this.setStatus('error');
+        // Build a useful error message: prefer explicit error, then stderr, then generic status
+        const trimmedStderr = result.stderr?.trim();
+        const errorMessage = result.error || trimmedStderr || `Execution ${result.status}`;
         this.emit({
           type: 'error:occurred',
           timestamp: new Date(),
-          error: result.error || `Execution ${result.status}`,
+          error: errorMessage,
         });
         return {
           success: false,
-          error: result.error || `Execution ${result.status}`,
+          error: errorMessage,
           durationMs,
         };
       }


### PR DESCRIPTION
## Motivation
When using `ralph-tui create-prd --chat` and sending a message, if the agent fails the error displayed is just "Execution failed" with no actionable information. This makes it impossible to diagnose what went wrong.

## Summary
- Include stderr content in error messages when result.error is empty
- Fallback chain: result.error → result.stderr → generic status message

## Test plan
- [x] Run `ralph-tui create-prd --chat` and trigger an agent failure
- [x] Verify error message now shows actual stderr content instead of generic "Execution failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling for non‑completed task results: the system now prioritises explicit error text, falls back to trimmed standard error output, and otherwise uses a clear generic execution status. Emitted error events and returned error values are now aligned, providing more consistent and informative messages for users and logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->