### PR TITLE
feat: Add work item type distinction

### DIFF
--- a/skills/ralph-tui-create-beads/SKILL.md
+++ b/skills/ralph-tui-create-beads/SKILL.md
@@ -16,9 +16,10 @@ Converts PRDs to beads (epic + child tasks) for ralph-tui autonomous execution.
 Take a PRD (markdown file or text) and create beads in `.beads/beads.jsonl`:
 1. **Extract Quality Gates** from the PRD's "Quality Gates" section
 2. Create an **epic** bead for the feature
-3. Create **child beads** for each user story (with quality gates appended)
+3. Create **child beads** for each work item (with quality gates appended)
 4. Set up **dependencies** between beads (schema → backend → UI)
-5. Output ready for `ralph-tui run --tracker beads`
+5. Map **work item type** to beads `--type=` flag
+6. Output ready for `ralph-tui run --tracker beads`
 
 ---
 
@@ -54,26 +55,41 @@ Beads use `bd create` command:
 bd create --type=epic \
   --title="[Feature Name]" \
   --description="[Feature description from PRD]" \
-  --labels="ralph,feature"
+  --labels="ralph"
 
 # Create child bead (with quality gates in acceptance criteria)
 bd create \
+  --type=[story|task] \
   --parent=EPIC_ID \
-  --title="[Story Title]" \
-  --description="[Story description with acceptance criteria INCLUDING quality gates]" \
+  --title="[Work Item Title]" \
+  --description="[Description with acceptance criteria INCLUDING quality gates]" \
   --priority=[1-4] \
