### PR TITLE
feat: add task type distinction (story vs task) in PRD conversion skills

### DIFF
--- a/skills/ralph-tui-create-beads/SKILL.md
+++ b/skills/ralph-tui-create-beads/SKILL.md
@@ -47,7 +47,7 @@ Extract:
 
 ## Output Format
 
-Beads use `bd create` command:
+Beads use `bd create` command with type distinction:
 
 ```bash
 # Create epic
@@ -56,14 +56,33 @@ bd create --type=epic \
   --description="[Feature description from PRD]" \
   --labels="ralph,feature"
 
-# Create child bead (with quality gates in acceptance criteria)
-bd create \
+# Create user story (US-xxx) - user-facing features
+bd create --type=story \
   --parent=EPIC_ID \
-  --title="[Story Title]" \
-  --description="[Story description with acceptance criteria INCLUDING quality gates]" \
+  --title="US-xxx: [Story Title]" \
+  --description="As a [user], I want [feature] so that [benefit]..." \
+  --priority=[1-4] \
+  --labels="ralph,story"
+
+# Create task (T-xxx) - technical/implementation work
+bd create --type=task \
+  --parent=EPIC_ID \
+  --title="T-xxx: [Task Title]" \
+  --description="[Technical task description with implementation details]" \
   --priority=[1-4] \
   --labels="ralph,task"
 ```
+
+### When to Use Each Type
+
+| PRD Item | Bead Type | Title Format | Example |
+|----------|-----------|--------------|---------|
+| **User Story (US-xxx)** | `--type=story` | `US-xxx: Title` | "US-001: View investor details" |
+| **Functional Req (FR-xxx)** | `--type=task` | `T-xxx: Title` | "T-001: Add investorType column" |
+| **Technical Task** | `--type=task` | `T-xxx: Title` | "T-002: Set up database migration" |
+
+**User Stories (US-xxx):** User-facing features described as "As a [user], I want..."
+**Tasks (T-xxx):** Technical work, database changes, refactoring, infrastructure
 
 ---
 
@@ -156,14 +175,26 @@ Each bead's description should include acceptance criteria with:
 ## Conversion Rules
 
 1. **Extract Quality Gates** from PRD first
-2. **Each user story → one bead**
-3. **First story**: No dependencies (creates foundation)
-4. **Subsequent stories**: Depend on their predecessors (UI depends on backend, etc.)
+2. **Convert PRD items to appropriate bead types:**
+   - **User Stories (US-xxx)** → `--type=story` bead with `US-xxx:` prefix
+   - **Functional Requirements (FR-xxx)** → `--type=task` bead with `T-xxx:` prefix
+   - **Technical work** (database, migrations, infrastructure) → `--type=task`
+3. **First item**: No dependencies (creates foundation)
+4. **Subsequent items**: Depend on their predecessors (UI depends on backend, etc.)
 5. **Priority**: Based on dependency order, then document order (0=critical, 2=medium, 4=backlog)
-6. **Labels**: Epic gets `ralph,feature`; Tasks get `ralph,task`
-7. **All stories**: `status: "open"`
-8. **Acceptance criteria**: Story criteria + quality gates appended
-9. **UI stories**: Also append UI-specific gates (browser verification)
+6. **Labels**: Epic gets `ralph,feature`; Stories get `ralph,story`; Tasks get `ralph,task`
+7. **All items**: `status: "open"`
+8. **Acceptance criteria**: Item criteria + quality gates appended
+9. **UI items**: Also append UI-specific gates (browser verification)
+
+### FR-xxx to T-xxx Mapping
+
+Functional Requirements (FR-xxx) in PRDs are technical tasks, not user stories. Convert them:
+
+| PRD | Bead |
+|-----|------|
+| `FR-001: Add investorType column` | `T-001: Add investorType column` with `--type=task` |
+| `FR-002: Set up migration` | `T-002: Set up migration` with `--type=task` |
 
 ---
 
@@ -205,16 +236,18 @@ These commands must pass for every user story:
 For UI stories, also include:
 - Verify in browser using dev-browser skill
 
-## User Stories
+## Functional Requirements
 
