### PR TITLE
Add tracker labels support to PRD creation workflow

### DIFF
--- a/src/commands/create-prd.tsx
+++ b/src/commands/create-prd.tsx
@@ -87,6 +87,29 @@ export function parseCreatePrdArgs(args: string[]): CreatePrdArgs {
 }
 
 /**
+ * Parse tracker labels from config trackerOptions.
+ * Handles both string (comma-separated) and array formats.
+ * @internal Exported for testing
+ */
+export function parseTrackerLabels(
+  trackerOptions?: Record<string, unknown>
+): string[] | undefined {
+  const configLabels = trackerOptions?.labels;
+  if (typeof configLabels === 'string') {
+    const parsed = configLabels.split(',').map((l) => l.trim()).filter(Boolean);
+    return parsed.length > 0 ? parsed : undefined;
+  }
+  if (Array.isArray(configLabels)) {
+    const parsed = (configLabels as unknown[])
+      .filter((l): l is string => typeof l === 'string')
+      .map((l) => l.trim())
+      .filter(Boolean);
+    return parsed.length > 0 ? parsed : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Print help for the create-prd command.
  */
 export function printCreatePrdHelp(): void {
@@ -412,16 +435,7 @@ export async function executeCreatePrdCommand(args: string[]): Promise<void> {
 
   const storedConfig = await loadStoredConfig(cwd);
 
-  // Load tracker labels from config (trackerOptions.labels)
-  const configLabels = storedConfig.trackerOptions?.labels;
-  if (typeof configLabels === 'string') {
-    parsedArgs.trackerLabels = configLabels.split(',').map((l) => l.trim()).filter(Boolean);
-  } else if (Array.isArray(configLabels)) {
-    parsedArgs.trackerLabels = (configLabels as unknown[])
-      .filter((l): l is string => typeof l === 'string')
-      .map((l) => l.trim())
-      .filter(Boolean);
-  }
+  parsedArgs.trackerLabels = parseTrackerLabels(storedConfig.trackerOptions);
 
   if (parsedArgs.prdSkill) {
     if (!storedConfig.skills_dir?.trim()) {

--- a/src/tui/components/PrdChatApp.labels.test.ts
+++ b/src/tui/components/PrdChatApp.labels.test.ts
@@ -1,0 +1,67 @@
+/**
+ * ABOUTME: Tests for buildBeadsLabelsInstruction helper.
+ * Verifies case-insensitive dedup and label instruction formatting.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { buildBeadsLabelsInstruction } from './PrdChatApp.js';
+
+describe('buildBeadsLabelsInstruction', () => {
+  test('returns empty string when trackerLabels is undefined', () => {
+    expect(buildBeadsLabelsInstruction(undefined)).toBe('');
+  });
+
+  test('returns empty string when trackerLabels is empty array', () => {
+    expect(buildBeadsLabelsInstruction([])).toBe('');
+  });
+
+  test('always includes ralph as first label', () => {
+    const result = buildBeadsLabelsInstruction(['frontend']);
+    expect(result).toContain('--labels "ralph,frontend"');
+  });
+
+  test('deduplicates ralph case-insensitively', () => {
+    const result = buildBeadsLabelsInstruction(['Ralph', 'frontend']);
+    expect(result).toContain('--labels "ralph,frontend"');
+    expect(result).not.toContain('Ralph');
+  });
+
+  test('deduplicates RALPH uppercase variant', () => {
+    const result = buildBeadsLabelsInstruction(['RALPH', 'backend']);
+    expect(result).toContain('--labels "ralph,backend"');
+    expect(result).not.toContain('RALPH');
+  });
+
+  test('deduplicates among user labels case-insensitively', () => {
+    const result = buildBeadsLabelsInstruction(['Frontend', 'frontend', 'FRONTEND']);
+    expect(result).toContain('--labels "ralph,Frontend"');
+    // Only the first occurrence is kept
+    expect(result.match(/frontend/gi)?.length).toBe(1);
+  });
+
+  test('preserves original casing of first occurrence', () => {
+    const result = buildBeadsLabelsInstruction(['MyLabel', 'mylabel']);
+    expect(result).toContain('ralph,MyLabel');
+  });
+
+  test('includes instruction text for bd/br create', () => {
+    const result = buildBeadsLabelsInstruction(['test']);
+    expect(result).toContain('IMPORTANT: Apply these labels to EVERY issue created');
+    expect(result).toContain('Add the --labels flag to every bd create / br create command.');
+  });
+
+  test('handles multiple unique labels', () => {
+    const result = buildBeadsLabelsInstruction(['frontend', 'backend', 'sprint-1']);
+    expect(result).toContain('--labels "ralph,frontend,backend,sprint-1"');
+  });
+
+  test('handles label that is exactly ralph (lowercase)', () => {
+    const result = buildBeadsLabelsInstruction(['ralph', 'other']);
+    expect(result).toContain('--labels "ralph,other"');
+    // ralph should appear exactly once in the labels string
+    const match = result.match(/--labels "([^"]+)"/);
+    expect(match).not.toBeNull();
+    const labels = match![1].split(',');
+    expect(labels.filter((l) => l.toLowerCase() === 'ralph')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds support for applying tracker labels to issues created during the PRD (Product Requirements Document) creation workflow. Labels are now loaded from the config file's `trackerOptions.labels` setting and automatically applied to all beads issues (epics and child tasks).

## Key Changes
- **CreatePrdArgs interface**: Added optional `trackerLabels` field to pass labels through the command execution pipeline
- **Config loading**: Implemented logic to parse `trackerOptions.labels` from stored config, supporting both comma-separated strings and array formats
- **PrdChatApp component**: 
  - Added `trackerLabels` prop to receive labels from parent
  - Implemented label instruction generation for beads format
  - Automatically injects `--labels` flag into all `bd create` and `br create` commands when labels are configured
  - Ensures 'ralph' label is always included first, followed by any additional configured labels

## Implementation Details
- Labels are parsed from config with trimming and filtering of empty values
- Type-safe handling of both string and array label formats from config
- Labels instruction is only added when using 'beads' format and labels are present
- The `--labels` flag is injected into the AI prompt to ensure consistent application across all created issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracker labels in the PRD creation workflow
  * Labels can now be configured and automatically applied when creating issues via the beads tracker format
  * Enhanced tracker integration with centralised label management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->