-  --labels="ralph,task"
+  --labels="ralph"
 ```
 
 ---
 
-## Story Size: The #1 Rule
+## Type Mapping
 
-**Each story must be completable in ONE ralph-tui iteration (~one agent context window).**
+Map work item prefixes to beads `--type=` flag (case-insensitive):
 
-ralph-tui spawns a fresh agent instance per iteration with no memory of previous work. If a story is too big, the agent runs out of context before finishing.
+| Prefix | `--type=` | Notes |
+|--------|-----------|-------|
+| US-xxx | story | User-facing features ("As a user, I want...") |
+| TA-xxx | task | Technical work (schema, backend, refactoring, bugs, maintenance) |
+| other | task | Default for unknown prefixes (including legacy FR-xxx) |
 
-### Right-sized stories:
+**Labels strategy:** Use `--labels="ralph"` for grouping only. Type classification uses `--type=` flag, not labels.
+
+---
+
+## Work Item Size: The #1 Rule
+
+**Each work item must be completable in ONE ralph-tui iteration (~one agent context window).**
+
+ralph-tui spawns a fresh agent instance per iteration with no memory of previous work. If an item is too big, the agent runs out of context before finishing.
+
+### Right-sized items:
 - Add a database column + migration
 - Add a UI component to an existing page
 - Update a server action with new logic
@@ -88,9 +104,9 @@ ralph-tui spawns a fresh agent instance per iteration with no memory of previous
 
 ---
 
-## Story Ordering: Dependencies First
+## Work Item Ordering: Dependencies First
 
-Stories execute in dependency order. Earlier stories must not depend on later ones.
+Items execute in dependency order. Earlier items must not depend on later ones.
 
 **Correct order:**
 1. Schema/database changes (migrations)
@@ -134,10 +150,10 @@ ralph-tui will:
 
 ---
 
-## Acceptance Criteria: Quality Gates + Story-Specific
+## Acceptance Criteria: Quality Gates + Item-Specific
 
 Each bead's description should include acceptance criteria with:
-1. **Story-specific criteria** from the PRD (what this story accomplishes)
+1. **Item-specific criteria** from the PRD (what this work item accomplishes)
 2. **Quality gates** from the PRD's Quality Gates section (appended at the end)
 
 ### Good criteria (verifiable):
@@ -156,14 +172,15 @@ Each bead's description should include acceptance criteria with:
 ## Conversion Rules
 
 1. **Extract Quality Gates** from PRD first
-2. **Each user story → one bead**
-3. **First story**: No dependencies (creates foundation)
-4. **Subsequent stories**: Depend on their predecessors (UI depends on backend, etc.)
-5. **Priority**: Based on dependency order, then document order (0=critical, 2=medium, 4=backlog)
-6. **Labels**: Epic gets `ralph,feature`; Tasks get `ralph,task`
-7. **All stories**: `status: "open"`
-8. **Acceptance criteria**: Story criteria + quality gates appended
-9. **UI stories**: Also append UI-specific gates (browser verification)
+2. **Each work item → one bead**
+3. **Map prefix to type**: US-xxx → story, TA-xxx (and others) → task
+4. **First item**: No dependencies (creates foundation)
+5. **Subsequent items**: Depend on their predecessors (UI depends on backend, etc.)
+6. **Priority**: Based on dependency order, then document order (0=critical, 2=medium, 4=backlog)
+7. **Labels**: All beads get `ralph` label only (type is in `--type=` flag)
+8. **All items**: `status: "open"`
+9. **Acceptance criteria**: Item criteria + quality gates appended
+10. **UI items**: Also append UI-specific gates (browser verification)
 
 ---
 
@@ -175,11 +192,11 @@ If a PRD has big features, split them:
 > "Add friends outreach track with different messaging"
 
 **Split into:**
-1. US-001: Add investorType field to database
+1. TA-001: Add investorType field to database
 2. US-002: Add type toggle to investor list UI
-3. US-003: Create friend-specific phase progression logic
-4. US-004: Create friend message templates
-5. US-005: Wire up task generation for friends
+3. TA-003: Create friend-specific phase progression logic
+4. TA-004: Create friend message templates
+5. TA-005: Wire up task generation for friends
 6. US-006: Add filter by type
 7. US-007: Update new investor form
 8. US-008: Update dashboard counts
@@ -198,36 +215,41 @@ Add ability to mark investors as "friends" for warm outreach.
 
 ## Quality Gates
 
-These commands must pass for every user story:
+These commands must pass for every work item:
 - `pnpm typecheck` - Type checking
 - `pnpm lint` - Linting
 
-For UI stories, also include:
+For UI items, also include:
 - Verify in browser using dev-browser skill
 
-## User Stories
+## Work Items
 
-### US-001: Add investorType field to investor table
-**Description:** As a developer, I need to categorize investors as 'cold' or 'friend'.
+### TA-001: Add investorType field to investor table
+**Type:** task
+**Description:** Add investorType column to categorize investors as 'cold' or 'friend'.
 
 **Acceptance Criteria:**
 - [ ] Add investorType column: 'cold' | 'friend' (default 'cold')
 - [ ] Generate and run migration successfully
 
 ### US-002: Add type toggle to investor list rows
-**Description:** As Ryan, I want to toggle investor type directly from the list.
+**Type:** story
+**Description:** As Ryan, I want to toggle investor type directly from the list so that I can quickly categorize investors.
 
 **Acceptance Criteria:**
 - [ ] Each row has Cold | Friend toggle
 - [ ] Switching shows confirmation dialog
 - [ ] On confirm: updates type in database
+**Depends on:** TA-001
 
 ### US-003: Filter investors by type
-**Description:** As Ryan, I want to filter the list to see just friends or cold.
+**Type:** story
+**Description:** As Ryan, I want to filter the list to see just friends or cold so that I can focus on specific investor groups.
 
 **Acceptance Criteria:**
 - [ ] Filter dropdown: All | Cold | Friend
 - [ ] Filter persists in URL params
+**Depends on:** US-002
 ```
 
 **Output beads:**
@@ -236,12 +258,13 @@ For UI stories, also include:
 bd create --type=epic \
   --title="Friends Outreach Track" \
   --description="Warm outreach for deck feedback" \
-  --labels="ralph,feature"
+  --labels="ralph"
 
