### PR TITLE
Sort children beads issues numerically

### DIFF
--- a/src/plugins/trackers/builtin/beads-rust/index.ts
+++ b/src/plugins/trackers/builtin/beads-rust/index.ts
@@ -380,7 +380,7 @@ export class BeadsRustTrackerPlugin extends BaseTrackerPlugin {
 
     let tasks = tasksJson.map(brTaskToTask);
 
-    // sort so that child issues of form <project>-<parentId>.<issueNumber> will appear in order starting from
+    // sort so that child issues of form <project>-<parentId>.<issueNumber> will appear in ascending numeric order
     tasks.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: "base" }));
 
     // Filter by parent (br list doesn't support --parent)

--- a/src/plugins/trackers/builtin/beads/index.test.ts
+++ b/src/plugins/trackers/builtin/beads/index.test.ts
@@ -415,6 +415,51 @@ describe('BeadsTrackerPlugin (mocked CLI)', () => {
       expect(tasks[0]?.parentId).toBe('explicit-parent');
     });
 
+    test('sorts tasks in ascending numeric order by id', async () => {
+      const plugin = await createInitializedPlugin();
+      mockSpawnResponses = [
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { id: 'proj-12', title: 'Twelve', status: 'open', priority: 2 },
+            { id: 'proj-2', title: 'Two', status: 'open', priority: 2 },
+            { id: 'proj-1', title: 'One', status: 'open', priority: 2 },
+            { id: 'proj-20', title: 'Twenty', status: 'open', priority: 2 },
+          ]),
+        },
+      ];
+
+      const tasks = await plugin.getTasks();
+
+      expect(tasks.map((t) => t.id)).toEqual(['proj-1', 'proj-2', 'proj-12', 'proj-20']);
+    });
+
+    test('sorts dotted child IDs numerically, not lexicographically', async () => {
+      const plugin = await createInitializedPlugin();
+      mockSpawnResponses = [
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { id: 'epic-5.12', title: 'Child 12', status: 'open', priority: 2 },
+            { id: 'epic-5.2', title: 'Child 2', status: 'open', priority: 2 },
+            { id: 'epic-5.1', title: 'Child 1', status: 'open', priority: 2 },
+            { id: 'epic-5.9', title: 'Child 9', status: 'open', priority: 2 },
+          ]),
+        },
+      ];
+
+      const tasks = await plugin.getTasks();
+
+      // Lexicographic would produce: epic-5.1, epic-5.12, epic-5.2, epic-5.9
+      // Numeric should produce: epic-5.1, epic-5.2, epic-5.9, epic-5.12
+      expect(tasks.map((t) => t.id)).toEqual([
+        'epic-5.1',
+        'epic-5.2',
+        'epic-5.9',
+        'epic-5.12',
+      ]);
+    });
+
     test('extracts blocking dependencies', async () => {
       const plugin = await createInitializedPlugin();
       mockSpawnResponses = [

--- a/src/plugins/trackers/builtin/beads/index.ts
+++ b/src/plugins/trackers/builtin/beads/index.ts
@@ -410,7 +410,7 @@ export class BeadsTrackerPlugin extends BaseTrackerPlugin {
     // Convert to TrackerTask
     let tasks = beads.map(beadToTask);
 
-    // sort so that child issues of form <project>-<parentId>.<issueNumber> will appear in order starting from
+    // sort so that child issues of form <project>-<parentId>.<issueNumber> will appear in ascending numeric order
     tasks.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: "base" }));
 
     // Apply additional filtering that bd doesn't support directly


### PR DESCRIPTION
Generally when planning things, I don't worry about priority but just plan beads in order as children of an epic, which makes the issues end up in the form of <project>-<epicId>.<issueNumber>, eg:

epic: `thing-zxy`
issues: `thing-zxy.1`, `thing.zxy.2`, `thing.zxy.3` etc...

Given the same priority and tasks only being dependents of the epic, this results in them appearing in reverse order in ralph, and with parallel mode enabled means it works backwards from how I planned things.

This simply sorts it so that the list comes out as .1, .2, .3 instead of .3, .2, .1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved task ordering in tracker plugins so child and dotted issue IDs are displayed in a predictable, numerically correct sequence.

* **Tests**
  * Added tests that verify task ID ordering is numeric (including dotted parts) rather than purely lexical, ensuring consistent display order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->