### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-tui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Ralph TUI - AI Agent Loop Orchestrator",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps package version from 0.4.0 to 0.5.0

## Test plan
- [ ] Verify `package.json` version field is `0.5.0`
- [ ] Confirm build still succeeds with `bun run build`