-# US-001: No deps (first - creates schema)
-bd create --parent=ralph-tui-abc \
-  --title="US-001: Add investorType field to investor table" \
-  --description="As a developer, I need to categorize investors as 'cold' or 'friend'.
+# TA-001: Task, no deps (first - creates schema)
+bd create --type=task \
+  --parent=ralph-tui-abc \
+  --title="TA-001: Add investorType field to investor table" \
+  --description="Add investorType column to categorize investors as 'cold' or 'friend'.
 
 ## Acceptance Criteria
 - [ ] Add investorType column: 'cold' | 'friend' (default 'cold')
@@ -249,12 +272,13 @@ bd create --parent=ralph-tui-abc \
 - [ ] pnpm typecheck passes
 - [ ] pnpm lint passes" \
   --priority=1 \
-  --labels="ralph,task"
+  --labels="ralph"
 
-# US-002: UI story (gets browser verification too)
-bd create --parent=ralph-tui-abc \
+# US-002: Story, UI (gets browser verification too)
+bd create --type=story \
+  --parent=ralph-tui-abc \
   --title="US-002: Add type toggle to investor list rows" \
-  --description="As Ryan, I want to toggle investor type directly from the list.
+  --description="As Ryan, I want to toggle investor type directly from the list so that I can quickly categorize investors.
 
 ## Acceptance Criteria
 - [ ] Each row has Cold | Friend toggle
@@ -264,15 +288,16 @@ bd create --parent=ralph-tui-abc \
 - [ ] pnpm lint passes
 - [ ] Verify in browser using dev-browser skill" \
   --priority=2 \
-  --labels="ralph,task"
+  --labels="ralph"
 
-# Add dependency: US-002 depends on US-001
+# Add dependency: US-002 depends on TA-001
 bd dep add ralph-tui-002 ralph-tui-001
 
-# US-003: UI story
-bd create --parent=ralph-tui-abc \
+# US-003: Story, UI
+bd create --type=story \
+  --parent=ralph-tui-abc \
   --title="US-003: Filter investors by type" \
-  --description="As Ryan, I want to filter the list to see just friends or cold.
+  --description="As Ryan, I want to filter the list to see just friends or cold so that I can focus on specific investor groups.
 
 ## Acceptance Criteria
 - [ ] Filter dropdown: All | Cold | Friend
@@ -281,7 +306,7 @@ bd create --parent=ralph-tui-abc \
 - [ ] pnpm lint passes
 - [ ] Verify in browser using dev-browser skill" \
   --priority=3 \
-  --labels="ralph,task"
+  --labels="ralph"
 
 # Add dependency: US-003 depends on US-002
 bd dep add ralph-tui-003 ralph-tui-002
@@ -313,10 +338,12 @@ ralph-tui will:
 ## Checklist Before Creating Beads
 
 - [ ] Extracted Quality Gates from PRD (or asked user if missing)
-- [ ] Each story is completable in one iteration (small enough)
-- [ ] Stories are ordered by dependency (schema → backend → UI)
+- [ ] Each work item is completable in one iteration (small enough)
+- [ ] Work items are ordered by dependency (schema → backend → UI)
+- [ ] Mapped item prefixes to `--type=` flag (US-xxx → story, TA-xxx → task)
+- [ ] Using `--labels="ralph"` only (no type in labels)
 - [ ] Quality gates appended to every bead's acceptance criteria
-- [ ] UI stories have browser verification (if specified in Quality Gates)
+- [ ] UI items have browser verification (if specified in Quality Gates)
 - [ ] Acceptance criteria are verifiable (not vague)
-- [ ] No story depends on a later story (only earlier stories)
+- [ ] No item depends on a later item (only earlier items)
 - [ ] Dependencies added with `bd dep add` after creating beads

--- a/skills/ralph-tui-prd/SKILL.md
+++ b/skills/ralph-tui-prd/SKILL.md
@@ -89,12 +89,12 @@ Brief description of the feature and the problem it solves.
 Specific, measurable objectives (bullet list).
 
 ### 3. Quality Gates
