### PR TITLE
Fix custom agents missing in settings (issue 287)

### DIFF
--- a/src/commands/run.tsx
+++ b/src/commands/run.tsx
@@ -1126,6 +1126,26 @@ function RunAppWrapper({
   const trackerRegistry = getTrackerRegistry();
   const availableAgents = agentRegistry.getRegisteredPlugins();
   const availableTrackers = trackerRegistry.getRegisteredPlugins();
+  const configuredAgentNames = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          (storedConfig?.agents ?? [])
+            .map((agent) => agent.name)
+            .filter((name): name is string => typeof name === 'string' && name.length > 0),
+        ),
+      ),
+    [storedConfig?.agents],
+  );
+  const availableAgentNames = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          [...availableAgents.map((agent) => agent.id), ...configuredAgentNames],
+        ),
+      ),
+    [availableAgents, configuredAgentNames],
+  );
 
   // Handle settings save
   const handleSaveSettings = async (newConfig: StoredConfig): Promise<void> => {
@@ -1233,7 +1253,7 @@ function RunAppWrapper({
       initialTasks={tasks}
       onStart={onStart}
       storedConfig={storedConfig}
-      availableAgents={availableAgents}
+      availableAgents={availableAgentNames}
       availableTrackers={availableTrackers}
       onSaveSettings={handleSaveSettings}
       onLoadEpics={handleLoadEpics}

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -220,6 +220,45 @@ describe('loadStoredConfig', () => {
     expect(config.notifications?.sound).toBe('ralph');
   });
 
+  test('promotes a misplaced defaultAgent from an agent options table', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    const projectConfigPath = join(projectConfigDir, 'config.toml');
+    await writeFile(
+      projectConfigPath,
+      `
+configVersion = "2.1"
+maxIterations = 0
+tracker = "beads-rust"
+
+[[agents]]
+name = "cc-claude-4.6"
+plugin = "claude"
+
+    [agents.options]
+    model = "claude-opus-4-6"
+
+[[agents]]
+name = "oc-claude-4.6"
+plugin = "opencode"
+
+    [agents.options]
+    model = "github-copilot/claude-opus-4.6"
+
+defaultAgent = "cc-claude-4.6"
+`,
+      'utf-8',
+    );
+
+    const config = await loadStoredConfig(tempDir, globalConfigPath);
+
+    expect(config.defaultAgent).toBe('cc-claude-4.6');
+    expect(config.agents?.[1]?.options).toEqual({
+      model: 'github-copilot/claude-opus-4.6',
+    });
+    expect(config.agents?.[1]?.options).not.toHaveProperty('defaultAgent');
+  });
+
   test('merges parallel config', async () => {
     await writeTomlConfig(globalConfigPath, {
       parallel: { mode: 'auto', maxWorkers: 2, worktreeDir: '.global/worktrees' },
@@ -401,6 +440,19 @@ describe('checkSetupStatus', () => {
     expect(status.configExists).toBe(false);
     expect(status.agentConfigured).toBe(false);
     expect(status.message).toContain('No configuration found');
+  });
+
+  test('treats configured agents as ready even without defaultAgent', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeTomlConfig(join(projectConfigDir, 'config.toml'), {
+      agents: [{ name: 'custom-agent', plugin: 'claude', options: {} }],
+    });
+
+    const status = await checkSetupStatus(tempDir);
+
+    expect(status.ready).toBe(true);
+    expect(status.agentConfigured).toBe(true);
   });
 });
 

--- a/src/tui/components/RunApp.tsx
+++ b/src/tui/components/RunApp.tsx
@@ -48,7 +48,6 @@ import type {
 } from '../../engine/index.js';
 import type { TrackerTask } from '../../plugins/trackers/types.js';
 import type { StoredConfig, SubagentDetailLevel, SandboxConfig, SandboxMode } from '../../config/types.js';
-import type { AgentPluginMeta } from '../../plugins/agents/types.js';
 import type { TrackerPluginMeta } from '../../plugins/trackers/types.js';
 import { getIterationLogsByTask } from '../../logs/index.js';
 import type { SubagentTraceStats, SubagentHierarchyNode } from '../../logs/types.js';
@@ -103,8 +102,8 @@ export interface RunAppProps {
   onStart?: () => Promise<void>;
   /** Current stored configuration (for settings view) */
   storedConfig?: StoredConfig;
-  /** Available agent plugins (for settings view) */
-  availableAgents?: AgentPluginMeta[];
+  /** Available agent names (for settings view) */
+  availableAgents?: string[];
   /** Available tracker plugins (for settings view) */
   availableTrackers?: TrackerPluginMeta[];
   /** Callback when settings should be saved */

--- a/src/tui/components/SettingsView.tsx
+++ b/src/tui/components/SettingsView.tsx
@@ -9,7 +9,6 @@ import { useState, useCallback, useEffect } from 'react';
 import { useKeyboard } from '@opentui/react';
 import { colors } from '../theme.js';
 import type { StoredConfig, SubagentDetailLevel, NotificationSoundMode } from '../../config/types.js';
-import type { AgentPluginMeta } from '../../plugins/agents/types.js';
 import type { TrackerPluginMeta } from '../../plugins/trackers/types.js';
 
 /**
@@ -41,8 +40,8 @@ export interface SettingsViewProps {
   visible: boolean;
   /** Current stored configuration */
   config: StoredConfig;
-  /** Available agent plugins */
-  agents: AgentPluginMeta[];
+  /** Available agent names for selection */
+  agents: string[];
   /** Available tracker plugins */
   trackers: TrackerPluginMeta[];
   /** Callback when settings should be saved */
@@ -55,7 +54,7 @@ export interface SettingsViewProps {
  * Build setting definitions based on available plugins
  */
 function buildSettingDefinitions(
-  agents: AgentPluginMeta[],
+  agents: string[],
   trackers: TrackerPluginMeta[]
 ): SettingDefinition[] {
   return [
@@ -78,8 +77,8 @@ function buildSettingDefinitions(
       label: 'Agent',
       type: 'select',
       description: 'AI agent plugin to use',
-      options: agents.map((a) => a.id),
-      getValue: (config) => config.agent ?? config.defaultAgent,
+      options: agents,
+      getValue: (config) => config.agent ?? config.defaultAgent ?? config.agents?.[0]?.name,
       setValue: (config, value) => ({
         ...config,
         agent: value as string,


### PR DESCRIPTION
## Summary
- Include configured agent names from [[agents]] in the TUI settings agent dropdown.
- Fall back to first configured agent when neither  nor  is set so the settings UI reflects runtime selection.
- Normalize loaded TOML configs where  was accidentally parsed into an agent options table by promoting it to top-level .
- Treat configured  as an agent-configured state for setup status checks.

## Testing
- bun run typecheck
- bun run build
- bun test src/config/index.test.ts

Fixes: #287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents configured via CLI are now visible alongside plugin-provided agents in the interface.

* **Bug Fixes**
  * Improved configuration handling for legacy or malformed layouts.
  * Enhanced setup status detection to recognise configured agents.

* **Tests**
  * Added test coverage for configuration normalisation and setup status detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->