### PR TITLE
fix: install templates to global config dir, not project

### DIFF
--- a/skills/ralph-tui-create-beads/SKILL.md
+++ b/skills/ralph-tui-create-beads/SKILL.md
@@ -50,10 +50,11 @@ Extract:
 Beads use `bd create` command:
 
 ```bash
-# Create epic
+# Create epic (link back to source PRD)
 bd create --type=epic \
   --title="[Feature Name]" \
   --description="[Feature description from PRD]" \
+  --external-ref="prd:./tasks/feature-name-prd.md" \
   --labels="ralph,feature"
 
 # Create child bead (with quality gates in acceptance criteria)
@@ -232,10 +233,11 @@ For UI stories, also include:
 
 **Output beads:**
 ```bash
-# Create epic
+# Create epic (link back to source PRD)
 bd create --type=epic \
   --title="Friends Outreach Track" \
   --description="Warm outreach for deck feedback" \
+  --external-ref="prd:./tasks/friends-outreach-prd.md" \
   --labels="ralph,feature"
 
 # US-001: No deps (first - creates schema)


### PR DESCRIPTION
## Summary

**Critical bug fix for v0.2.1**: Migration was incorrectly writing templates to the **project** directory instead of the **global** config directory.

### The Problem

Templates were being written to:
- ❌ `.ralph-tui/prompt.hbs` (project-level override)

Should be written to:
- ✅ `~/.config/ralph-tui/templates/*.hbs` (global user-level)

### Why This Matters

**Template resolution hierarchy:**
1. `customPath` (explicit --prompt or config)
2. **Project**: `./.ralph-tui/templates/{tracker}.hbs` ← User overrides
3. **Global**: `~/.config/ralph-tui/templates/{tracker}.hbs` ← User defaults
4. Tracker plugin template
5. Built-in template

Project-level templates are for **user customizations per-project**. We should never write there during migration - that's what global templates are for.

### Changes

- Use `installBuiltinTemplates()` to install all templates to global dir
- Install: `default.hbs`, `beads.hbs`, `beads-bv.hbs`, `json.hbs`
- Skip existing templates (preserves user customizations)

### Also Included

Update `ralph-tui-create-beads` skill to include PRD link in epics:
```bash
bd create --type=epic \
  --external-ref="prd:./tasks/feature-name-prd.md" \
  ...
```

## Test plan

- [x] 21 migration tests pass
- [x] Full test suite (1210 tests) passes
- [x] Typecheck passes
- [x] Build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated epic creation command examples and guidance documentation to include external references linking to project requirement documents for improved traceability.

* **Chores**
  * Refactored template installation to centralise provisioning at a global level rather than handling templates per-project. Enhanced installation resilience with improved error handling and installation status tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->