### PR TITLE
Remove PRD link inclusion from bead conversion

### DIFF
--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -304,11 +304,6 @@ async function convertToBeads(
       '--silent',
     ];
 
-    // Include PRD link if available
-    if (prdPath) {
-      storyArgs.splice(-1, 0, '--external-ref', `prd:${prdPath}`);
-    }
-
     if (verbose) {
       console.log(`  bd ${storyArgs.join(' ')}`);
     }


### PR DESCRIPTION
## Summary
Removed the logic that automatically includes PRD (Product Requirements Document) links as external references when converting stories to beads.

## Changes
- Deleted the conditional block that appended `--external-ref prd:{prdPath}` to the story arguments during bead conversion
- This simplifies the conversion process by removing the automatic PRD reference injection

## Details
The removed code was checking if a `prdPath` was available and, if so, inserting an external reference argument into the bead command. This functionality is no longer needed in the conversion workflow.

https://claude.ai/code/session_013iLssPBjrhK6LJG8Pqkm8n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic external PRD reference injection from epic and story bead creation. Beads will no longer include external reference parameters during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->