### PR TITLE
Fix Windows shell execution with paths containing spaces

### DIFF
--- a/src/plugins/agents/builtin/claude.ts
+++ b/src/plugins/agents/builtin/claude.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { BaseAgentPlugin, findCommandPath } from '../base.js';
+import { BaseAgentPlugin, findCommandPath, quoteForWindowsShell } from '../base.js';
 import { processAgentEvents, processAgentEventsToSegments, type AgentDisplayEvent } from '../output-formatting.js';
 import type {
   AgentPluginMeta,
@@ -177,7 +177,7 @@ export class ClaudeAgentPlugin extends BaseAgentPlugin {
   ): Promise<{ success: boolean; version?: string; error?: string }> {
     return new Promise((resolve) => {
       const useShell = process.platform === 'win32';
-      const proc = spawn(command, ['--version'], {
+      const proc = spawn(useShell ? quoteForWindowsShell(command) : command, ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: useShell,
       });

--- a/src/plugins/agents/builtin/codex.ts
+++ b/src/plugins/agents/builtin/codex.ts
@@ -5,7 +5,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { BaseAgentPlugin, findCommandPath } from '../base.js';
+import { BaseAgentPlugin, findCommandPath, quoteForWindowsShell } from '../base.js';
 import { processAgentEvents, processAgentEventsToSegments, type AgentDisplayEvent } from '../output-formatting.js';
 import type {
   AgentPluginMeta,
@@ -216,7 +216,7 @@ export class CodexAgentPlugin extends BaseAgentPlugin {
     return new Promise((resolve) => {
       // Only use shell on Windows where direct spawn may not work
       const useShell = process.platform === 'win32';
-      const proc = spawn(command, ['--version'], {
+      const proc = spawn(useShell ? quoteForWindowsShell(command) : command, ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: useShell,
       });

--- a/src/plugins/agents/builtin/gemini.ts
+++ b/src/plugins/agents/builtin/gemini.ts
@@ -5,7 +5,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { BaseAgentPlugin, findCommandPath } from '../base.js';
+import { BaseAgentPlugin, findCommandPath, quoteForWindowsShell } from '../base.js';
 import { processAgentEvents, processAgentEventsToSegments, type AgentDisplayEvent } from '../output-formatting.js';
 import type {
   AgentPluginMeta,
@@ -190,7 +190,7 @@ export class GeminiAgentPlugin extends BaseAgentPlugin {
     return new Promise((resolve) => {
       // Only use shell on Windows where direct spawn may not work
       const useShell = process.platform === 'win32';
-      const proc = spawn(command, ['--version'], {
+      const proc = spawn(useShell ? quoteForWindowsShell(command) : command, ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: useShell,
       });

--- a/src/plugins/agents/builtin/kiro.ts
+++ b/src/plugins/agents/builtin/kiro.ts
@@ -5,7 +5,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { BaseAgentPlugin, findCommandPath } from '../base.js';
+import { BaseAgentPlugin, findCommandPath, quoteForWindowsShell } from '../base.js';
 import type {
   AgentPluginMeta,
   AgentPluginFactory,
@@ -113,7 +113,7 @@ export class KiroAgentPlugin extends BaseAgentPlugin {
       // Use -V flag (the documented version flag for kiro-cli)
       // Only use shell on Windows where direct spawn may not work
       const useShell = process.platform === 'win32';
-      const proc = spawn(command, ['-V'], {
+      const proc = spawn(useShell ? quoteForWindowsShell(command) : command, ['-V'], {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: useShell,
       });

--- a/src/plugins/agents/builtin/opencode.ts
+++ b/src/plugins/agents/builtin/opencode.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { BaseAgentPlugin, findCommandPath } from '../base.js';
+import { BaseAgentPlugin, findCommandPath, quoteForWindowsShell } from '../base.js';
 import { processAgentEvents, processAgentEventsToSegments, type AgentDisplayEvent } from '../output-formatting.js';
 import type {
   AgentPluginMeta,
@@ -300,7 +300,7 @@ export class OpenCodeAgentPlugin extends BaseAgentPlugin {
   ): Promise<{ success: boolean; version?: string; error?: string }> {
     return new Promise((resolve) => {
       const useShell = process.platform === 'win32';
-      const proc = spawn(command, ['--version'], {
+      const proc = spawn(useShell ? quoteForWindowsShell(command) : command, ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: useShell,
       });

--- a/src/plugins/agents/droid/index.ts
+++ b/src/plugins/agents/droid/index.ts
@@ -6,7 +6,7 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { platform } from 'node:os';
-import { BaseAgentPlugin } from '../base.js';
+import { BaseAgentPlugin, quoteForWindowsShell } from '../base.js';
 import type {
   AgentPluginMeta,
   AgentPluginFactory,
@@ -191,7 +191,7 @@ export class DroidAgentPlugin extends BaseAgentPlugin {
 
     let proc;
     if (isWindows) {
-      proc = spawn(command, allArgs, {
+      proc = spawn(quoteForWindowsShell(command), allArgs, {
         cwd: options?.cwd ?? process.cwd(),
         env,
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/tests/plugins/agents/runversion-shell.test.ts
+++ b/tests/plugins/agents/runversion-shell.test.ts
@@ -1,7 +1,7 @@
 /**
  * ABOUTME: Tests for the runVersion method's conditional shell behavior.
- * Verifies that shell: true is only used on Windows (process.platform === 'win32').
- * This matches the fix in PR #187 for claude and opencode agents.
+ * Verifies that shell: true is only used on Windows (process.platform === 'win32'),
+ * and that paths with spaces are properly quoted for Windows shell execution (issue #206).
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -159,6 +159,33 @@ describe('runVersion conditional shell behavior (PR #187)', () => {
       expect(runVersionCall.args).toContain('--version');
       expect(runVersionCall.options?.shell).toBe(true);
 
+      // Verify path with spaces is quoted for Windows shell (issue #206)
+      expect(runVersionCall.cmd).toBe('"C:\\Program Files\\claude\\claude.exe"');
+
+      await plugin.dispose();
+    });
+
+    test('does not quote paths without spaces on Windows', async () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+
+      spawnResponses = [
+        { stdout: 'C:\\claude\\claude.exe', exitCode: 0 },
+        { stdout: 'claude 1.0.5', exitCode: 0 },
+      ];
+
+      const plugin = new ClaudeAgentPlugin();
+      await plugin.initialize({});
+
+      await plugin.detect();
+
+      expect(spawnCalls.length).toBe(2);
+      const runVersionCall = spawnCalls[1];
+      // No quotes needed when path has no spaces
+      expect(runVersionCall.cmd).toBe('C:\\claude\\claude.exe');
+
       await plugin.dispose();
     });
 
@@ -303,6 +330,33 @@ describe('runVersion conditional shell behavior (PR #187)', () => {
       expect(runVersionCall.args).toContain('--version');
       expect(runVersionCall.options?.shell).toBe(true);
 
+      // Verify path with spaces is quoted for Windows shell (issue #206)
+      expect(runVersionCall.cmd).toBe('"C:\\Program Files\\opencode\\opencode.exe"');
+
+      await plugin.dispose();
+    });
+
+    test('does not quote paths without spaces on Windows', async () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+
+      spawnResponses = [
+        { stdout: 'C:\\opencode\\opencode.exe', exitCode: 0 },
+        { stdout: 'opencode 0.5.2', exitCode: 0 },
+      ];
+
+      const plugin = new OpenCodeAgentPlugin();
+      await plugin.initialize({});
+
+      await plugin.detect();
+
+      expect(spawnCalls.length).toBe(2);
+      const runVersionCall = spawnCalls[1];
+      // No quotes needed when path has no spaces
+      expect(runVersionCall.cmd).toBe('C:\\opencode\\opencode.exe');
+
       await plugin.dispose();
     });
 
@@ -370,5 +424,42 @@ describe('runVersion conditional shell behavior (PR #187)', () => {
 
       await plugin.dispose();
     });
+  });
+});
+
+// Import quoteForWindowsShell for unit testing (pure function, no mocking needed)
+const { quoteForWindowsShell } = await import('../../../src/plugins/agents/base.js');
+
+describe('quoteForWindowsShell (issue #206)', () => {
+  test('quotes paths containing spaces', () => {
+    expect(quoteForWindowsShell('C:\\Program Files\\nodejs\\opencode.cmd')).toBe(
+      '"C:\\Program Files\\nodejs\\opencode.cmd"'
+    );
+  });
+
+  test('does not quote paths without spaces', () => {
+    expect(quoteForWindowsShell('C:\\nodejs\\opencode.cmd')).toBe(
+      'C:\\nodejs\\opencode.cmd'
+    );
+  });
+
+  test('does not double-quote already-quoted paths', () => {
+    expect(quoteForWindowsShell('"C:\\Program Files\\opencode.cmd"')).toBe(
+      '"C:\\Program Files\\opencode.cmd"'
+    );
+  });
+
+  test('handles simple command names without modification', () => {
+    expect(quoteForWindowsShell('opencode')).toBe('opencode');
+  });
+
+  test('handles empty string', () => {
+    expect(quoteForWindowsShell('')).toBe('');
+  });
+
+  test('quotes Unix paths with spaces', () => {
+    expect(quoteForWindowsShell('/usr/local/my programs/bin/tool')).toBe(
+      '"/usr/local/my programs/bin/tool"'
+    );
   });
 });


### PR DESCRIPTION
## Summary
Fixes issue #206 by properly quoting command paths containing spaces when executing with `shell: true` on Windows. When Node.js `spawn()` is used with `shell: true` on Windows, paths with spaces must be wrapped in double quotes to prevent cmd.exe from splitting them at the space character.

## Changes
- **New utility function**: Added `quoteForWindowsShell()` in `src/plugins/agents/base.ts` that intelligently quotes paths only when necessary (contains spaces and not already quoted)
- **Updated BaseAgentPlugin**: Modified `runVersion()` and `execute()` methods to quote command paths on Windows before spawning
- **Updated all agent plugins**: Applied quoting to version detection in:
  - ClaudeAgentPlugin
  - CodexAgentPlugin
  - GeminiAgentPlugin
  - KiroAgentPlugin
  - OpenCodeAgentPlugin
  - DroidAgentPlugin
- **Comprehensive tests**: Added unit tests for `quoteForWindowsShell()` and integration tests verifying proper quoting behavior in version detection across multiple agent plugins

## Implementation Details
- The `quoteForWindowsShell()` function is a pure utility that:
  - Returns paths unchanged if they contain no spaces
  - Returns paths unchanged if already quoted
  - Wraps paths with spaces in double quotes
- Quoting is only applied on Windows (`platform() === 'win32'`) and only when `shell: true` is used
- The solution is backward compatible and doesn't affect Unix/Linux behavior