### PR TITLE
Load bead labels from config.toml instead of hardcoding 'ralph'

### DIFF
--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -599,7 +599,10 @@ async function executeBeadsConversion(
     if (typeof configLabels === 'string') {
       labels = configLabels.split(',').map((l) => l.trim()).filter(Boolean);
     } else if (Array.isArray(configLabels)) {
-      labels = configLabels.filter((l): l is string => typeof l === 'string');
+      labels = configLabels
+        .filter((l): l is string => typeof l === 'string')
+        .map((l) => l.trim())
+        .filter(Boolean);
     }
   }
 


### PR DESCRIPTION
## Summary
This PR removes the hardcoded 'ralph' label requirement and instead allows users to configure default labels for beads through `config.toml`. The CLI `--labels` flag still takes precedence when provided.

## Key Changes
- Added import of `loadStoredConfig` to load configuration from `config.toml`
- Updated help text to reference `config.toml [trackerOptions].labels` instead of hardcoded 'ralph'
- Modified `convertToBeads()` to conditionally add labels only when configured (instead of always including 'ralph')
- Updated `executeBeadsConversion()` to load labels from config when not provided via CLI, with proper precedence: CLI args > config file > no labels
- Refactored label argument insertion to only add `--labels` flag when labels are actually configured
- Updated command description to reflect the new configurable behavior

## Implementation Details
- Labels are now optional rather than mandatory
- The `--labels` CLI flag still takes full precedence over config file settings
- Config labels support both string (comma-separated) and array formats
- Labels are properly trimmed and filtered to remove empty values
- The change maintains backward compatibility for users who have configured labels in their config file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bead conversion now loads default labels from your config when no CLI labels are provided; CLI labels take precedence. Labels are only applied when a non-empty set exists.

* **Documentation**
  * Updated help text and usage guidance to explain label precedence and that defaults can come from your configuration file.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->