### PR TITLE
chore: release v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-tui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Ralph TUI - AI Agent Loop Orchestrator",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bumps package version from `0.8.0` to `0.9.0` in `package.json`

## Why
- prepares the repository for the `v0.9.0` release and corresponding GitHub tag/release

## Validation
- `bun run typecheck`
- `bun run build`

## Notes
- no runtime or behavioral code changes are included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped from 0.8.0 to 0.9.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->