### PR TITLE
fix: clamp status progress bar inputs

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -417,10 +417,21 @@ function getIterationStatusIcon(status: string): string {
  * Create a progress bar string
  */
 function createProgressBar(percent: number, width: number): string {
-  const filled = Math.round((percent / 100) * width);
-  const empty = width - filled;
+  const safeWidth = Number.isFinite(width) ? Math.max(0, Math.round(width)) : 0;
+  const normalizedPercent = Number.isFinite(percent)
+    ? Math.min(100, Math.max(0, percent))
+    : percent === Infinity
+      ? 100
+      : 0;
+  const filledRaw = Math.round((normalizedPercent / 100) * safeWidth);
+  const filled = Math.min(safeWidth, Math.max(0, filledRaw));
+  const empty = safeWidth - filled;
   return `[${'█'.repeat(filled)}${'░'.repeat(empty)}]`;
 }
+
+export const __test__ = {
+  createProgressBar,
+};
 
 /**
  * Execute the status command

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -531,6 +531,25 @@ describe('status command', () => {
     });
   });
 
+  describe('progress bar rendering', () => {
+    test('clamps invalid percent values to avoid RangeError', () => {
+      const { __test__ } = require('../../src/commands/status.js');
+      const { createProgressBar } = __test__ as { createProgressBar: (percent: number, width: number) => string };
+
+      expect(createProgressBar(-10, 10)).toBe('[░░░░░░░░░░]');
+      expect(createProgressBar(150, 10)).toBe('[██████████]');
+      expect(createProgressBar(Number.NaN, 10)).toBe('[░░░░░░░░░░]');
+    });
+
+    test('handles non-finite width safely', () => {
+      const { __test__ } = require('../../src/commands/status.js');
+      const { createProgressBar } = __test__ as { createProgressBar: (percent: number, width: number) => string };
+
+      expect(createProgressBar(50, Number.NaN)).toBe('[]');
+      expect(createProgressBar(50, Number.POSITIVE_INFINITY)).toBe('[]');
+    });
+  });
+
   describe('progress calculation', () => {
     test('calculates progress percentage correctly', () => {
       const calculateProgress = (completed: number, total: number): number => {


### PR DESCRIPTION
## Summary
- prevent status progress bar rendering from throwing on corrupted or non-finite inputs
- add progress bar rendering tests for negative, NaN, and non-finite values

## Repro
1) Copy and corrupt a session file:
```
cp /home/bhd/Documents/Projects/bhd/poli-arbt/.ralph-tui/session.json /tmp/ralph-tui-session.json
# edit /tmp/ralph-tui-session.json and set \"tasksCompleted\": -1
```
2) Place in temp project:
```
mkdir -p /tmp/ralph-tui-repro/.ralph-tui
cp /tmp/ralph-tui-session.json /tmp/ralph-tui-repro/.ralph-tui/session.json
```
3) Run:
```
bun run ./src/cli.tsx status --cwd /tmp/ralph-tui-repro
```
4) Prior behavior: RangeError from createProgressBar on negative repeat count.

## Tests
- bun test tests/commands/status.test.ts
- bun run typecheck && bun run build

## Notes
- No user-facing docs update required; behavior is defensive for corrupted session data.
- Codecov >50% on changed lines via targeted tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced progress bar calculation to safely handle edge cases including invalid percentage values and non-finite measurements, ensuring consistent and accurate rendering across all input scenarios.

* **Tests**
  * Added comprehensive test coverage for progress bar rendering, validating correct behaviour with boundary values and abnormal input conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->