### PR TITLE
fix: resolve Gemini CLI command name with legacy fallback

### DIFF
--- a/src/plugins/agents/builtin/gemini.test.ts
+++ b/src/plugins/agents/builtin/gemini.test.ts
@@ -32,7 +32,11 @@ describe('GeminiAgentPlugin', () => {
     });
 
     test('has correct default command', () => {
-      expect(plugin.meta.defaultCommand).toBe('gemini');
+      expect(plugin.meta.defaultCommand).toBe('gemini-cli');
+    });
+
+    test('supports legacy gemini alias', () => {
+      expect(plugin.meta.commandAliases).toEqual(['gemini']);
     });
 
     test('supports streaming', () => {

--- a/src/plugins/agents/types.ts
+++ b/src/plugins/agents/types.ts
@@ -315,6 +315,9 @@ export interface AgentPluginMeta {
   /** Default command name for the agent CLI */
   defaultCommand: string;
 
+  /** Optional alternate command names used for auto-detection */
+  commandAliases?: string[];
+
   /** Whether the agent supports streaming output */
   supportsStreaming: boolean;
 

--- a/website/content/docs/plugins/agents/gemini.mdx
+++ b/website/content/docs/plugins/agents/gemini.mdx
@@ -5,7 +5,7 @@ description: Integrate Google's Gemini CLI with Ralph TUI for AI-assisted coding
 
 ## Gemini Agent
 
-The Gemini agent plugin integrates with Google's `gemini` CLI to execute AI coding tasks. It supports YOLO mode for autonomous operation and streaming JSONL output for subagent tracing.
+The Gemini agent plugin integrates with Google's `gemini-cli` CLI to execute AI coding tasks. It supports YOLO mode for autonomous operation and streaming JSONL output for subagent tracing.
 
 <Callout type="tip">
 Gemini supports **subagent tracing** via stream-json output - Ralph TUI can show tool calls in real-time as Gemini works.
@@ -22,7 +22,7 @@ npm install -g @google/gemini-cli
 Verify installation:
 
 ```bash
-gemini --version
+gemini-cli --version
 ```
 
 ## Basic Usage
@@ -77,7 +77,7 @@ For advanced control:
 name = "my-gemini"
 plugin = "gemini"
 default = true
-command = "gemini"
+command = "gemini-cli"
 timeout = 300000
 
 [agents.options]
@@ -92,7 +92,7 @@ yoloMode = true
 | `model` | string | - | Gemini model: `gemini-2.5-pro`, `gemini-2.5-flash` |
 | `yoloMode` | boolean | `true` | Skip approval prompts for autonomous operation |
 | `timeout` | number | `0` | Execution timeout in ms (0 = no timeout) |
-| `command` | string | `"gemini"` | Path to Gemini CLI executable |
+| `command` | string | `"gemini-cli"` | Path to Gemini CLI executable |
 
 ## Models
 
@@ -149,7 +149,7 @@ Or toggle in TUI:
 
 When Ralph TUI executes a task with Gemini:
 
-1. **Build command**: Constructs `gemini [options]`
+1. **Build command**: Constructs `gemini-cli [options]`
 2. **Pass prompt via stdin**: Avoids shell escaping issues with special characters
 3. **Stream output**: Captures stdout/stderr in real-time
 4. **Parse JSONL**: Extracts structured tool call data (always enabled)
@@ -161,7 +161,7 @@ When Ralph TUI executes a task with Gemini:
 Ralph TUI builds these arguments:
 
 ```bash
-gemini \
+gemini-cli \
   --output-format stream-json \    # Always used for structured output
   -m gemini-2.5-pro \              # If model specified
   --yolo \                         # When yoloMode enabled
@@ -189,12 +189,14 @@ Gemini agent validates that model names start with `gemini-`:
 Ensure Gemini is installed and in your PATH:
 
 ```bash
-which gemini
-# Should output: /path/to/gemini
+which gemini-cli
+# Should output: /path/to/gemini-cli
 
 # If not found, install:
 npm install -g @google/gemini-cli
 ```
+
+If you still use a legacy `gemini` binary, Ralph TUI accepts it as a fallback alias.
 
 ### "Invalid model"
 


### PR DESCRIPTION
## Why this fix
Selecting `gemini` in setup currently validates against the canonical command string stored by plugin metadata. In this repo, `gemini` users were hitting a mismatch because the binary installed by Google is `gemini-cli`.

## What changed
- Updated Gemini plugin metadata to keep internal plugin id unchanged while correcting the canonical command:
  - `defaultCommand` is now `gemini-cli`
  - Added `commandAliases: ['gemini']` for legacy compatibility
- Added shared base resolution logic so plugins can resolve:
  - explicit configured command override first
  - canonical command
  - legacy/alternate aliases
- Improved command-not-found messaging to include acceptable command candidates.
- Added targeted tests covering:
  - resolves `gemini-cli`
  - falls back to legacy `gemini`
  - configured explicit command
  - clear error listing both accepted names
  - setup wizard path selecting `gemini` now persists `agent = "gemini"` correctly
- Updated Gemini docs from `gemini` to `gemini-cli`, with legacy alias note.

## Compatibility map
- Internal agent id remains `gemini` (no config migration impact).
- Canonical command for detection/execution is `gemini-cli`.
- Legacy `gemini` binary remains supported as fallback with a warning-style behavior through candidate selection logic.

## Verification
- `bun run typecheck`
- `bun run build`
- `bun test tests/plugins/gemini-agent.test.ts src/plugins/agents/builtin/gemini.test.ts src/setup/wizard.test.ts`

## Notes
- Behavior for `kiro-cli` and existing Codex/Claude flows unchanged.
- No user home config writes were used during validation; tests use isolated PATH/config paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for command aliases, enabling legacy fallback names for CLI tools.
  * Improved error messaging to clearly indicate which commands are expected during detection failures.

* **Documentation**
  * Updated references to reflect the Gemini CLI binary is now `gemini-cli`, with `gemini` supported as a legacy alias for backwards compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->