### PR TITLE
fix: prevent false positive rate-limit detection from package names

### DIFF
--- a/src/engine/rate-limit-detector.ts
+++ b/src/engine/rate-limit-detector.ts
@@ -58,8 +58,9 @@ const COMMON_PATTERNS: RateLimitPattern[] = [
     retryAfterPattern: /retry[- ]?after[:\s]+(\d+)\s*s/i,
   },
   // Generic rate limit phrases
+  // NOTE: Requires space or hyphen separator to avoid matching package names like @upstash/ratelimit
   {
-    pattern: /rate[- ]?limit/i,
+    pattern: /rate[- ]limit/i,
     retryAfterPattern: /retry[- ]?after[:\s]+(\d+)\s*s/i,
   },
   // Too many requests


### PR DESCRIPTION
## Summary
- Fixed regex pattern that caused false positive rate-limit detection when agent output contained package names like `@upstash/ratelimit`
- Changed pattern from `/rate[- ]?limit/i` to `/rate[- ]limit/i` to require separator between "rate" and "limit"
- Added regression tests for the specific false positive scenario

## Test plan
- [x] All 42 rate-limit-detector tests pass
- [x] New tests verify `@upstash/ratelimit`, import statements, and function names don't trigger false positives
- [x] Typecheck passes
- [x] Build succeeds

Fixes #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Improved rate limit detection accuracy and reliability through regression testing. The updates prevent false positives when encountering package-like names, concatenated terms, and function/variable identifiers.

* **Tests**
  * Added regression tests to prevent false positives in rate limit pattern matching.

* **Documentation**
  * Clarified rate limit pattern matching requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->