### PR TITLE
feat: add top-level 'command' config for custom agent executables

### DIFF
--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -16,6 +16,7 @@ import {
   getProjectConfigPath,
   getProjectConfigDir,
   checkSetupStatus,
+  buildConfig,
   CONFIG_PATHS,
 } from './index.js';
 import type { StoredConfig, RalphConfig } from './types.js';
@@ -543,31 +544,31 @@ describe('Config merging - scalar overrides', () => {
     expect(config.fallbackAgents).toEqual(['droid']);
   });
 
-  test('project overrides executable', async () => {
-    await writeTomlConfig(globalConfigPath, { executable: 'global-ccr code' });
+  test('project overrides command', async () => {
+    await writeTomlConfig(globalConfigPath, { command: 'global-ccr code' });
 
     const projectConfigDir = join(tempDir, '.ralph-tui');
     await mkdir(projectConfigDir, { recursive: true });
-    await writeTomlConfig(join(projectConfigDir, 'config.toml'), { executable: 'project-ccr code' });
+    await writeTomlConfig(join(projectConfigDir, 'config.toml'), { command: 'project-ccr code' });
 
     const config = await loadStoredConfig(tempDir, globalConfigPath);
-    expect(config.executable).toBe('project-ccr code');
+    expect(config.command).toBe('project-ccr code');
   });
 
-  test('executable from global config is preserved when project has none', async () => {
+  test('command from global config is preserved when project has none', async () => {
     await writeTomlConfig(globalConfigPath, {
       agent: 'claude',
-      executable: 'ccr code',
+      command: 'ccr code',
     });
 
     const projectConfigDir = join(tempDir, '.ralph-tui');
     await mkdir(projectConfigDir, { recursive: true });
     await writeTomlConfig(join(projectConfigDir, 'config.toml'), {
-      maxIterations: 20,  // Other field, no executable
+      maxIterations: 20,  // Other field, no command
     });
 
     const config = await loadStoredConfig(tempDir, globalConfigPath);
-    expect(config.executable).toBe('ccr code');
+    expect(config.command).toBe('ccr code');
     expect(config.maxIterations).toBe(20);
   });
 });
@@ -732,5 +733,86 @@ describe('validateConfig', () => {
     const result = await validateConfig(config);
     expect(result.valid).toBe(false);
     expect(result.errors.some((e) => e.includes('PRD'))).toBe(true);
+  });
+});
+
+describe('buildConfig - command shorthand', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('applies command shorthand to agent config', async () => {
+    // Create project config with command shorthand
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeFile(
+      join(projectConfigDir, 'config.toml'),
+      `
+agent = "claude"
+tracker = "beads-bv"
+command = "ccr code"
+`,
+      'utf-8'
+    );
+
+    const config = await buildConfig({ cwd: tempDir });
+
+    expect(config).not.toBeNull();
+    expect(config!.agent.command).toBe('ccr code');
+  });
+
+  test('agent-level command takes precedence over top-level command', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeFile(
+      join(projectConfigDir, 'config.toml'),
+      `
+command = "top-level-command"
+tracker = "beads-bv"
+
+[[agents]]
+name = "claude"
+plugin = "claude"
+command = "agent-level-command"
+default = true
+`,
+      'utf-8'
+    );
+
+    const config = await buildConfig({ cwd: tempDir });
+
+    expect(config).not.toBeNull();
+    // Agent-level command should win
+    expect(config!.agent.command).toBe('agent-level-command');
+  });
+
+  test('command shorthand is not applied if agent already has command', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeFile(
+      join(projectConfigDir, 'config.toml'),
+      `
+command = "should-not-be-used"
+tracker = "beads-bv"
+
+[[agents]]
+name = "custom-claude"
+plugin = "claude"
+command = "my-custom-claude"
+default = true
+`,
+      'utf-8'
+    );
+
+    const config = await buildConfig({ cwd: tempDir });
+
+    expect(config).not.toBeNull();
+    expect(config!.agent.command).toBe('my-custom-claude');
   });
 });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -147,7 +147,7 @@ function mergeConfigs(global: StoredConfig, project: StoredConfig): StoredConfig
   if (project.outputDir !== undefined) merged.outputDir = project.outputDir;
   if (project.agent !== undefined) merged.agent = project.agent;
   if (project.agentCommand !== undefined) merged.agentCommand = project.agentCommand;