-**CRITICAL:** List the commands that must pass for every user story.
+**CRITICAL:** List the commands that must pass for every work item.
 
 ```markdown
 ## Quality Gates
 
-These commands must pass for every user story:
+These commands must pass for every work item:
 - `pnpm typecheck` - Type checking
 - `pnpm lint` - Linting
 
@@ -104,51 +104,63 @@ For UI stories, also include:
 
 This section is extracted by conversion tools (ralph-tui-create-json, ralph-tui-create-beads) and appended to each story's acceptance criteria.
 
-### 4. User Stories
-Each story needs:
-- **Title:** Short descriptive name
-- **Description:** "As a [user], I want [feature] so that [benefit]"
+### 4. Work Items
+Each work item needs:
+- **ID with Type Prefix:** US-xxx (story) or TA-xxx (task)
+- **Type:** Explicit type declaration
+- **Description:** Format depends on type (see below)
 - **Acceptance Criteria:** Verifiable checklist of what "done" means
 
-Each story should be small enough to implement in one focused AI agent session.
+Each item should be small enough to implement in one focused AI agent session.
+
+**Work Item Types:**
+
+| Prefix | Type | When to Use | Description Format |
+|--------|------|-------------|-------------------|
+| US-xxx | story | User-facing features | "As a [user], I want [X] so that [Y]" |
+| TA-xxx | task | Technical work (schema, backend, refactoring, bugs, maintenance) | Imperative: "Add X", "Fix Y" |
+
+**ID Counter:** Use a global counter across both types (US-001, TA-002, US-003, not US-001, TA-001).
 
 **Format:**
 ```markdown
-### US-001: [Title]
+### US-001: [Story Title]
+**Type:** story
 **Description:** As a [user], I want [feature] so that [benefit].
 
 **Acceptance Criteria:**
 - [ ] Specific verifiable criterion
 - [ ] Another criterion
+
+### TA-002: [Task Title]
+**Type:** task
+**Description:** Add [X] to support [feature Y].
+
+**Acceptance Criteria:**
+- [ ] Specific verifiable criterion
 ```
 
-**Note:** Do NOT include quality gate commands in individual story criteria - they are defined once in the Quality Gates section and applied automatically during conversion.
+**Note:** Do NOT include quality gate commands in individual item criteria - they are defined once in the Quality Gates section and applied automatically during conversion.
 
 **Important:**
 - Acceptance criteria must be verifiable, not vague
 - "Works correctly" is bad
 - "Button shows confirmation dialog before deleting" is good
-- Each story should be independently completable
+- Each item should be independently completable
+- Order items by dependency (items that must be done first appear first)
 
-### 5. Functional Requirements
-Numbered list of specific functionalities:
-- "FR-1: The system must allow users to..."
-- "FR-2: When a user clicks X, the system must..."
-
-Be explicit and unambiguous.
-
-### 6. Non-Goals (Out of Scope)
+### 5. Non-Goals (Out of Scope)
 What this feature will NOT include. Critical for managing scope.
 
-### 7. Technical Considerations (Optional)
+### 6. Technical Considerations (Optional)
 - Known constraints or dependencies
 - Integration points with existing systems
 - Performance requirements
 
-### 8. Success Metrics
+### 7. Success Metrics
 How will success be measured?
 
-### 9. Open Questions
+### 8. Open Questions
 Remaining questions or areas needing clarification.
 
 ---
@@ -158,7 +170,7 @@ Remaining questions or areas needing clarification.
 The PRD will be executed by AI coding agents via ralph-tui. Therefore:
 
 - Be explicit and unambiguous
-- User stories should be small (completable in one session)
+- Work items should be small (completable in one session)
 - Acceptance criteria must be machine-verifiable where possible
 - Include specific file paths if you know them
 - Reference existing code patterns in the project
@@ -179,7 +191,7 @@ The PRD will be executed by AI coding agents via ralph-tui. Therefore:
 ## Quality Gates
 ...
 
-## User Stories
+## Work Items
 ...
 [/PRD]
 ```
@@ -242,25 +254,27 @@ Add dark mode support to ralph-tui to reduce eye strain during long orchestratio
 
 ## Quality Gates
 
-These commands must pass for every user story:
+These commands must pass for every work item:
 - `pnpm typecheck` - Type checking
 - `pnpm lint` - Linting
 
 For UI stories, also include:
 - Verify in browser using dev-browser skill
 
