### PR TITLE
fix: pin @opentui/core to 0.1.72 to prevent symbol mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@opentui/core": "^0.1.72",
-    "@opentui/react": "^0.1.72",
+    "@opentui/core": "0.1.72",
+    "@opentui/react": "0.1.72",
     "handlebars": "^4.7.8",
     "node-notifier": "^8.0.2",
     "smol-toml": "^1.6.0",


### PR DESCRIPTION
## Summary

- Pin `@opentui/core` and `@opentui/react` from `^0.1.72` to exact `0.1.72`
- The caret range resolves to 0.1.80 which renamed `setCursorStyle` → `setCursorStyleOptions` in the native dylib, crashing ralph-tui on startup

## Context

The bundled `dist/index.js` has FFI bindings that call `setCursorStyle(renderer, style, blinking)`. In `@opentui/core-darwin-arm64@0.1.80`, this symbol was renamed to `setCursorStyleOptions` with a different calling convention (options struct). Pinning to 0.1.72 is a stopgap; longer-term fix is rebuilding the bundle against 0.1.80.

Fixes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted version specifications for internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->