-  if (project.executable !== undefined) merged.executable = project.executable;
+  if (project.command !== undefined) merged.command = project.command;
   if (project.tracker !== undefined) merged.tracker = project.tracker;
 
   // Replace arrays entirely if present in project config
@@ -315,13 +315,12 @@ function getDefaultAgentConfig(
       };
     }
 
-    // Apply executable shorthand (only if not already set on agent config)
+    // Apply command shorthand (only if not already set on agent config)
     // This allows users to specify a custom executable like 'ccr code' for Claude Code Router
-    // The 'executable' field in StoredConfig maps to 'command' in AgentPluginConfig
-    if (storedConfig.executable && !result.command) {
+    if (storedConfig.command && !result.command) {
       result = {
         ...result,
-        command: storedConfig.executable,
+        command: storedConfig.command,
       };
     }
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -391,81 +391,81 @@ describe('validateStoredConfig', () => {
   });
 });
 
-describe('StoredConfigSchema executable field', () => {
-  test('accepts valid executable paths', () => {
+describe('StoredConfigSchema command field', () => {
+  test('accepts valid command paths', () => {
     const result = StoredConfigSchema.parse({
-      executable: 'ccr code',
+      command: 'ccr code',
     });
-    expect(result.executable).toBe('ccr code');
+    expect(result.command).toBe('ccr code');
   });
 
   test('accepts absolute paths', () => {
     const result = StoredConfigSchema.parse({
-      executable: '/opt/bin/my-claude',
+      command: '/opt/bin/my-claude',
     });
-    expect(result.executable).toBe('/opt/bin/my-claude');
+    expect(result.command).toBe('/opt/bin/my-claude');
   });
 
   test('accepts paths with arguments', () => {
     const result = StoredConfigSchema.parse({
-      executable: 'ccr code --verbose',
+      command: 'ccr code --verbose',
     });
-    expect(result.executable).toBe('ccr code --verbose');
+    expect(result.command).toBe('ccr code --verbose');
   });
 
-  test('rejects executables with semicolons (command chaining)', () => {
+  test('rejects commands with semicolons (command chaining)', () => {
     expect(() =>
       StoredConfigSchema.parse({
-        executable: 'ccr; rm -rf /',
+        command: 'ccr; rm -rf /',
       })
     ).toThrow(/shell metacharacters/);
   });
 
-  test('rejects executables with ampersands (background execution)', () => {
+  test('rejects commands with ampersands (background execution)', () => {
     expect(() =>
       StoredConfigSchema.parse({
-        executable: 'ccr & malicious',
+        command: 'ccr & malicious',
       })
     ).toThrow(/shell metacharacters/);
   });
 
-  test('rejects executables with pipes (command piping)', () => {
+  test('rejects commands with pipes (command piping)', () => {
     expect(() =>
       StoredConfigSchema.parse({
-        executable: 'ccr | tee /etc/passwd',
+        command: 'ccr | tee /etc/passwd',
       })
     ).toThrow(/shell metacharacters/);
   });
 
-  test('rejects executables with backticks (command substitution)', () => {
+  test('rejects commands with backticks (command substitution)', () => {
     expect(() =>
       StoredConfigSchema.parse({
-        executable: 'ccr `whoami`',
+        command: 'ccr `whoami`',
       })
     ).toThrow(/shell metacharacters/);
   });
 
-  test('rejects executables with dollar signs (variable expansion)', () => {
+  test('rejects commands with dollar signs (variable expansion)', () => {
     expect(() =>
       StoredConfigSchema.parse({
-        executable: 'ccr $HOME',
+        command: 'ccr $HOME',
       })
     ).toThrow(/shell metacharacters/);
   });
 
-  test('rejects executables with parentheses (subshells)', () => {
+  test('rejects commands with parentheses (subshells)', () => {
     expect(() =>
       StoredConfigSchema.parse({
-        executable: 'ccr $(cat /etc/passwd)',
+        command: 'ccr $(cat /etc/passwd)',
       })
     ).toThrow(/shell metacharacters/);
   });
 
   test('allows dashes, underscores, and slashes in paths', () => {
     const result = StoredConfigSchema.parse({
-      executable: '/usr/local/bin/my-agent_v2',
+      command: '/usr/local/bin/my-agent_v2',
     });
-    expect(result.executable).toBe('/usr/local/bin/my-agent_v2');
+    expect(result.command).toBe('/usr/local/bin/my-agent_v2');
   });
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -120,7 +120,7 @@ export const StoredConfigSchema = z
     agent: z.string().optional(),
     agentCommand: z.string().optional(),
     /**
-     * Custom executable path for the agent.
+     * Custom command/executable path for the agent.
      *
      * Use this to route agent requests through wrapper tools like Claude Code Router (CCR)
      * or to specify a custom binary location.
@@ -133,11 +133,11 @@ export const StoredConfigSchema = z
      * @example "ccr code" - Route through Claude Code Router
      * @example "/opt/bin/my-claude" - Absolute path to custom binary
      */
-    executable: z
+    command: z
       .string()
       .refine(
         (cmd) => !/[;&|`$()]/.test(cmd),
-        'Executable path cannot contain shell metacharacters (;&|`$()). Use a wrapper script instead.'
+        'Command cannot contain shell metacharacters (;&|`$()). Use a wrapper script instead.'
       )
       .optional(),
     agentOptions: AgentOptionsSchema.optional(),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -178,7 +178,7 @@ export interface StoredConfig {
   agentCommand?: string;
 
   /**
-   * Custom executable path for the agent.
+   * Custom command/executable path for the agent.
    *
    * Use this to route agent requests through wrapper tools like Claude Code Router (CCR)
    * or to specify a custom binary location.
@@ -191,7 +191,7 @@ export interface StoredConfig {
    * @example "ccr code" - Route through Claude Code Router
    * @example "/opt/bin/my-claude" - Absolute path to custom binary
    */
-  executable?: string;
+  command?: string;
 
   /** Shorthand: tracker plugin name */
   tracker?: string;

--- a/website/content/docs/configuration/config-file.mdx
+++ b/website/content/docs/configuration/config-file.mdx
@@ -35,8 +35,8 @@ Here's a fully annotated configuration file showing all available options:
 # Default agent plugin name
 agent = "claude"
 
-# Custom executable (optional) - use wrapper tools like Claude Code Router
-# executable = "ccr code"
+# Custom command (optional) - use wrapper tools like Claude Code Router
+# command = "ccr code"
 
 # Default tracker plugin name
 tracker = "beads-bv"
@@ -215,7 +215,7 @@ Use [Claude Code Router](https://github.com/anthropics/ccr) to route requests th
 
 ```toml
 agent = "claude"
-executable = "ccr code"
+command = "ccr code"
 tracker = "beads-bv"
 ```
 

--- a/website/content/docs/configuration/options.mdx
+++ b/website/content/docs/configuration/options.mdx
@@ -18,7 +18,7 @@ These control basic execution behavior.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `agent` | string | - | Agent plugin to use (e.g., "claude", "opencode") |
-| `executable` | string | - | Custom executable for the agent (e.g., "ccr code") |
+| `command` | string | - | Custom command/executable for the agent (e.g., "ccr code") |
 | `tracker` | string | - | Tracker plugin to use (e.g., "beads-bv", "json") |
 | `maxIterations` | number | `10` | Maximum iterations per session (0 = unlimited, max 1000) |
 | `iterationDelay` | number | `1000` | Delay between iterations in milliseconds (max 300000) |
@@ -56,12 +56,12 @@ model = "claude-sonnet-4-20250514"
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `agent` | string | - | Agent plugin name |
-| `executable` | string | - | Custom executable path (see below) |
+| `command` | string | - | Custom command/executable path (see below) |
 | `agentOptions` | object | `{}` | Plugin-specific options |
 
-### Custom Executable
+### Custom Command
 
-The `executable` option lets you specify a custom binary or wrapper for your agent. This is useful for:
+The `command` option lets you specify a custom binary or wrapper for your agent. This is useful for:
 
 - **AI routing tools** like [Claude Code Router (CCR)](https://github.com/anthropics/ccr) that proxy to different providers
 - **Custom wrappers** that add logging, authentication, or other behavior
@@ -69,21 +69,21 @@ The `executable` option lets you specify a custom binary or wrapper for your age
 
 ```toml
 agent = "claude"
-executable = "ccr code"
+command = "ccr code"
 ```
 
 This uses the Claude agent plugin but routes requests through CCR, which can proxy to OpenRouter, DeepSeek, Ollama, Gemini, or other providers.
 
 #### Precedence
 
-The executable follows this precedence (highest to lowest):
+The command follows this precedence (highest to lowest):
 
 1. **Agent-specific**: `command` field in `[[agents]]` array
-2. **Top-level**: `executable` field
+2. **Top-level**: `command` field (this option)
 3. **Plugin default**: e.g., "claude" for the Claude plugin
 
 <Callout type="warning">
-For security, the `executable` field cannot contain shell metacharacters (`;`, `&`, `|`, `` ` ``, `$`, `(`, `)`). If you need complex command logic, create a wrapper script.
+For security, the `command` field cannot contain shell metacharacters (`;`, `&`, `|`, `` ` ``, `$`, `(`, `)`). If you need complex command logic, create a wrapper script.
 </Callout>
 
 ### Full Agent Configuration

--- a/website/content/docs/plugins/agents/claude.mdx
+++ b/website/content/docs/plugins/agents/claude.mdx
@@ -94,12 +94,12 @@ printMode = "text"
 | `command` | string | `"claude"` | Path to Claude CLI executable |
 
 <Callout type="tip">
-For simple configs, you can use the top-level `executable` option instead of the `[[agents]]` array:
+For simple configs, you can use the top-level `command` option instead of the `[[agents]]` array:
 ```toml
 agent = "claude"
-executable = "ccr code"  # Use Claude Code Router
+command = "ccr code"  # Use Claude Code Router
 ```
-See [Custom Executable](/docs/configuration/options#custom-executable) for details.
+See [Custom Command](/docs/configuration/options#custom-command) for details.
 </Callout>
 
 ## Models

--- a/website/content/docs/plugins/agents/opencode.mdx
+++ b/website/content/docs/plugins/agents/opencode.mdx
@@ -90,12 +90,12 @@ format = "default"
 | `command` | string | `"opencode"` | Path to OpenCode CLI executable |
 
 <Callout type="tip">
-For simple configs, you can use the top-level `executable` option instead of the `[[agents]]` array:
+For simple configs, you can use the top-level `command` option instead of the `[[agents]]` array:
 ```toml
 agent = "opencode"
-executable = "/custom/path/opencode"
+command = "/custom/path/opencode"
 ```
-See [Custom Executable](/docs/configuration/options#custom-executable) for details.
+See [Custom Command](/docs/configuration/options#custom-command) for details.
 </Callout>
 
 ## Providers and Models

--- a/website/content/docs/troubleshooting/common-issues.mdx
+++ b/website/content/docs/troubleshooting/common-issues.mdx
@@ -100,15 +100,15 @@ Ralph TUI cannot locate your AI agent CLI executable.
    ralph-tui run --agent claude --prd ./prd.json
    ```
 
-5. Use `executable` config for custom paths:
+5. Use `command` config for custom paths:
    ```toml
    # .ralph-tui/config.toml
    agent = "claude"
-   executable = "/custom/path/to/claude"
+   command = "/custom/path/to/claude"
    ```
 
 <Callout type="tip">
-If you installed an agent with a different package manager (npm, cargo, pip), you may need to add its bin directory to your PATH, or use the `executable` config option to specify the full path.
+If you installed an agent with a different package manager (npm, cargo, pip), you may need to add its bin directory to your PATH, or use the `command` config option to specify the full path.
 </Callout>
 
 ### Agent Output Not Streaming


### PR DESCRIPTION
## Summary

Adds a top-level `command` config option that allows users to specify a custom executable for their agent, enabling use of wrapper tools like Claude Code Router (CCR).

## Usage

```toml
agent = "claude"
command = "ccr code"
```

This uses the Claude agent plugin but routes requests through CCR, which can proxy to alternative AI providers like OpenRouter, DeepSeek, Ollama, or Gemini.

## Changes

- Added `command` field to `StoredConfigSchema` (zod validation)
- Added `command` field to `StoredConfig` type
- Updated config merging to include `command` from project config
- Updated `applyAgentOptions()` to apply command override to agent config

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run build` passes

## Notes

The existing per-agent `command` field in the `[[agents]]` array already worked:

```toml
[[agents]]
name = "claude-ccr"
plugin = "claude"
command = "ccr code"
```

This PR adds the shorthand version for simpler configs.

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add top-level and project-level "command" option to configs; project-level values override global and are applied to agent configs when not set at agent level.
* **Documentation**
  * Added examples, precedence notes, security guidance and a CCR routing example across docs.
* **Tests**
  * Added tests for merging behaviour and validation, including rejection of unsafe shell metacharacters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->