-## User Stories
+## Work Items
 
-### US-001: Add theme configuration
-**Description:** As a user, I want to set my preferred theme (light/dark) so that it persists across sessions.
+### TA-001: Add theme configuration schema
+**Type:** task
+**Description:** Add theme field to configuration schema to support light/dark modes.
 
 **Acceptance Criteria:**
 - [ ] Add `theme` field to `.ralph-tui.yaml` schema
 - [ ] Support values: "light", "dark", "system"
 - [ ] Default to "light" for backwards compatibility
 
-### US-002: Create dark theme color palette
-**Description:** As a user, I want a soft-contrast dark theme that's easy on the eyes.
+### TA-002: Create dark theme color palette
+**Type:** task
+**Description:** Define dark theme color palette with proper contrast ratios.
 
 **Acceptance Criteria:**
 - [ ] Define dark palette with gray tones (not pure black)
@@ -268,7 +282,8 @@ For UI stories, also include:
 - [ ] Colors work well for all UI states (selected, hover, disabled)
 
 ### US-003: Apply theme to TUI components
-**Description:** As a user, I want all TUI components to respect my theme preference.
+**Type:** story
+**Description:** As a user, I want all TUI components to respect my theme preference so that I have a consistent viewing experience.
 
 **Acceptance Criteria:**
 - [ ] Header component uses theme colors
@@ -276,20 +291,17 @@ For UI stories, also include:
 - [ ] Detail panels use theme colors
 - [ ] Progress bar uses theme colors
 - [ ] Dialogs use theme colors
+**Depends on:** TA-001, TA-002
 
 ### US-004: Add theme toggle in settings
-**Description:** As a user, I want to toggle themes from within the TUI settings.
+**Type:** story
+**Description:** As a user, I want to toggle themes from within the TUI settings so that I can change themes without editing config files.
 
 **Acceptance Criteria:**
 - [ ] Theme option visible in settings view
 - [ ] Changes apply immediately without restart
 - [ ] Changes persist to config file
-
-## Functional Requirements
-- FR-1: Theme setting must be readable from `.ralph-tui.yaml`
-- FR-2: Theme must apply on TUI startup
-- FR-3: Theme changes in settings must apply immediately
-- FR-4: All text must maintain readability in both themes
+**Depends on:** US-003
 
 ## Non-Goals
 - System theme auto-detection (future enhancement)
@@ -320,8 +332,11 @@ Before outputting the PRD:
 - [ ] Asked about quality gates (REQUIRED)
 - [ ] Asked follow-up questions when needed
 - [ ] Quality Gates section included with project-specific commands
-- [ ] User stories are small and independently completable
-- [ ] User stories do NOT include quality gate commands (they're in the Quality Gates section)
-- [ ] Functional requirements are numbered and unambiguous
+- [ ] Work items use correct prefixes: US-xxx (story) or TA-xxx (task)
+- [ ] Work items include explicit **Type:** line
+- [ ] Stories use "As a user..." format; tasks use imperative format
+- [ ] Work items are small and independently completable
+- [ ] Work items do NOT include quality gate commands (they're in the Quality Gates section)
+- [ ] Work items are ordered by dependency (dependencies first)
 - [ ] Non-goals section defines clear boundaries
 - [ ] PRD is wrapped in `[PRD]...[/PRD]` markers


### PR DESCRIPTION
Addresses #88

## Changes

Adds work item type distinction to PRD skills and JSON tracker:

| Prefix | Type | When to Use |
|--------|------|-------------|
| `US-xxx` | story | User-facing features ("As a user, I want...") |
| `TA-xxx` | task | Technical work (schema, backend, bugs, maintenance) |

- PRD skills now document `US-xxx` for stories, `TA-xxx` for tasks
- Adds `type` field to prd.json schema (inferred from prefix if not explicit)
- Beads converter uses `--type=story|task` flag
- Backward compatible: existing files without `type` field still work

**Note:** Haven't tested this yet - wanted to run it by you early. Happy to adjust based on feedback.