### PR TITLE
docs: add --force flag to setup reconfiguration tip

### DIFF
--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -143,7 +143,7 @@ The setup wizard will:
 4. **Detect trackers** - Optionally find existing prd.json or Beads setups
 
 <Callout type="tip">
-You can re-run `ralph-tui setup` at any time to reconfigure your project.
+You can re-run `ralph-tui setup --force` at any time to reconfigure your project.
 </Callout>
 
 ## Verifying Installation


### PR DESCRIPTION
## Summary

- Updates the installation docs to correctly mention `--force` flag for re-running setup

Fixes #104. The documentation incorrectly stated that running `ralph-tui setup` would reconfigure the project, but the actual behavior requires `--force` to overwrite existing configuration.

## Test plan

- [ ] Review the docs change in the PR diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation guidance to clarify re-running setup with the explicit --force flag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->