### PR TITLE
Update Beads-BV tracker documentation with correct repository link

### DIFF
--- a/website/content/docs/plugins/trackers/beads-bv.mdx
+++ b/website/content/docs/plugins/trackers/beads-bv.mdx
@@ -5,7 +5,7 @@ description: Smart task selection using PageRank, critical path, and graph analy
 
 ## Beads-BV Tracker
 
-The Beads-BV tracker extends the standard Beads tracker with intelligent task selection powered by [bv](https://github.com/steveyegge/bv) (Beads Viewer). It uses graph algorithms like PageRank and critical path analysis to pick tasks that unblock the most downstream work.
+The Beads-BV tracker extends the standard Beads tracker with intelligent task selection powered by [bv](https://github.com/Dicklesworthstone/beads_viewer) (Beads Viewer). It uses graph algorithms like PageRank and critical path analysis to pick tasks that unblock the most downstream work.
 
 <Callout type="tip">
 Beads-BV is ideal for large projects with complex dependency graphs. It automatically prioritizes bottleneck tasks.


### PR DESCRIPTION
## Summary
Updated the documentation for the Beads-BV tracker plugin to reference the correct GitHub repository for the Beads Viewer (bv) project.

## Changes
- Updated the `bv` GitHub repository link from `steveyegge/bv` to `Dicklesworthstone/beads_viewer` in the Beads-BV tracker documentation

## Details
The original repository link was incorrect and has been corrected to point to the actual maintained repository for the Beads Viewer project. This ensures users can access the correct upstream project when learning about the bv tool that powers the Beads-BV tracker's intelligent task selection capabilities.

https://claude.ai/code/session_013xEaXndGdYooC5vwF8x6E6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Beads-BV plugin documentation to reference the current repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->