### PR TITLE
fix: engine delegates to tracker.getNextTask() for dependency ordering

### DIFF
--- a/src/plugins/trackers/base.ts
+++ b/src/plugins/trackers/base.ts
@@ -238,6 +238,12 @@ export abstract class BaseTrackerPlugin implements TrackerPlugin {
       result = result.filter((t) => t.type && types.includes(t.type));
     }
 
+    // Exclude specific task IDs (used for skipped/failed tasks)
+    if (filter.excludeIds && filter.excludeIds.length > 0) {
+      const excludeSet = new Set(filter.excludeIds);
+      result = result.filter((t) => !excludeSet.has(t.id));
+    }
+
     // Filter to ready tasks (no unresolved dependencies)
     if (filter.ready) {
       result = result.filter((t) => this.checkTaskReady(t, tasks));

--- a/src/plugins/trackers/builtin/beads.ts
+++ b/src/plugins/trackers/builtin/beads.ts
@@ -611,7 +611,17 @@ export class BeadsTrackerPlugin extends BaseTrackerPlugin {
     }
 
     // Convert to TrackerTask
-    const tasks = beads.map(beadToTask);
+    let tasks = beads.map(beadToTask);
+
+    // Filter out excluded task IDs (used by engine for skipped/failed tasks)
+    if (filter?.excludeIds && filter.excludeIds.length > 0) {
+      const excludeSet = new Set(filter.excludeIds);
+      tasks = tasks.filter((t) => !excludeSet.has(t.id));
+    }
+
+    if (tasks.length === 0) {
+      return undefined;
+    }
 
     // Prefer in_progress tasks over open tasks (same as base implementation)
     const inProgress = tasks.find((t) => t.status === 'in_progress');

--- a/src/plugins/trackers/types.ts
+++ b/src/plugins/trackers/types.ts
@@ -176,6 +176,9 @@ export interface TaskFilter {
 
   /** Offset for pagination */
   offset?: number;
+
+  /** Exclude tasks with these IDs (used by engine to skip failed tasks) */
+  excludeIds?: string[];
 }
 
 /**

--- a/tests/engine/integration.test.ts
+++ b/tests/engine/integration.test.ts
@@ -140,6 +140,34 @@ function createControllableTracker(options: {
         return dep?.status === 'completed';
       });
     },
+    async getNextTask(filter) {
+      // Filter to open/in_progress tasks
+      const activeTasks = tasks.filter(t =>
+        t.status === 'open' || t.status === 'in_progress'
+      );
+
+      // Filter out excluded IDs
+      const excludeSet = new Set(filter?.excludeIds ?? []);
+      const candidates = activeTasks.filter(t => !excludeSet.has(t.id));
+
+      // Find ready tasks (no unresolved dependencies)
+      for (const task of candidates) {
+        if (!task.dependsOn || task.dependsOn.length === 0) {
+          return task;
+        }
+        const allDepsComplete = task.dependsOn.every(depId => {
+          const dep = tasks.find(t => t.id === depId);
+          return dep?.status === 'completed';
+        });
+        if (allDepsComplete) {
+          return task;
+        }
+      }
+      return undefined;
+    },
+    async getEpics() {
+      return [];
+    },
     async updateTaskStatus(taskId, status) {
       const task = tasks.find(t => t.id === taskId);
       if (task) {

--- a/tests/plugins/beads-tracker.test.ts
+++ b/tests/plugins/beads-tracker.test.ts
@@ -227,6 +227,35 @@ describe('BeadsTrackerPlugin getNextTask', () => {
     });
   });
 
+  describe('excludeIds filter handling', () => {
+    // Tests for excludeIds filter - used by engine to skip failed tasks
+    // See: https://github.com/subsy/ralph-tui/issues/97#issuecomment-3762075053
+
+    test('accepts TaskFilter with excludeIds', async () => {
+      await plugin.initialize({ workingDir: '/tmp/nonexistent-beads-test' });
+
+      // Should accept excludeIds without throwing
+      const result = await plugin.getNextTask({
+        excludeIds: ['task-1', 'task-2', 'task-3'],
+      });
+      expect(result).toBeUndefined();
+    });
+
+    test('accepts TaskFilter with empty excludeIds', async () => {
+      await plugin.initialize({ workingDir: '/tmp/nonexistent-beads-test' });
+
+      const result = await plugin.getNextTask({
+        excludeIds: [],
+      });
+      expect(result).toBeUndefined();
+    });
+
+    test.todo('excludeIds filters out specified tasks from bd ready results - requires CLI mocking');
+    // When bd ready returns tasks [task-1, task-2, task-3] and excludeIds=['task-1'],
+    // getNextTask should return task-2 instead of task-1
+    // This is critical for the engine's skipped task handling
+  });
+
   describe('behavior documentation', () => {
     // These tests document the expected behavior of getNextTask
     // The implementation uses bd ready for server-side dependency filtering


### PR DESCRIPTION
## Summary

- Fix engine to call `tracker.getNextTask()` instead of doing its own task selection loop
- Add `excludeIds` to `TaskFilter` for skipped task handling
- The PR #109 fix added `getNextTask()` to `BeadsTrackerPlugin` but the engine never called it

## Root Cause

The engine's `getNextAvailableTask()` was doing its own loop:
1. Call `getTasks()` (returns tasks in reverse ID order from beads)
2. Loop through checking `isTaskReady()` on each
3. Return first ready task found

This bypassed the `getNextTask()` method that uses `bd ready` for proper dependency ordering.

## Changes

- **src/plugins/trackers/types.ts** - Add `excludeIds` to `TaskFilter`
- **src/plugins/trackers/base.ts** - Handle `excludeIds` in `filterTasks()`
- **src/plugins/trackers/builtin/beads.ts** - Filter excluded IDs in `getNextTask()`
- **src/engine/index.ts** - Delegate to `tracker.getNextTask()` with `excludeIds`
- Tests updated for new behavior

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] `bun test` passes (993 pass, 7 todo, 0 fail)
- [ ] Manual testing with chained dependencies confirms correct ordering

Fixes #97