### PR TITLE
docs: document using skills directly in agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Ralph selects the highest-priority task, builds a prompt, executes your AI agent
 - **Real-time TUI**: Watch agent output, control execution with keyboard shortcuts
 - **Subagent Tracing**: See nested agent calls in real-time
 - **Cross-iteration Context**: Automatic progress tracking between tasks
+- **Flexible Skills**: Use PRD/task skills directly in your agent or via the TUI
 
 ## CLI Commands
 
@@ -138,6 +139,19 @@ ralph-tui create-prd --output ./docs
 | `?` | Show help |
 
 See the [full CLI reference](https://ralph-tui.com/docs/cli/overview) for all options.
+
+### Using Skills Directly in Your Agent
+
+After running `ralph-tui setup`, skills are installed to `~/.claude/skills/` and can be used directly in Claude Code:
+
+```bash
+# In Claude Code, use these slash commands:
+/ralph-tui-prd           # Create a PRD interactively
+/ralph-tui-create-json   # Convert PRD to prd.json
+/ralph-tui-create-beads  # Convert PRD to Beads issues
+```
+
+This lets you create PRDs while referencing source files (`@filename`) and using your full conversation context—then use `ralph-tui run` for autonomous execution.
 
 ### Custom Skills Directory
 

--- a/website/content/docs/cli/setup.mdx
+++ b/website/content/docs/cli/setup.mdx
@@ -130,13 +130,17 @@ retryDelayMs = 5000
 
 ## Skills Installation
 
-Skills are installed to your Claude Code skills directory:
+Skills are installed to your Claude Code skills directory (`~/.claude/skills/`):
 
 | Skill | Location | Purpose |
 |-------|----------|---------|
-| `ralph-tui-prd` | `~/.claude-code/skills/` | AI-powered PRD creation |
-| `ralph-tui-create-json` | `~/.claude-code/skills/` | Convert PRD to JSON tasks |
-| `ralph-tui-create-beads` | `~/.claude-code/skills/` | Convert PRD to Beads issues |
+| `ralph-tui-prd` | `~/.claude/skills/` | AI-powered PRD creation |
+| `ralph-tui-create-json` | `~/.claude/skills/` | Convert PRD to JSON tasks |
+| `ralph-tui-create-beads` | `~/.claude/skills/` | Convert PRD to Beads issues |
+
+<Callout type="tip">
+These skills can also be used **directly in Claude Code** without the Ralph TUI interface. See [Using Skills Directly](#using-skills-directly) below.
+</Callout>
 
 <Callout type="info">
 Skills require Claude Code. If using OpenCode, you can still create PRDs using the built-in template mode.
@@ -205,6 +209,58 @@ mkdir -p ~/.claude-code/skills
 # Check permissions
 ls -la ~/.claude-code/
 ```
+
+## Using Skills Directly
+
+After running `ralph-tui setup`, the installed skills can be used **directly in your preferred AI agent** (Claude Code, OpenCode) without needing the Ralph TUI interface. This is ideal when you want to:
+
+- Reference files and use agent-native features during PRD creation
+- Integrate PRD creation into your existing workflow
+- Use the skills as part of a larger conversation with your agent
+
+### Direct Skill Usage in Claude Code
+
+Once skills are installed, invoke them with slash commands:
+
+```bash
+# In Claude Code, type:
+/ralph-tui-prd         # Start creating a PRD interactively
+/ralph-tui-create-json # Convert an existing PRD to prd.json
+/ralph-tui-create-beads # Convert an existing PRD to Beads issues
+```
+
+### Example Workflow
+
+1. **Create a PRD directly in Claude Code:**
+   ```
+   You: /ralph-tui-prd
+   Claude: I'll help you create a PRD. What feature would you like to plan?
+   You: I want to add user authentication. Here's our existing auth code: @src/auth/
+   Claude: [Asks clarifying questions, references your code]
+   ```
+
+2. **Convert to tasks:**
+   ```
+   You: /ralph-tui-create-json
+   Claude: I'll convert the PRD to prd.json format...
+   ```
+
+3. **Run Ralph for autonomous execution:**
+   ```bash
+   ralph-tui run --prd ./prd.json
+   ```
+
+### Why Use Skills Directly?
+
+| Approach | Best For |
+|----------|----------|
+| `ralph-tui create-prd --chat` | Quick standalone PRD creation |
+| `/ralph-tui-prd` in Claude Code | Complex PRDs that need file references, existing context, or iterative refinement |
+| `ralph-tui run` | Autonomous task execution |
+
+<Callout type="tip">
+Using skills directly in Claude Code gives you full access to file references (`@filename`), conversation context, and all agent features while creating your PRD.
+</Callout>
 
 ## Related Commands
 

--- a/website/content/docs/getting-started/introduction.mdx
+++ b/website/content/docs/getting-started/introduction.mdx
@@ -92,6 +92,18 @@ Manual AI-assisted coding works well for single tasks, but becomes tedious when 
 2. Watch the progress dashboard
 3. Coffee break ☕
 
+## Flexible Usage
+
+Ralph TUI is designed to fit your workflow, not the other way around:
+
+- **Full TUI Experience**: Use `ralph-tui run` for autonomous execution with a real-time dashboard
+- **Skills in Your Agent**: Use the bundled skills (`/ralph-tui-prd`, `/ralph-tui-create-json`, `/ralph-tui-create-beads`) directly in Claude Code or OpenCode for PRD creation and task conversion
+- **Mix and Match**: Create PRDs in your agent where you can reference files and context, then use Ralph TUI for autonomous execution
+
+<Callout type="tip">
+After running `ralph-tui setup`, skills are installed to `~/.claude/skills/` and can be invoked directly in Claude Code. This gives you the power of Ralph's PRD and task creation without leaving your preferred agent interface.
+</Callout>
+
 ## Next Steps
 
 Ready to get started? Here's where to go next:

--- a/website/content/docs/getting-started/quick-start.mdx
+++ b/website/content/docs/getting-started/quick-start.mdx
@@ -94,6 +94,26 @@ Beads provides additional features like:
 - Hierarchy (epics containing stories)
 - Labels and priorities
 
+## Alternative: Using Skills Directly in Your Agent
+
+Prefer to stay in Claude Code or OpenCode? After running `ralph-tui setup`, you can use the installed skills directly in your agent:
+
+```bash
+# In Claude Code or OpenCode, use slash commands:
+/ralph-tui-prd           # Create a PRD interactively
+/ralph-tui-create-json   # Convert PRD to prd.json
+/ralph-tui-create-beads  # Convert PRD to Beads issues
+```
+
+This approach lets you:
+- Reference files with `@filename` during PRD creation
+- Use your existing conversation context
+- Keep your preferred agent interface
+
+<Callout type="tip">
+**Recommended hybrid workflow:** Create your PRD using `/ralph-tui-prd` in Claude Code where you can reference source files, then use `ralph-tui run` for autonomous task execution.
+</Callout>
+
 ## Controlling Execution
 
 While Ralph is running, use these keyboard shortcuts:


### PR DESCRIPTION
## Summary

- Documents that ralph-tui skills can be used directly in Claude Code or OpenCode without the TUI
- Fixes incorrect skills path (`~/.claude-code/skills/` → `~/.claude/skills/`)
- Addresses feedback from #87 about the custom TUI interface being limiting

## Changes

- **setup.mdx**: Fixed skills path, added "Using Skills Directly" section with examples
- **introduction.mdx**: Added "Flexible Usage" section explaining three approaches (TUI, direct skills, hybrid)
- **quick-start.mdx**: Added alternative workflow section for direct skill usage
- **README.md**: Added skills info to features list and usage section

## Test plan

- [ ] Verify MDX syntax is valid (no build errors)
- [ ] Review rendered documentation on preview
- [ ] Confirm skills path matches actual installation location (`~/.claude/skills/`)

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Expanded documentation to cover flexible usage modes: full TUI experience, direct skill integration in Claude Code, and hybrid workflows.
* Added comprehensive guidance on using installed skills directly in agents without the TUI.
* Included practical examples and troubleshooting steps for direct skill implementation.
* Updated skills installation path information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->