### PR TITLE
feat: add envExclude option to filter environment variables for agents

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -186,6 +186,7 @@ function mergeConfigs(global: StoredConfig, project: StoredConfig): StoredConfig
 
   // Replace arrays entirely if present in project config
   if (project.fallbackAgents !== undefined) merged.fallbackAgents = project.fallbackAgents;
+  if (project.envExclude !== undefined) merged.envExclude = project.envExclude;
 
   // Merge nested objects
   if (project.rateLimitHandling !== undefined) {
@@ -332,6 +333,14 @@ function getDefaultAgentConfig(
       result = {
         ...result,
         command: storedConfig.command,
+      };
+    }
+
+    // Apply envExclude shorthand (only if not already set on agent config)
+    if (storedConfig.envExclude && !result.envExclude) {
+      result = {
+        ...result,
+        envExclude: storedConfig.envExclude,
       };
     }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -78,6 +78,7 @@ export const AgentPluginConfigSchema = z.object({
   options: AgentOptionsSchema.optional().default({}),
   fallbackAgents: z.array(z.string().min(1)).optional(),
   rateLimitHandling: RateLimitHandlingConfigSchema.optional(),
+  envExclude: z.array(z.string().min(1)).optional(),
 });
 
 /**
@@ -159,6 +160,9 @@ export const StoredConfigSchema = z
 
     // Rate limit handling (shorthand for default agent)
     rateLimitHandling: RateLimitHandlingConfigSchema.optional(),
+
+    // Environment variable exclusion (shorthand for default agent)
+    envExclude: z.array(z.string().min(1)).optional(),
 
     // Custom prompt template path
     prompt_template: z.string().optional(),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -217,6 +217,13 @@ export interface StoredConfig {
   /** Shorthand: rate limit handling configuration for the default agent */
   rateLimitHandling?: RateLimitHandlingConfig;
 
+  /**
+   * Shorthand: environment variables to exclude for the default agent.
+   * Use this to prevent sensitive keys from being inherited by agent processes.
+   * Supports exact names (e.g., "ANTHROPIC_API_KEY") or glob patterns (e.g., "*_API_KEY").
+   */
+  envExclude?: string[];
+
   /** Whether to auto-commit after successful tasks */
   autoCommit?: boolean;
 

--- a/src/plugins/agents/registry.ts
+++ b/src/plugins/agents/registry.ts
@@ -296,6 +296,7 @@ export class AgentRegistry {
       command: config.command,
       defaultFlags: config.defaultFlags,
       timeout: config.timeout,
+      envExclude: config.envExclude,
     };
 
     await instance.initialize(initConfig);

--- a/src/plugins/agents/types.ts
+++ b/src/plugins/agents/types.ts
@@ -234,6 +234,16 @@ export interface AgentPluginConfig {
 
   /** Rate limit handling configuration for this agent */
   rateLimitHandling?: RateLimitHandlingConfig;
+
+  /**
+   * Environment variables to exclude when spawning the agent process.
+   * Use this to prevent sensitive keys from being inherited by the agent.
+   * Supports exact names (e.g., "ANTHROPIC_API_KEY") or glob patterns (e.g., "*_API_KEY").
+   *
+   * @example ["ANTHROPIC_API_KEY"] - Exclude specific key
+   * @example ["*_API_KEY", "*_SECRET"] - Exclude all API keys and secrets
+   */
+  envExclude?: string[];
 }
 
 export interface AgentSandboxRequirements {

--- a/website/content/docs/configuration/options.mdx
+++ b/website/content/docs/configuration/options.mdx
@@ -118,6 +118,7 @@ timeout = 300000
 | `options` | object | `{}` | Plugin-specific options |
 | `fallbackAgents` | string[] | `[]` | Agents to try on rate limit |
 | `rateLimitHandling` | object | - | Rate limit configuration |
+| `envExclude` | string[] | `[]` | Environment variables to exclude (see below) |
 
 ## Tracker Options
 
@@ -234,6 +235,85 @@ recoverPrimaryBetweenIterations = true
 | `rateLimitHandling.maxRetries` | number | `3` | Retries before fallback (0-10) |
 | `rateLimitHandling.baseBackoffMs` | number | `5000` | Base backoff time (0-300000 ms) |
 | `rateLimitHandling.recoverPrimaryBetweenIterations` | boolean | `true` | Try primary between iterations |
+
+## Environment Variable Exclusion
+
+Controls which environment variables are passed to agent subprocesses. This is essential when your shell environment contains API keys that conflict with the agent's authentication method.
+
+### The Problem
+
+When you run ralph-tui from a directory containing a `.env` or `.env.local` file, tools like **direnv**, **dotenv-cli**, or frameworks like **Next.js** may automatically load these variables into your shell environment. If one of these variables is an API key (e.g., `ANTHROPIC_API_KEY`), the agent CLI will use it instead of your intended authentication method (like a Max subscription).
+
+### Solution: envExclude
+
+The `envExclude` option specifies environment variable patterns to filter out before spawning the agent process.
+
+```toml
+# Exclude specific variables
+envExclude = ["ANTHROPIC_API_KEY"]
+
+# Or use glob patterns to exclude multiple keys
+envExclude = ["*_API_KEY", "*_SECRET", "*_TOKEN"]
+```
+
+### Shorthand Configuration
+
+Apply to the default agent with a top-level setting:
+
+```toml
+agent = "claude"
+envExclude = ["ANTHROPIC_API_KEY"]
+```
+
+### Per-Agent Configuration
+
+Apply to specific agents in the `[[agents]]` array:
+
+```toml
+[[agents]]
+name = "claude-max"
+plugin = "claude"
+envExclude = ["ANTHROPIC_API_KEY"]
+
+[[agents]]
+name = "claude-api"
+plugin = "claude"
+# No envExclude - uses ANTHROPIC_API_KEY from environment
+```
+
+### Glob Pattern Syntax
+
+The `envExclude` patterns support glob-style wildcards:
+
+| Pattern | Matches |
+|---------|---------|
+| `ANTHROPIC_API_KEY` | Exact match only |
+| `*_API_KEY` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc. |
+| `*_SECRET` | `DB_SECRET`, `JWT_SECRET`, etc. |
+| `AWS_*` | All AWS environment variables |
+| `*TOKEN*` | Any variable containing "TOKEN" |
+
+### Common Use Cases
+
+**Use Max subscription instead of API credits:**
+```toml
+agent = "claude"
+envExclude = ["ANTHROPIC_API_KEY"]
+```
+
+**Exclude all sensitive keys:**
+```toml
+envExclude = ["*_API_KEY", "*_SECRET", "*_TOKEN", "*_PASSWORD"]
+```
+
+**Keep environment clean for multiple agents:**
+```toml
+envExclude = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"]
+```
+
+<Callout type="tip">
+If you're experiencing unexpected API credit usage while using a Max subscription, check if your shell environment has `ANTHROPIC_API_KEY` set. Run `echo $ANTHROPIC_API_KEY` to verify.
+</Callout>
 
 ## Notifications
 
@@ -407,6 +487,22 @@ Ralph TUI respects these environment variables:
 | Variable | Description |
 |----------|-------------|
 | `XDG_CONFIG_HOME` | Override global config location (default: `~/.config`) |
+
+### Environment Variable Filtering
+
+By default, Ralph TUI passes all parent process environment variables to agent subprocesses. Use the `envExclude` option to filter specific variables:
+
+```toml
+# Prevent ANTHROPIC_API_KEY from being passed to the agent
+envExclude = ["ANTHROPIC_API_KEY"]
+```
+
+This is particularly useful when:
+- Your shell auto-loads `.env` files via direnv or similar tools
+- You want to use a subscription-based auth (like Claude Max) instead of API keys
+- You need to prevent credential leakage to agent processes
+
+See [Environment Variable Exclusion](#environment-variable-exclusion) for details.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

- Adds `envExclude` configuration option to filter environment variables before spawning agent processes
- Supports exact match and glob patterns (e.g., `*_API_KEY`, `*_SECRET`)
- Adds comprehensive documentation to the website

## Test plan

- [x] Run `bun run typecheck` - passes
- [x] Run `bun run build` - passes
- [x] Run `bun test src/plugins/agents/base.test.ts` - 28 tests pass

## Usage

```toml
# Top-level shorthand
agent = "claude"
envExclude = ["ANTHROPIC_API_KEY"]

# Or per-agent configuration
[[agents]]
name = "claude-max"
plugin = "claude"
envExclude = ["ANTHROPIC_API_KEY", "*_SECRET"]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced environment variable exclusion configuration to control which environment variables are passed to agent processes.
  * Supports exact names and glob patterns (e.g., `*_API_KEY`) for flexible filtering.
  * Configurable at global, project, and per-agent levels.

* **Documentation**
  * Added comprehensive documentation on environment variable exclusion syntax and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->