### PR TITLE
fix: show fallback description for [read] and [apply_patch] tool lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,37 +189,17 @@ jobs:
 
       - name: Check coverage threshold
         run: |
-          # Use bun's text output to check coverage. Bun reports per-file average
-          # line coverage under "All files | % Funcs | % Lines". Each batch prints
-          # this line. We use the tests/ batch (first line, 1400+ tests) as the
-          # primary indicator since it loads the most code paths.
-          #
-          # Note: we intentionally use bun's text output (per-file average) rather
-          # than lcov --summary (raw line totals). Raw totals are misleadingly low
-          # because a few large UI/server files with ~0% coverage contain thousands
-          # of lines that dwarf the well-tested files. Per-file average treats each
-          # source file equally, which better reflects actual test quality.
+          # Keep bun's text output for quick batch-by-batch visibility, but enforce
+          # the threshold using merged LCOV data across all batches. The merged metric
+          # still uses an equal-weight per-file average so very large low-coverage UI
+          # files do not drown out well-tested modules.
 
           echo "Coverage breakdown by batch:"
           echo "  %-Funcs  %-Lines"
           grep "^All files" coverage-output.txt | awk '{printf "  %6s  %6s\n", $4, $6}'
           echo ""
 
-          # Extract line coverage (% Lines, field $6) from the tests/ batch (first "All files" line)
-          LINES_COV=$(awk '/^All files/{print $6; exit}' coverage-output.txt)
-
-          echo "Primary line coverage (tests/ batch): $LINES_COV%"
-
-          # Check if coverage is below 38%
-          # Note: Threshold lowered from 40% to 38% when parallel execution was added.
-          # The tests/ batch doesn't exercise src/parallel/ code (which has its own tests
-          # in src/parallel/*.test.ts with 87-100% coverage). A better approach would be
-          # to use combined coverage from all batches.
-          if [ -z "$LINES_COV" ] || [ "$(echo "$LINES_COV < 38" | bc -l)" -eq 1 ]; then
-            echo "❌ Line coverage $LINES_COV% is below 38% threshold"
-            exit 1
-          fi
-          echo "✅ Line coverage $LINES_COV% meets 38% threshold"
+          bun testing/check-coverage.mjs coverage-parts 38
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ralph-tui",