-### US-001: Add investorType field to investor table
-**Description:** As a developer, I need to categorize investors as 'cold' or 'friend'.
+### FR-001: Add investorType column to database
+Add investorType column: 'cold' | 'friend' with default 'cold'.
 
 **Acceptance Criteria:**
-- [ ] Add investorType column: 'cold' | 'friend' (default 'cold')
+- [ ] Add investorType column to investor table
 - [ ] Generate and run migration successfully
 
-### US-002: Add type toggle to investor list rows
+## User Stories
+
+### US-001: Add type toggle to investor list rows
 **Description:** As Ryan, I want to toggle investor type directly from the list.
 
 **Acceptance Criteria:**
@@ -222,7 +255,7 @@ For UI stories, also include:
 - [ ] Switching shows confirmation dialog
 - [ ] On confirm: updates type in database
 
-### US-003: Filter investors by type
+### US-002: Filter investors by type
 **Description:** As Ryan, I want to filter the list to see just friends or cold.
 
 **Acceptance Criteria:**
@@ -238,22 +271,22 @@ bd create --type=epic \
   --description="Warm outreach for deck feedback" \
   --labels="ralph,feature"
 
-# US-001: No deps (first - creates schema)
-bd create --parent=ralph-tui-abc \
-  --title="US-001: Add investorType field to investor table" \
-  --description="As a developer, I need to categorize investors as 'cold' or 'friend'.
+# T-001: Technical task (FR-001 → T-001)
+bd create --type=task --parent=ralph-tui-abc \
+  --title="T-001: Add investorType column to database" \
+  --description="Add investorType column: 'cold' | 'friend' with default 'cold'.
 
 ## Acceptance Criteria
-- [ ] Add investorType column: 'cold' | 'friend' (default 'cold')
+- [ ] Add investorType column to investor table
 - [ ] Generate and run migration successfully
 - [ ] pnpm typecheck passes
 - [ ] pnpm lint passes" \
   --priority=1 \
   --labels="ralph,task"
 
-# US-002: UI story (gets browser verification too)
-bd create --parent=ralph-tui-abc \
-  --title="US-002: Add type toggle to investor list rows" \
+# US-001: User story with UI (gets browser verification too)
+bd create --type=story --parent=ralph-tui-abc \
+  --title="US-001: Add type toggle to investor list rows" \
   --description="As Ryan, I want to toggle investor type directly from the list.
 
 ## Acceptance Criteria
@@ -264,14 +297,14 @@ bd create --parent=ralph-tui-abc \
 - [ ] pnpm lint passes
 - [ ] Verify in browser using dev-browser skill" \
   --priority=2 \
-  --labels="ralph,task"
+  --labels="ralph,story"
 
-# Add dependency: US-002 depends on US-001
+# Add dependency: US-001 depends on T-001 (UI needs schema first)
 bd dep add ralph-tui-002 ralph-tui-001
 
-# US-003: UI story
-bd create --parent=ralph-tui-abc \
-  --title="US-003: Filter investors by type" \
+# US-002: User story with UI
+bd create --type=story --parent=ralph-tui-abc \
+  --title="US-002: Filter investors by type" \
   --description="As Ryan, I want to filter the list to see just friends or cold.
 
 ## Acceptance Criteria
@@ -281,9 +314,9 @@ bd create --parent=ralph-tui-abc \
 - [ ] pnpm lint passes
 - [ ] Verify in browser using dev-browser skill" \
   --priority=3 \
-  --labels="ralph,task"
+  --labels="ralph,story"
 
