### PR TITLE
Add parallel execution and progress file configuration schemas

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -66,6 +66,25 @@ export const NotificationsConfigSchema = z.object({
 });
 
 /**
+ * Parallel execution mode schema
+ */
+export const ParallelModeSchema = z.enum(['auto', 'always', 'never']);
+
+/**
+ * Parallel execution configuration schema
+ */
+export const ParallelConfigSchema = z.object({
+  /** Execution mode: 'auto' analyzes dependencies, 'always' forces parallel, 'never' disables */
+  mode: ParallelModeSchema.optional(),
+  /** Maximum concurrent workers (default: 3) */
+  maxWorkers: z.number().int().min(1).max(32).optional(),
+  /** Directory for git worktrees relative to project root */
+  worktreeDir: z.string().optional(),
+  /** Merge directly to the current branch instead of creating a session branch */
+  directMerge: z.boolean().optional(),
+});
+
+/**
  * Agent plugin configuration schema
  */
 export const AgentPluginConfigSchema = z.object({
@@ -178,6 +197,12 @@ export const StoredConfigSchema = z
 
     // Notifications configuration
     notifications: NotificationsConfigSchema.optional(),
+
+    // Progress file path for cross-iteration context
+    progressFile: z.string().optional(),
+
+    // Parallel execution configuration
+    parallel: ParallelConfigSchema.optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
This PR adds schema definitions and comprehensive test coverage for two new configuration features: parallel execution settings and progress file tracking.

## Key Changes
- **New Schemas Added:**
  - `ParallelModeSchema`: Enum schema validating execution modes ('auto', 'always', 'never')
  - `ParallelConfigSchema`: Object schema for parallel execution configuration with fields:
    - `mode`: Execution mode selection
    - `maxWorkers`: Integer between 1-32 for concurrent worker limit
    - `worktreeDir`: Directory path for git worktrees
    - `directMerge`: Boolean flag for direct branch merging
  - `progressFile`: New optional string field in `StoredConfigSchema` for progress tracking

- **Updated StoredConfigSchema:**
  - Added `progressFile` field for cross-iteration context persistence
  - Added `parallel` field with full `ParallelConfigSchema` support

- **Comprehensive Test Coverage:**
  - `ParallelModeSchema` tests: valid modes, invalid input rejection
  - `ParallelConfigSchema` tests: full/partial configs, optional fields, bounds validation, type validation
  - `StoredConfigSchema` tests: progressFile field, parallel configuration (full/partial), combined usage, validation of nested constraints

## Implementation Details
- All new fields are optional to maintain backward compatibility
- `maxWorkers` enforces strict integer bounds (1-32) to prevent resource exhaustion
- Parallel configuration is fully optional and can be partially specified
- Tests validate both happy paths and error cases for robust schema enforcement

https://claude.ai/code/session_01PWHJ8gPeEp6FckvPj7L4Rp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added parallel execution configuration with selectable modes ('auto', 'always', 'never').
  * Configurable worker thread limits (1–32 workers maximum).
  * Added progress file support for cross-iteration context tracking.

* **Tests**
  * Comprehensive test coverage for new configuration schemas and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->