### PR TITLE
Stabilize dotted child task ordering across beads trackers

### DIFF
--- a/src/plugins/trackers/builtin/beads-bv/index.test.ts
+++ b/src/plugins/trackers/builtin/beads-bv/index.test.ts
@@ -465,6 +465,37 @@ describe('BeadsBvTrackerPlugin', () => {
     });
   });
 
+  describe('getTasks ordering', () => {
+    test('applies shared dotted child numeric ordering through parent beads tracker', async () => {
+      const plugin = new BeadsBvTrackerPlugin();
+
+      queueSpawnResponse({
+        command: 'bd',
+        stdout: JSON.stringify([
+          { id: 'epic-5.12', title: 'Child 12', status: 'open', priority: 2 },
+          { id: 'task-alpha', title: 'Non-child A', status: 'open', priority: 2 },
+          { id: 'epic-5.2', title: 'Child 2', status: 'open', priority: 2 },
+          { id: 'thing.xyz', title: 'Dotted non-numeric', status: 'open', priority: 2 },
+          { id: 'epic-5.1', title: 'Child 1', status: 'open', priority: 2 },
+          { id: 'task-beta', title: 'Non-child B', status: 'open', priority: 2 },
+          { id: 'epic-5.9', title: 'Child 9', status: 'open', priority: 2 },
+        ]),
+      });
+
+      const tasks = await plugin.getTasks();
+
+      expect(tasks.map((t) => t.id)).toEqual([
+        'epic-5.1',
+        'task-alpha',
+        'epic-5.2',
+        'thing.xyz',
+        'epic-5.9',
+        'task-beta',
+        'epic-5.12',
+      ]);
+    });
+  });
+
   describe('scheduleTriageRefresh', () => {
     test('queues a forced refresh while a refresh is already in-flight', async () => {
       const plugin = new BeadsBvTrackerPlugin();

--- a/src/plugins/trackers/builtin/beads-rust/index.test.ts
+++ b/src/plugins/trackers/builtin/beads-rust/index.test.ts
@@ -465,6 +465,68 @@ describe('BeadsRustTrackerPlugin', () => {
       expect(tasks[0]?.priority).toBe(4);
     });
 
+    test('preserves original order when no IDs match dotted child pattern', async () => {
+      mockSpawnResponses = [
+        { exitCode: 0, stdout: 'br version 0.4.1\n' },
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { id: 'proj-12', title: 'Twelve', status: 'open', priority: 2 },
+            { id: 'proj-2', title: 'Two', status: 'open', priority: 2 },
+            { id: 'thing.xyz', title: 'Dotted non-numeric', status: 'open', priority: 2 },
+            { id: 'thing.abj', title: 'Another dotted non-numeric', status: 'open', priority: 2 },
+          ]),
+        },
+      ];
+
+      const plugin = new BeadsRustTrackerPlugin();
+      await plugin.initialize({ workingDir: '/test' });
+      mockSpawnArgs = [];
+
+      const tasks = await plugin.getTasks();
+
+      expect(tasks.map((t) => t.id)).toEqual([
+        'proj-12',
+        'proj-2',
+        'thing.xyz',
+        'thing.abj',
+      ]);
+    });
+
+    test('sorts dotted child IDs numerically in mixed lists while preserving non-child slots', async () => {
+      mockSpawnResponses = [
+        { exitCode: 0, stdout: 'br version 0.4.1\n' },
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { id: 'epic-5.12', title: 'Child 12', status: 'open', priority: 2 },
+            { id: 'task-alpha', title: 'Non-child A', status: 'open', priority: 2 },
+            { id: 'epic-5.2', title: 'Child 2', status: 'open', priority: 2 },
+            { id: 'thing.xyz', title: 'Dotted non-numeric', status: 'open', priority: 2 },
+            { id: 'epic-5.1', title: 'Child 1', status: 'open', priority: 2 },
+            { id: 'task-beta', title: 'Non-child B', status: 'open', priority: 2 },
+            { id: 'epic-5.9', title: 'Child 9', status: 'open', priority: 2 },
+          ]),
+        },
+      ];
+
+      const plugin = new BeadsRustTrackerPlugin();
+      await plugin.initialize({ workingDir: '/test' });
+      mockSpawnArgs = [];
+
+      const tasks = await plugin.getTasks();
+
+      expect(tasks.map((t) => t.id)).toEqual([
+        'epic-5.1',
+        'task-alpha',
+        'epic-5.2',
+        'thing.xyz',
+        'epic-5.9',
+        'task-beta',
+        'epic-5.12',
+      ]);
+    });
+
     test('enriches dependencies only for tasks that remain after parent filtering', async () => {
       mockSpawnResponses = [
         { exitCode: 0, stdout: 'br version 0.4.1\n' },

--- a/src/plugins/trackers/builtin/beads-rust/index.ts
+++ b/src/plugins/trackers/builtin/beads-rust/index.ts
@@ -9,6 +9,7 @@ import { constants } from 'node:fs';
 import { access, readFile } from 'node:fs/promises';
 import { resolve, relative, isAbsolute, join } from 'node:path';
 import { BaseTrackerPlugin } from '../../base.js';
+import { sortDottedChildTaskIds } from '../../task-ordering.js';
 import { BEADS_RUST_TEMPLATE } from '../../../../templates/builtin.js';
 import type {
   SyncResult,
@@ -394,6 +395,7 @@ export class BeadsRustTrackerPlugin extends BaseTrackerPlugin {
         : undefined
       : filter;
     tasks = this.filterTasks(tasks, filterWithoutParent);
+    tasks = sortDottedChildTaskIds(tasks);
 
     // Enrich dependencies after all filtering so we only query tasks that will
     // actually be used by the executor.

--- a/src/plugins/trackers/builtin/beads/index.test.ts
+++ b/src/plugins/trackers/builtin/beads/index.test.ts
@@ -415,6 +415,60 @@ describe('BeadsTrackerPlugin (mocked CLI)', () => {
       expect(tasks[0]?.parentId).toBe('explicit-parent');
     });
 
+    test('preserves original order when no IDs match dotted child pattern', async () => {
+      const plugin = await createInitializedPlugin();
+      mockSpawnResponses = [
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { id: 'proj-12', title: 'Twelve', status: 'open', priority: 2 },
+            { id: 'proj-2', title: 'Two', status: 'open', priority: 2 },
+            { id: 'thing.xyz', title: 'Dotted non-numeric', status: 'open', priority: 2 },
+            { id: 'thing.abj', title: 'Another dotted non-numeric', status: 'open', priority: 2 },
+          ]),
+        },
+      ];
+
+      const tasks = await plugin.getTasks();
+
+      expect(tasks.map((t) => t.id)).toEqual([
+        'proj-12',
+        'proj-2',
+        'thing.xyz',
+        'thing.abj',
+      ]);
+    });
+
+    test('sorts dotted child IDs numerically in mixed lists while preserving non-child slots', async () => {
+      const plugin = await createInitializedPlugin();
+      mockSpawnResponses = [
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { id: 'epic-5.12', title: 'Child 12', status: 'open', priority: 2 },
+            { id: 'task-alpha', title: 'Non-child A', status: 'open', priority: 2 },
+            { id: 'epic-5.2', title: 'Child 2', status: 'open', priority: 2 },
+            { id: 'thing.xyz', title: 'Dotted non-numeric', status: 'open', priority: 2 },
+            { id: 'epic-5.1', title: 'Child 1', status: 'open', priority: 2 },
+            { id: 'task-beta', title: 'Non-child B', status: 'open', priority: 2 },
+            { id: 'epic-5.9', title: 'Child 9', status: 'open', priority: 2 },
+          ]),
+        },
+      ];
+
+      const tasks = await plugin.getTasks();
+
+      expect(tasks.map((t) => t.id)).toEqual([
+        'epic-5.1',
+        'task-alpha',
+        'epic-5.2',
+        'thing.xyz',
+        'epic-5.9',
+        'task-beta',
+        'epic-5.12',
+      ]);
+    });
+
     test('extracts blocking dependencies', async () => {
       const plugin = await createInitializedPlugin();
       mockSpawnResponses = [

--- a/src/plugins/trackers/builtin/beads/index.ts
+++ b/src/plugins/trackers/builtin/beads/index.ts
@@ -9,6 +9,7 @@ import { access, constants } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { BaseTrackerPlugin } from '../../base.js';
+import { sortDottedChildTaskIds } from '../../task-ordering.js';
 import { BEADS_TEMPLATE } from '../../../../templates/builtin.js';
 import type {
   SetupQuestion,
@@ -415,6 +416,7 @@ export class BeadsTrackerPlugin extends BaseTrackerPlugin {
     // (bd list --json doesn't include parent field in output, so filterTasks would incorrectly remove tasks)
     const filterWithoutParent = filter ? { ...filter, parentId: undefined } : undefined;
     tasks = this.filterTasks(tasks, filterWithoutParent);
+    tasks = sortDottedChildTaskIds(tasks);
 
     // Enrich dependencies after filtering so we only query tasks that will be used.
     await this.enrichDependencies(tasks, beads);

--- a/src/plugins/trackers/task-ordering.ts
+++ b/src/plugins/trackers/task-ordering.ts
@@ -1,0 +1,105 @@
+/**
+ * ABOUTME: Shared task ordering utilities for tracker plugins.
+ * Provides deterministic sorting for dotted child task IDs while preserving
+ * the original positions of non-child IDs in mixed task lists.
+ */
+
+interface TaskWithId {
+  id: string;
+}
+
+interface ParsedChildId {
+  rawId: string;
+  prefix: string;
+  issueNumber: number;
+}
+
+const CHILD_TASK_ID_PATTERN = /^(.*)\.(\d+)$/;
+
+function parseChildTaskId(id: string): ParsedChildId | undefined {
+  const match = CHILD_TASK_ID_PATTERN.exec(id);
+  if (!match) {
+    return undefined;
+  }
+
+  const prefix = match[1];
+  const issueNumberString = match[2];
+  if (prefix === undefined || issueNumberString === undefined) {
+    return undefined;
+  }
+
+  const issueNumber = Number(issueNumberString);
+  if (!Number.isFinite(issueNumber)) {
+    return undefined;
+  }
+
+  return {
+    rawId: id,
+    prefix,
+    issueNumber,
+  };
+}
+
+function compareParsedChildIds(a: ParsedChildId, b: ParsedChildId): number {
+  const prefixComparison = a.prefix.localeCompare(b.prefix, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+  if (prefixComparison !== 0) {
+    return prefixComparison;
+  }
+
+  if (a.issueNumber !== b.issueNumber) {
+    return a.issueNumber - b.issueNumber;
+  }
+
+  return a.rawId.localeCompare(b.rawId, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+}
+
+/**
+ * Sort dotted child IDs of form "<prefix>.<number>" numerically while keeping
+ * non-child IDs fixed in their original relative positions.
+ */
+export function sortDottedChildTaskIds<T extends TaskWithId>(tasks: T[]): T[] {
+  if (tasks.length < 2) {
+    return tasks;
+  }
+
+  const childEntries: Array<{ index: number; task: T; parsed: ParsedChildId }> = [];
+  for (let index = 0; index < tasks.length; index += 1) {
+    const task = tasks[index];
+    if (!task) {
+      continue;
+    }
+
+    const parsed = parseChildTaskId(task.id);
+    if (parsed) {
+      childEntries.push({ index, task, parsed });
+    }
+  }
+
+  if (childEntries.length < 2) {
+    return tasks;
+  }
+
+  const sortedChildren = childEntries
+    .slice()
+    .sort((a, b) => compareParsedChildIds(a.parsed, b.parsed))
+    .map((entry) => entry.task);
+
+  const result = tasks.slice();
+  for (let i = 0; i < childEntries.length; i += 1) {
+    const originalEntry = childEntries[i];
+    const sortedTask = sortedChildren[i];
+    if (!originalEntry || !sortedTask) {
+      continue;
+    }
+    result[originalEntry.index] = sortedTask;
+  }
+
+  return result;
+}
+


### PR DESCRIPTION
## Summary
- add shared tracker utility `sortDottedChildTaskIds` for deterministic dotted child ordering
- apply shared ordering in both `beads` and `beads-rust` `getTasks()` after filtering
- preserve non-child task positions while numerically ordering child IDs like `<prefix>.<number>`
- add mixed-list and non-child-order tests for `beads`, `beads-rust`, and `beads-bv` (via inherited `getTasks`)

## Why
PR 336's comparator approach can leave child IDs unsorted in mixed lists because non-child comparisons return equality. This implementation makes ordering deterministic without moving non-child entries.

## Validation
- `bun test src/plugins/trackers/builtin/beads/index.test.ts src/plugins/trackers/builtin/beads-rust/index.test.ts src/plugins/trackers/builtin/beads-bv/index.test.ts`
- `bun run typecheck`
- `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced task ordering for items with dotted child identifiers (e.g., epic-5.1, epic-5.2, epic-5.12)
  * Tasks with dotted child IDs are now sorted numerically by their numeric suffix, whilst non-child items retain their original positions in mixed lists
  * Ensures consistent, deterministic task ordering across tracker implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->