### PR TITLE
Remove fake progress bar from ChatView

### DIFF
--- a/src/tui/components/ChatView.tsx
+++ b/src/tui/components/ChatView.tsx
@@ -36,38 +36,6 @@ function AnimatedSpinner(): ReactNode {
 }
 
 /**
- * Animated progress bar with fake percentage (asymptotically approaches 99%)
- * Simulates progress for unknown-duration tasks like AI responses
- */
-function AnimatedProgressBar({ width = 20 }: { width?: number }): ReactNode {
-  const [percentage, setPercentage] = useState(0);
-
-  useEffect(() => {
-    const startTime = Date.now();
-    const interval = setInterval(() => {
-      const elapsed = (Date.now() - startTime) / 1000; // seconds
-      // Asymptotic function: quickly reaches 50%, slowly approaches 99%
-      // Formula: 99 * (1 - e^(-elapsed/10))
-      const newPercentage = Math.min(99, Math.floor(99 * (1 - Math.exp(-elapsed / 10))));
-      setPercentage(newPercentage);
-    }, 100);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  const filledWidth = Math.floor((percentage / 100) * width);
-  const emptyWidth = width - filledWidth;
-  const filled = '▓'.repeat(filledWidth);
-  const empty = '░'.repeat(emptyWidth);
-
-  return (
-    <text fg={colors.status.info}>
-      {filled}{empty} {percentage}%
-    </text>
-  );
-}
-
-/**
  * Props for the ChatView component
  */
 export interface ChatViewProps {
@@ -506,7 +474,6 @@ export function ChatView({
           {isLoading ? (
             <>
               <AnimatedSpinner />
-              <AnimatedProgressBar width={20} />
               <text fg={colors.status.info}>{loadingText}</text>
             </>
           ) : (


### PR DESCRIPTION
## Summary

Removes the `AnimatedProgressBar` component that showed a fake percentage asymptotically approaching 99%.

**Why remove it:**
- Modern users know AI tasks have indeterminate timing
- The spinner alone communicates "working" effectively
- Fake progress bars feel deceptive to savvy users
- Industry standard (ChatGPT, Claude.ai, Copilot) uses simple spinners, not fake percentages

**Before:** `⠋ ▓▓▓▓▓▓▓▓░░░░░░░░░░░░ 39% Generating PRD...`

**After:** `⠋ Generating PRD...`

## Test plan
- [ ] Verify PRD wizard shows spinner without progress bar when generating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed inaccurate progress indicator from loading state. The loading interface now displays only a spinner and status text for improved clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->