-# Add dependency: US-003 depends on US-002
+# Add dependency: US-002 depends on US-001
 bd dep add ralph-tui-003 ralph-tui-002
 ```
 

--- a/skills/ralph-tui-create-json/SKILL.md
+++ b/skills/ralph-tui-create-json/SKILL.md
@@ -54,12 +54,12 @@ Extract:
   "description": "[Feature description from PRD]",
   "userStories": [
     {
-      "id": "US-001",
-      "title": "[Story title]",
-      "description": "As a [user], I want [feature] so that [benefit]",
+      "id": "T-001",
+      "type": "task",
+      "title": "[Technical task title]",
+      "description": "Technical task description...",
       "acceptanceCriteria": [
         "Criterion 1 from PRD",
-        "Criterion 2 from PRD",
         "pnpm typecheck passes",
         "pnpm lint passes"
       ],
@@ -69,11 +69,13 @@ Extract:
       "dependsOn": []
     },
     {
-      "id": "US-002",
-      "title": "[UI Story that depends on US-001]",
-      "description": "...",
+      "id": "US-001",
+      "type": "story",
+      "title": "[Story title]",
+      "description": "As a [user], I want [feature] so that [benefit]",
       "acceptanceCriteria": [
-        "...",
+        "Criterion 1 from PRD",
+        "Criterion 2 from PRD",
         "pnpm typecheck passes",
         "pnpm lint passes",
         "Verify in browser using dev-browser skill"
@@ -81,11 +83,20 @@ Extract:
       "priority": 2,
       "passes": false,
       "notes": "",
-      "dependsOn": ["US-001"]
+      "dependsOn": ["T-001"]
     }
   ]
 }
 ```
+
+### Task Types
+
+| PRD Item | ID Format | Type | Description |
+|----------|-----------|------|-------------|
+| **User Story (US-xxx)** | `US-001` | `"story"` | User-facing features: "As a [user], I want..." |
+| **Functional Req (FR-xxx)** | `T-001` | `"task"` | Technical work: database, migrations, refactoring |
+
+The `type` field is optional (defaults to `"story"`) but recommended for clarity.
 
 ---
 
@@ -158,14 +169,17 @@ Each story's acceptance criteria should include:
 ## Conversion Rules
 
 1. **Extract Quality Gates** from PRD first
-2. **Each user story → one JSON entry**
-3. **IDs**: Sequential (US-001, US-002, etc.)
+2. **Convert PRD items to appropriate types:**
+   - **User Stories (US-xxx)** → `id: "US-xxx"`, `type: "story"`
+   - **Functional Requirements (FR-xxx)** → `id: "T-xxx"`, `type: "task"`
+   - **Technical work** → `id: "T-xxx"`, `type: "task"`
+3. **IDs**: Sequential within type (T-001, T-002 for tasks; US-001, US-002 for stories)
 4. **Priority**: Based on dependency order (1 = highest)
-5. **dependsOn**: Array of story IDs this story requires
-6. **All stories**: `passes: false` and empty `notes`
+5. **dependsOn**: Array of item IDs this item requires
+6. **All items**: `passes: false` and empty `notes`
 7. **branchName**: Derive from feature name, kebab-case, prefixed with `ralph/`
-8. **Acceptance criteria**: Story criteria + quality gates appended
-9. **UI stories**: Also append UI-specific gates (browser verification)
+8. **Acceptance criteria**: Item criteria + quality gates appended
+9. **UI items**: Also append UI-specific gates (browser verification)
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the bundled PRD conversion skills to properly distinguish between user stories and technical tasks, fixing the semantic mismatch where technical work was forced into "user story" format.

## Changes

### ralph-tui-create-beads
- Add `--type=story` for user stories (US-xxx)
- Add `--type=task` for functional requirements (FR-xxx → T-xxx)
- Update conversion rules with FR-xxx to T-xxx mapping
- Update example to show both story and task types
- Update labels: stories get `ralph,story`, tasks get `ralph,task`

### ralph-tui-create-json
- Add optional `type` field: `"story"` or `"task"`
- Add T-xxx ID format for technical tasks
- Update conversion rules for type handling
- Document type mapping table

## Benefits

- **Semantic correctness:** Technical tasks aren't forced into awkward "As a developer, I want..." format
- **Better filtering:** Filter beads by type (show me all tasks, show me all stories)
- **Clearer PRD structure:** Readers understand what's user-facing vs technical
- **Leverages existing capability:** beads already supports `issue_type`
- **Backwards compatible:** `type` field is optional

## Example

**Before:**
```bash
bd create --title="US-001: Add investorType field" --description="As a developer, I need..."
```

**After:**
```bash
bd create --type=task --title="T-001: Add investorType column" --description="Add investorType column..."
```

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified bead creation types with distinct workflows for epics, stories, and tasks.
  * Updated PRD-to-task conversion mapping with explicit functional requirement guidance.
  * Enhanced command examples with type-specific formats and labelling conventions.
  * Improved acceptance criteria specifications with item-type alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->