### PR TITLE
fix: add --max-turns 1 to Claude preflight check for reliable completion

### DIFF
--- a/src/plugins/agents/builtin/claude.ts
+++ b/src/plugins/agents/builtin/claude.ts
@@ -589,9 +589,15 @@ export class ClaudeAgentPlugin extends BaseAgentPlugin {
       }
 
       if (result.status === 'failed') {
+        // Include exit code and stderr for debugging
+        const details = [
+          result.error,
+          result.exitCode !== undefined ? `exit code: ${result.exitCode}` : null,
+          result.stderr ? `stderr: ${result.stderr.slice(0, 200)}` : null,
+        ].filter(Boolean).join(', ');
         return {
           success: false,
-          error: result.error ?? 'Agent execution failed',
+          error: details || 'Agent execution failed',
           suggestion: this.getPreflightSuggestion(),
           durationMs,
         };


### PR DESCRIPTION
The preflight check was timing out because it didn't limit Claude to a
single turn. Without --max-turns 1, Claude could run multiple turns or
attempt tool use, potentially exceeding the 30-second timeout even for
a simple test prompt.

This matches the behavior of a working manual test:
  claude -p "Say OK" --max-turns 1

Fixes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent preflight validation to run a quick, bounded feasibility check before operations.
  * Performs a minimal one-turn test, captures output and timing, and identifies timeouts or execution failures.
  * Returns timing information and actionable error suggestions to help troubleshoot availability issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->