--- a/src/plugins/agents/builtin/opencode.ts
+++ b/src/plugins/agents/builtin/opencode.ts
@@ -124,9 +124,10 @@ function parseOpenCodeJsonLine(jsonLine: string): AgentDisplayEvent[] {
 
       case 'tool_use': {
         // Tool being called - show name and relevant details
-        // opencode structure: event.part.state.input contains tool arguments
+        // opencode structure: event.part.state.input contains tool arguments,
+        // but some tools may have input at event.part.input directly
         const toolName = event.part?.tool || event.part?.name || 'unknown';
-        const toolInput = event.part?.state?.input;
+        const toolInput = event.part?.state?.input ?? event.part?.input;
         events.push({ type: 'tool_use', name: toolName, input: toolInput });
         break;
       }

--- a/src/plugins/agents/output-formatting.test.ts
+++ b/src/plugins/agents/output-formatting.test.ts
@@ -439,9 +439,9 @@ describe('formatToolCallSegments fallback', () => {
     const segments = formatToolCallSegments('read', { file_path: '/src/index.ts' });
     const text = segmentsToPlainText(segments);
     expect(text).toContain('/src/index.ts');
-    // file_path is a known field, should use normal formatting (purple color) not fallback (muted)
-    const muted = segments.filter(s => s.color === 'muted');
-    expect(muted.length).toBe(0);
+    const pathSegments = segments.filter((s) => s.text.includes('/src/index.ts'));
+    expect(pathSegments).toHaveLength(1);
+    expect(pathSegments[0]?.color).toBe('purple');
   });
 
   test('does not show arbitrary unknown string fields', () => {

--- a/src/plugins/agents/output-formatting.test.ts
+++ b/src/plugins/agents/output-formatting.test.ts
@@ -267,8 +267,14 @@ describe('formatToolCall', () => {
     const longContent = 'x'.repeat(300);
     const result = formatToolCall('write', { body: longContent } as unknown as Parameters<typeof formatToolCall>[1]);
     expect(result).toContain('[write]');
-    // Long value should be skipped, only tool name shown
+    // Unknown keys should not be shown as fallback content.
     expect(result).not.toContain('xxx');
+  });
+
+  test('fallback ignores arbitrary unknown string fields', () => {
+    const result = formatToolCall('custom_tool', { token: 'super-secret-token' } as unknown as Parameters<typeof formatToolCall>[1]);
+    expect(result).toContain('[custom_tool]');
+    expect(result).not.toContain('super-secret-token');
   });
 
   test('combines all supported fields', () => {
@@ -412,5 +418,12 @@ describe('formatToolCallSegments fallback', () => {
     // file_path is a known field, should use normal formatting (purple color) not fallback (muted)
     const muted = segments.filter(s => s.color === 'muted');
     expect(muted.length).toBe(0);
+  });
+
+  test('does not show arbitrary unknown string fields', () => {
+    const segments = formatToolCallSegments('custom_tool', { token: 'super-secret-token' } as Record<string, unknown>);
+    const text = segmentsToPlainText(segments);
+    expect(text).toContain('[custom_tool]');
+    expect(text).not.toContain('super-secret-token');
   });
 });

--- a/src/plugins/agents/output-formatting.test.ts
+++ b/src/plugins/agents/output-formatting.test.ts
@@ -13,6 +13,8 @@ import {
   formatPattern,
   formatUrl,
   formatToolCall,
+  formatToolCallSegments,
+  segmentsToPlainText,
   processAgentEvents,
 } from './output-formatting.js';
 
@@ -248,6 +250,27 @@ describe('formatToolCall', () => {
     expect(result).toContain('$ npm run build');
   });
 
+  test('falls back to first useful string for unknown fields', () => {
+    // Simulates apply_patch or tools with non-standard param names
+    const result = formatToolCall('apply_patch', { patch: '--- a/file.ts\n+++ b/file.ts' } as unknown as Parameters<typeof formatToolCall>[1]);
+    expect(result).toContain('[apply_patch]');
+    expect(result).toContain('--- a/file.ts');
+  });
+
+  test('fallback prioritizes path-like values', () => {
+    const result = formatToolCall('read', { filename: '/src/index.ts', other: 'noise' } as unknown as Parameters<typeof formatToolCall>[1]);
+    expect(result).toContain('[read]');
+    expect(result).toContain('/src/index.ts');
+  });
+
+  test('fallback skips very long values', () => {
+    const longContent = 'x'.repeat(300);
+    const result = formatToolCall('write', { body: longContent } as unknown as Parameters<typeof formatToolCall>[1]);
+    expect(result).toContain('[write]');
+    // Long value should be skipped, only tool name shown
+    expect(result).not.toContain('xxx');
+  });
+
   test('combines all supported fields', () => {
     const result = formatToolCall('complex', {
       description: 'Test',
@@ -364,5 +387,30 @@ describe('processAgentEvents', () => {
     const result = processAgentEvents(events);
     // Non-empty text gets trailing newline
     expect(result).toBe('visible\n');
+  });
+});
+
+describe('formatToolCallSegments fallback', () => {
+  test('shows fallback for unknown field names', () => {
+    const segments = formatToolCallSegments('apply_patch', { patch: '--- a/file.ts' } as Record<string, unknown>);
+    const text = segmentsToPlainText(segments);
+    expect(text).toContain('[apply_patch]');
+    expect(text).toContain('--- a/file.ts');
+  });
+
+  test('fallback prioritizes path-like values', () => {
+    const segments = formatToolCallSegments('read', { filename: '/src/index.ts', mode: 'utf8' } as Record<string, unknown>);
+    const text = segmentsToPlainText(segments);
+    expect(text).toContain('[read]');
+    expect(text).toContain('/src/index.ts');
+  });
+
+  test('no fallback when known fields present', () => {
+    const segments = formatToolCallSegments('read', { file_path: '/src/index.ts' });
+    const text = segmentsToPlainText(segments);
+    expect(text).toContain('/src/index.ts');
+    // file_path is a known field, should use normal formatting (purple color) not fallback (muted)
+    const muted = segments.filter(s => s.color === 'muted');
+    expect(muted.length).toBe(0);
   });
 });

--- a/src/plugins/agents/output-formatting.test.ts
+++ b/src/plugins/agents/output-formatting.test.ts
@@ -257,6 +257,21 @@ describe('formatToolCall', () => {
     expect(result).toContain('--- a/file.ts');
   });
 
+  test('fallback normalizes patch content to a single line', () => {
+    const patch = '\n--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old value\n+new value\n';
+    const result = formatToolCall('apply_patch', { patch } as unknown as Parameters<typeof formatToolCall>[1]);
+    expect(result).toContain('[apply_patch]');
+    expect(result).toContain('--- a/file.ts');
+    expect(result).not.toContain('\n--- a/file.ts\n+++ b/file.ts');
+  });
+
+  test('fallback prefers diff header when patch includes one', () => {
+    const patch = 'diff --git a/file.ts b/file.ts\nindex 123..456 100644\n--- a/file.ts\n+++ b/file.ts';
+    const result = formatToolCall('apply_patch', { patch } as unknown as Parameters<typeof formatToolCall>[1]);
+    expect(result).toContain('diff --git a/file.ts b/file.ts');
+    expect(result).not.toContain('index 123..456');
+  });
+
   test('fallback prioritizes path-like values', () => {
     const result = formatToolCall('read', { filename: '/src/index.ts', other: 'noise' } as unknown as Parameters<typeof formatToolCall>[1]);
     expect(result).toContain('[read]');
@@ -409,6 +424,15 @@ describe('formatToolCallSegments fallback', () => {
     const text = segmentsToPlainText(segments);
     expect(text).toContain('[read]');
     expect(text).toContain('/src/index.ts');
+  });
+
+  test('segment fallback normalizes patch content to one line', () => {
+    const patch = 'diff --git a/file.ts b/file.ts\nindex 123..456 100644\n--- a/file.ts\n+++ b/file.ts';
+    const segments = formatToolCallSegments('apply_patch', { patch } as Record<string, unknown>);
+    const text = segmentsToPlainText(segments);
+    expect(text).toContain('diff --git a/file.ts b/file.ts');
+    expect(text).not.toContain('index 123..456');
+    expect(text.split('\n').filter(Boolean)).toHaveLength(1);
   });
 
   test('no fallback when known fields present', () => {

--- a/src/plugins/agents/output-formatting.ts
+++ b/src/plugins/agents/output-formatting.ts
@@ -141,28 +141,30 @@ export interface ToolInputFormatters {
   new_string?: string;
 }
 
+const FALLBACK_DISPLAY_KEYS = ['filename', 'fileName', 'filepath', 'filePath', 'patch'] as const;
+
 /**
  * Extract a fallback display string from tool input when no known fields matched.
- * Looks for the first string value that looks useful (file paths, names, etc.).
+ * Only considers known non-standard keys to avoid exposing arbitrary input values.
  * Long values are truncated to 120 chars for display.
  */
 function extractFallbackDisplay(input: Record<string, unknown>): string | undefined {
-  // Priority: look for path-like values first, then any short string
+  // Priority: look for path-like values first, then any other known-safe fallback keys.
   let bestPath: string | undefined;
-  let bestShort: string | undefined;
+  let bestValue: string | undefined;
 
-  for (const [, value] of Object.entries(input)) {
+  for (const key of FALLBACK_DISPLAY_KEYS) {
+    const value = input[key];
     if (typeof value !== 'string' || value.length === 0) continue;
 
-    // Path-like values get priority
     if (value.startsWith('/') || value.startsWith('./') || value.startsWith('~')) {
       if (!bestPath) bestPath = value;
-    } else if (!bestShort) {
-      bestShort = value;
+    } else if (!bestValue) {
+      bestValue = value;
     }
   }
 
-  const result = bestPath ?? bestShort;
+  const result = bestPath ?? bestValue;
   if (!result) return undefined;
 
   // Truncate if needed

--- a/src/plugins/agents/output-formatting.ts
+++ b/src/plugins/agents/output-formatting.ts
@@ -143,8 +143,8 @@ export interface ToolInputFormatters {
 
 /**
  * Extract a fallback display string from tool input when no known fields matched.
- * Looks for the first short string value that looks useful (file paths, names, etc.).
- * Skips very long values (like file content or patch bodies) to keep output clean.
+ * Looks for the first string value that looks useful (file paths, names, etc.).
+ * Long values are truncated to 120 chars for display.
  */
 function extractFallbackDisplay(input: Record<string, unknown>): string | undefined {
   // Priority: look for path-like values first, then any short string
@@ -153,8 +153,6 @@ function extractFallbackDisplay(input: Record<string, unknown>): string | undefi
 
   for (const [, value] of Object.entries(input)) {
     if (typeof value !== 'string' || value.length === 0) continue;
-    // Skip very long values (file content, patch bodies, etc.)
-    if (value.length > 200) continue;
 
     // Path-like values get priority
     if (value.startsWith('/') || value.startsWith('./') || value.startsWith('~')) {

--- a/src/plugins/agents/output-formatting.ts
+++ b/src/plugins/agents/output-formatting.ts
@@ -142,6 +142,36 @@ export interface ToolInputFormatters {
 }
 
 /**
+ * Extract a fallback display string from tool input when no known fields matched.
+ * Looks for the first short string value that looks useful (file paths, names, etc.).
+ * Skips very long values (like file content or patch bodies) to keep output clean.
+ */
+function extractFallbackDisplay(input: Record<string, unknown>): string | undefined {
+  // Priority: look for path-like values first, then any short string
+  let bestPath: string | undefined;
+  let bestShort: string | undefined;
+
+  for (const [, value] of Object.entries(input)) {
+    if (typeof value !== 'string' || value.length === 0) continue;
+    // Skip very long values (file content, patch bodies, etc.)
+    if (value.length > 200) continue;
+
+    // Path-like values get priority
+    if (value.startsWith('/') || value.startsWith('./') || value.startsWith('~')) {
+      if (!bestPath) bestPath = value;
+    } else if (!bestShort) {
+      bestShort = value;
+    }
+  }
+
+  const result = bestPath ?? bestShort;
+  if (!result) return undefined;
+
+  // Truncate if needed
+  return result.length > 120 ? result.slice(0, 120) + '...' : result;
+}
+
+/**
  * Format tool call details from input fields (legacy string version).
  * @param toolName The tool name
  * @param input The tool input object (can have various fields)
@@ -188,6 +218,14 @@ export function formatToolCall(toolName: string, input?: ToolInputFormatters): s
       ? input.new_string.slice(0, 50) + '...'
       : input.new_string;
     parts.push(`edit: "${displayOld}" → "${displayNew}"`);
+  }
+
+  // Fallback: if only the tool name was added, show the first useful value from input
+  if (parts.length === 1) {
+    const fallback = extractFallbackDisplay(input as Record<string, unknown>);
+    if (fallback) {
+      parts.push(fallback);
+    }
   }
 
   return parts.join(' ') + '\n';
@@ -295,6 +333,18 @@ export function formatToolCallSegments(toolName: string, input?: ToolInputFormat
     segments.push({ text: '" → "', color: 'muted' });
     segments.push({ text: displayNew, color: 'green' });
     segments.push({ text: '"', color: 'muted' });
+  }
+
+  // Fallback: if no known fields produced output, show the first useful string value.
+  // This handles tools with non-standard parameter names (e.g. read with 'filename',
+  // apply_patch with 'patch') so they don't display as bare [toolname] with nothing after.
+  const hasContent = segments.length > 1; // more than just the tool name bracket
+  if (!hasContent) {
+    const fallback = extractFallbackDisplay(input as Record<string, unknown>);
+    if (fallback) {
+      segments.push({ text: ' ' });
+      segments.push({ text: fallback, color: 'muted' });
+    }
   }
 
   segments.push({ text: '\n' });

--- a/src/plugins/agents/output-formatting.ts
+++ b/src/plugins/agents/output-formatting.ts
@@ -143,6 +143,42 @@ export interface ToolInputFormatters {
 
 const FALLBACK_DISPLAY_KEYS = ['filename', 'fileName', 'filepath', 'filePath', 'patch'] as const;
 
+function looksLikeUnifiedDiff(value: string): boolean {
+  return value.split('\n').some(
+    (line) => line.startsWith('diff ') || line.startsWith('--- ') || line.startsWith('+++ ')
+  );
+}
+
+function summarizeUnifiedDiff(value: string): string {
+  const lines = value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return '';
+  }
+
+  const headerLine = lines.find(
+    (line) => line.startsWith('diff ') || line.startsWith('--- ') || line.startsWith('+++ ')
+  );
+
+  return headerLine ?? lines[0]!;
+}
+
+function normalizeFallbackDisplayValue(key: string, value: string): string {
+  const displayValue = key === 'patch' || looksLikeUnifiedDiff(value)
+    ? summarizeUnifiedDiff(value)
+    : value;
+
+  const normalized = displayValue.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= 120) {
+    return normalized;
+  }
+
+  return normalized.slice(0, 120) + '...';
+}
+
 /**
  * Extract a fallback display string from tool input when no known fields matched.
  * Only considers known non-standard keys to avoid exposing arbitrary input values.
@@ -158,17 +194,16 @@ function extractFallbackDisplay(input: Record<string, unknown>): string | undefi
     if (typeof value !== 'string' || value.length === 0) continue;
 
     if (value.startsWith('/') || value.startsWith('./') || value.startsWith('~')) {
-      if (!bestPath) bestPath = value;
+      if (!bestPath) bestPath = normalizeFallbackDisplayValue(key, value);
     } else if (!bestValue) {
-      bestValue = value;
+      bestValue = normalizeFallbackDisplayValue(key, value);
     }
   }
 
   const result = bestPath ?? bestValue;
   if (!result) return undefined;
 
-  // Truncate if needed
-  return result.length > 120 ? result.slice(0, 120) + '...' : result;
+  return result;
 }
 
 /**

--- a/src/tui/output-parser.test.ts
+++ b/src/tui/output-parser.test.ts
@@ -118,8 +118,8 @@ describe('StreamingOutputParser with opencode format', () => {
     });
     parser.push(toolUse + '\n');
     const output = parser.getOutput();
-    expect(output).toContain('[Tool: Bash]');
-    expect(output).toContain('command=ls -la');
+    expect(output).toContain('[Bash]');
+    expect(output).toContain('$ ls -la');
   });
 
   test('parses opencode tool_use with name field', () => {
@@ -129,7 +129,22 @@ describe('StreamingOutputParser with opencode format', () => {
       part: { name: 'Read' },
     });
     parser.push(toolUse + '\n');
-    expect(parser.getOutput()).toContain('[Tool: Read]');
+    expect(parser.getOutput()).toContain('[Read]');
+  });
+
+  test('parses opencode tool_use input from part.input fallback', () => {
+    const parser = new StreamingOutputParser({ agentPlugin: 'opencode' });
+    const toolUse = JSON.stringify({
+      type: 'tool_use',
+      part: {
+        tool: 'read',
+        input: { filename: '/tmp/demo.ts' },
+      },
+    });
+    parser.push(toolUse + '\n');
+    const output = parser.getOutput();
+    expect(output).toContain('[read]');
+    expect(output).toContain('/tmp/demo.ts');
   });
 
   test('shows opencode tool_result errors', () => {
@@ -578,7 +593,8 @@ describe('parseAgentOutput', () => {
     ].join('\n');
     const result = parseAgentOutput(lines, 'opencode');
     expect(result).toContain('Hello from OpenCode');
-    expect(result).toContain('[Tool: Bash]');
+    expect(result).toContain('[Bash]');
+    expect(result).toContain('$ pwd');
     // Successful tool results should not appear
     expect(result).not.toContain('Success');
   });

--- a/src/tui/output-parser.ts
+++ b/src/tui/output-parser.ts
@@ -13,7 +13,13 @@ import {
   parseDroidJsonlLine,
   type DroidJsonlMessage,
 } from '../plugins/agents/droid/outputParser.js';
-import { stripAnsiCodes, type FormattedSegment } from '../plugins/agents/output-formatting.js';
+import {
+  formatToolCall,
+  formatToolCallSegments,
+  stripAnsiCodes,
+  type FormattedSegment,
+  type ToolInputFormatters,
+} from '../plugins/agents/output-formatting.js';
 import {
   extractTokenUsageFromJsonLine,
   TokenUsageAccumulator,
@@ -203,6 +209,7 @@ interface OpenCodeEvent {
     text?: string;
     tool?: string;
     name?: string;
+    input?: Record<string, unknown>;
     state?: {
       input?: Record<string, unknown>;
       isError?: boolean;
@@ -467,18 +474,9 @@ function formatOpenCodeEventForDisplay(event: OpenCodeEvent): string | undefined
       break;
 
     case 'tool_use': {
-      // Tool being called - show name
       const toolName = event.part?.tool || event.part?.name || 'unknown';
-      const input = event.part?.state?.input;
-      if (input) {
-        // Show tool name and key input details
-        const inputStr = Object.entries(input)
-          .slice(0, 2)
-          .map(([k, v]) => `${k}=${typeof v === 'string' ? v.slice(0, 50) : '...'}`)
-          .join(', ');
-        return `[Tool: ${toolName}] ${inputStr}`;
-      }
-      return `[Tool: ${toolName}]`;
+      const input = event.part?.state?.input ?? event.part?.input;
+      return stripAnsiCodes(formatToolCall(toolName, input as ToolInputFormatters | undefined)).trimEnd();
     }
 
     case 'tool_result': {
@@ -793,7 +791,9 @@ export class StreamingOutputParser {
       const extractedSegments = this.extractReadableSegments(line);
       if (extractedSegments.length > 0) {
         newSegments.push(...extractedSegments);
-        newSegments.push({ text: '\n' }); // Add newline segment
+        if (!extractedSegments[extractedSegments.length - 1]!.text.endsWith('\n')) {
+          newSegments.push({ text: '\n' });
+        }
       }
     }
 
@@ -999,12 +999,14 @@ export class StreamingOutputParser {
     if (this.isOpenCode) {
       const openCodeResult = parseOpenCodeJsonlLine(trimmed);
       if (openCodeResult.success && openCodeResult.event) {
+        if (openCodeResult.event.type === 'tool_use') {
+          const toolName = openCodeResult.event.part?.tool || openCodeResult.event.part?.name || 'unknown';
+          const input = openCodeResult.event.part?.state?.input ?? openCodeResult.event.part?.input;
+          return formatToolCallSegments(toolName, input as ToolInputFormatters | undefined);
+        }
+
         const displayText = formatOpenCodeEventForDisplay(openCodeResult.event);
         if (displayText) {
-          // Format tool calls with color
-          if (openCodeResult.event.type === 'tool_use') {
-            return [{ text: displayText, color: 'cyan' }];
-          }
           if (openCodeResult.event.type === 'error') {
             return [{ text: displayText, color: 'yellow' }];
           }

--- a/testing/check-coverage.mjs
+++ b/testing/check-coverage.mjs
@@ -1,0 +1,150 @@
+/**
+ * ABOUTME: Merges LCOV batch outputs and checks an equal-weight per-file line coverage threshold.
+ * This avoids skew from using only the first coverage batch or raw line totals from very large files.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const [, , coverageDir = 'coverage-parts', thresholdArg = '38'] = process.argv;
+const threshold = Number.parseFloat(thresholdArg);
+
+if (!Number.isFinite(threshold)) {
+  console.error(`Invalid coverage threshold: ${thresholdArg}`);
+  process.exit(1);
+}
+
+/**
+ * @param {string} line
+ * @returns {{ lineNumber: number, hits: number } | null}
+ */
+function parseCoverageLine(line) {
+  if (!line.startsWith('DA:')) {
+    return null;
+  }
+
+  const [lineNumberText, hitsText] = line.slice(3).split(',', 2);
+  const lineNumber = Number.parseInt(lineNumberText ?? '', 10);
+  const hits = Number.parseInt(hitsText ?? '', 10);
+
+  if (!Number.isInteger(lineNumber) || !Number.isInteger(hits)) {
+    return null;
+  }
+
+  return { lineNumber, hits };
+}
+
+/**
+ * @param {string} dir
+ * @returns {Promise<string[]>}
+ */
+async function getLcovFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.lcov'))
+    .map((entry) => join(dir, entry.name))
+    .sort();
+}
+
+/**
+ * @param {string[]} lcovFiles
+ * @returns {Promise<Map<string, Map<number, number>>>}
+ */
+async function mergeCoverage(lcovFiles) {
+  const merged = new Map();
+
+  for (const lcovFile of lcovFiles) {
+    const content = await readFile(lcovFile, 'utf8');
+    let currentSourceFile;
+
+    for (const rawLine of content.split('\n')) {
+      const line = rawLine.trim();
+
+      if (line.startsWith('SF:')) {
+        currentSourceFile = line.slice(3);
+        if (!merged.has(currentSourceFile)) {
+          merged.set(currentSourceFile, new Map());
+        }
+        continue;
+      }
+
+      if (line === 'end_of_record') {
+        currentSourceFile = undefined;
+        continue;
+      }
+
+      if (!currentSourceFile) {
+        continue;
+      }
+
+      const parsedCoverageLine = parseCoverageLine(line);
+      if (!parsedCoverageLine) {
+        continue;
+      }
+
+      const fileCoverage = merged.get(currentSourceFile);
+      if (!fileCoverage) {
+        continue;
+      }
+
+      const previousHits = fileCoverage.get(parsedCoverageLine.lineNumber) ?? 0;
+      fileCoverage.set(parsedCoverageLine.lineNumber, Math.max(previousHits, parsedCoverageLine.hits));
+    }
+  }
+
+  return merged;
+}
+
+try {
+  const lcovFiles = await getLcovFiles(coverageDir);
+  if (lcovFiles.length === 0) {
+    console.error(`No LCOV files found in ${coverageDir}`);
+    process.exit(1);
+  }
+
+  const mergedCoverage = await mergeCoverage(lcovFiles);
+  const perFileLineCoverage = [];
+
+  for (const [sourceFile, coveredLines] of mergedCoverage.entries()) {
+    const totalLines = coveredLines.size;
+    if (totalLines === 0) {
+      continue;
+    }
+
+    let hitLines = 0;
+    for (const hits of coveredLines.values()) {
+      if (hits > 0) {
+        hitLines += 1;
+      }
+    }
+
+    perFileLineCoverage.push({
+      sourceFile,
+      lineCoverage: (hitLines / totalLines) * 100,
+    });
+  }
+
+  if (perFileLineCoverage.length === 0) {
+    console.error('No instrumented source files were found in the merged LCOV data');
+    process.exit(1);
+  }
+
+  const averageLineCoverage = perFileLineCoverage
+    .reduce((sum, fileCoverage) => sum + fileCoverage.lineCoverage, 0) / perFileLineCoverage.length;
+
+  console.log(
+    `Combined per-file line coverage: ${averageLineCoverage.toFixed(2)}% ` +
+    `across ${perFileLineCoverage.length} files from ${lcovFiles.length} LCOV batches`
+  );
+
+  if (averageLineCoverage < threshold) {
+    console.error(`❌ Combined per-file line coverage ${averageLineCoverage.toFixed(2)}% is below ${threshold}% threshold`);
+    process.exit(1);
+  }
+
+  console.log(`✅ Combined per-file line coverage ${averageLineCoverage.toFixed(2)}% meets ${threshold}% threshold`);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to check coverage: ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Tool call lines like `[read]` and `[apply_patch]` displayed with no arguments when input field names didn't match the hardcoded formatter set (`file_path`, `command`, `pattern`, etc.)
- Added `extractFallbackDisplay()` that kicks in when no known fields match — scans input values for the first useful short string, prioritizing path-like values
- Also added fallback input extraction in OpenCode parser: `event.part?.input` when `event.part?.state?.input` is missing

Closes #362

## Test plan
- [x] 6 new tests covering fallback behavior for both legacy string and TUI-native segment formatters
- [x] Existing 51 formatting tests + 97 OpenCode tests all pass
- [x] Typecheck and build clean
- [ ] Manual verification: run ralph-tui with opencode agent and confirm `[read]` and `[apply_patch]` lines now show their arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tool-call displays now append concise fallback details (e.g. path-like values or diff headers) when standard inputs are absent; long values are normalised and truncated and tool labels render more compactly (e.g. “[Bash]”).
  * Tool-event input resolution now falls back to an alternate input source.
  * Streaming output avoids duplicate newline insertions for cleaner display.

* **Tests**
  * Expanded coverage for fallback formatting, patch normalisation, path prioritisation and suppression of arbitrary unknown fields.

* **Chores**
  * CI coverage check updated and a new coverage merge/validation script added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->