### PR TITLE
fix(beads-rust): unwrap br JSON envelope before filtering

### DIFF
--- a/src/plugins/agents/output-formatting.test.ts
+++ b/src/plugins/agents/output-formatting.test.ts
@@ -278,6 +278,22 @@ describe('formatToolCall', () => {
     expect(result).toContain('/src/index.ts');
   });
 
+  test('fallback uses only the first line of safe values', () => {
+    const result = formatToolCall('read', { filename: '/src/index.ts\nignored-line' } as unknown as Parameters<typeof formatToolCall>[1]);
+    expect(result).toContain('/src/index.ts');
+    expect(result).not.toContain('ignored-line');
+  });
+
+  test('fallback skips over-cap candidates instead of truncating them', () => {
+    const tooLongPath = '/' + 'x'.repeat(121);
+    const result = formatToolCall('apply_patch', {
+      filename: tooLongPath,
+      patch: '--- a/file.ts\n+++ b/file.ts',
+    } as unknown as Parameters<typeof formatToolCall>[1]);
+    expect(result).toContain('--- a/file.ts');
+    expect(result).not.toContain(tooLongPath);
+  });
+
   test('fallback skips very long values', () => {
     const longContent = 'x'.repeat(300);
     const result = formatToolCall('write', { body: longContent } as unknown as Parameters<typeof formatToolCall>[1]);
@@ -424,6 +440,24 @@ describe('formatToolCallSegments fallback', () => {
     const text = segmentsToPlainText(segments);
     expect(text).toContain('[read]');
     expect(text).toContain('/src/index.ts');
+  });
+
+  test('segment fallback uses only the first line of safe values', () => {
+    const segments = formatToolCallSegments('read', { filename: '/src/index.ts\nignored-line' } as Record<string, unknown>);
+    const text = segmentsToPlainText(segments);
+    expect(text).toContain('/src/index.ts');
+    expect(text).not.toContain('ignored-line');
+  });
+
+  test('segment fallback skips over-cap candidates instead of truncating them', () => {
+    const tooLongPath = '/' + 'x'.repeat(121);
+    const segments = formatToolCallSegments('apply_patch', {
+      filename: tooLongPath,
+      patch: '--- a/file.ts\n+++ b/file.ts',
+    } as Record<string, unknown>);
+    const text = segmentsToPlainText(segments);
+    expect(text).toContain('--- a/file.ts');
+    expect(text).not.toContain(tooLongPath);
   });
 
   test('segment fallback normalizes patch content to one line', () => {

--- a/src/plugins/agents/output-formatting.ts
+++ b/src/plugins/agents/output-formatting.ts
@@ -142,6 +142,7 @@ export interface ToolInputFormatters {
 }
 
 const FALLBACK_DISPLAY_KEYS = ['filename', 'fileName', 'filepath', 'filePath', 'patch'] as const;
+const FALLBACK_DISPLAY_MAX_LENGTH = 120;
 
 function looksLikeUnifiedDiff(value: string): boolean {
   return value.split('\n').some(
@@ -166,23 +167,24 @@ function summarizeUnifiedDiff(value: string): string {
   return headerLine ?? lines[0]!;
 }
 
-function normalizeFallbackDisplayValue(key: string, value: string): string {
+function selectFallbackDisplayValue(key: string, value: string): string | undefined {
   const displayValue = key === 'patch' || looksLikeUnifiedDiff(value)
     ? summarizeUnifiedDiff(value)
     : value;
+  const [firstLine = ''] = displayValue.split(/\r?\n/, 1);
+  const normalized = firstLine.trim();
 
-  const normalized = displayValue.replace(/\s+/g, ' ').trim();
-  if (normalized.length <= 120) {
-    return normalized;
+  if (normalized.length === 0 || normalized.length > FALLBACK_DISPLAY_MAX_LENGTH) {
+    return undefined;
   }
 
-  return normalized.slice(0, 120) + '...';
+  return normalized;
 }
 
 /**
  * Extract a fallback display string from tool input when no known fields matched.
  * Only considers known non-standard keys to avoid exposing arbitrary input values.
- * Long values are truncated to 120 chars for display.
+ * Multi-line values are reduced to their first line and overlong candidates are ignored.
  */
 function extractFallbackDisplay(input: Record<string, unknown>): string | undefined {
   // Priority: look for path-like values first, then any other known-safe fallback keys.
@@ -192,11 +194,13 @@ function extractFallbackDisplay(input: Record<string, unknown>): string | undefi
   for (const key of FALLBACK_DISPLAY_KEYS) {
     const value = input[key];
     if (typeof value !== 'string' || value.length === 0) continue;
+    const displayValue = selectFallbackDisplayValue(key, value);
+    if (!displayValue) continue;
 
-    if (value.startsWith('/') || value.startsWith('./') || value.startsWith('~')) {
-      if (!bestPath) bestPath = normalizeFallbackDisplayValue(key, value);
+    if (displayValue.startsWith('/') || displayValue.startsWith('./') || displayValue.startsWith('~')) {
+      if (!bestPath) bestPath = displayValue;
     } else if (!bestValue) {
-      bestValue = normalizeFallbackDisplayValue(key, value);
+      bestValue = displayValue;
     }
   }
 

--- a/src/plugins/trackers/builtin/beads-rust/index.test.ts
+++ b/src/plugins/trackers/builtin/beads-rust/index.test.ts
@@ -192,9 +192,11 @@ describe('BeadsRustTrackerPlugin', () => {
         { exitCode: 0, stdout: 'br version 0.4.1\n' },
         {
           exitCode: 0,
-          stdout: JSON.stringify([
-            { id: 't1', title: 'Task 1', status: 'open', priority: 2 },
-          ]),
+          stdout: JSON.stringify({
+            issues: [
+              { id: 't1', title: 'Task 1', status: 'open', priority: 2 },
+            ],
+          }),
         },
       ];
 
@@ -207,6 +209,37 @@ describe('BeadsRustTrackerPlugin', () => {
       expect(mockSpawnArgs.length).toBe(1);
       expect(mockSpawnArgs[0]?.cmd).toBe('br');
       expect(mockSpawnArgs[0]?.args).toEqual(['list', '--json', '--all', '--limit', '0']);
+    });
+
+    test('returns empty array and logs unexpected br list JSON shapes', async () => {
+      const originalError = console.error;
+      const errorMessages: string[] = [];
+      console.error = (...args: unknown[]) => {
+        errorMessages.push(args.map((arg) => String(arg)).join(' '));
+      };
+
+      try {
+        mockSpawnResponses = [
+          { exitCode: 0, stdout: 'br version 0.4.1\n' },
+          {
+            exitCode: 0,
+            stdout: JSON.stringify({ tasks: [] }),
+          },
+        ];
+
+        const plugin = new BeadsRustTrackerPlugin();
+        await plugin.initialize({ workingDir: '/test' });
+        mockSpawnArgs = [];
+
+        const tasks = await plugin.getTasks();
+
+        expect(tasks).toEqual([]);
+        expect(errorMessages).toHaveLength(1);
+        expect(errorMessages[0]).toContain('unwrapBrJson expected BrTaskJson[] or { issues: BrTaskJson[] }');
+        expect(errorMessages[0]).toContain('{"tasks":[]}');
+      } finally {
+        console.error = originalError;
+      }
     });
 
     test('supports --parent filtering via in-memory filtering', async () => {
@@ -677,15 +710,17 @@ describe('BeadsRustTrackerPlugin', () => {
         { exitCode: 0, stdout: 'br version 0.4.1\n' },
         {
           exitCode: 0,
-          stdout: JSON.stringify([
-            {
-              id: 'epic1',
-              title: 'Epic 1',
-              status: 'open',
-              priority: 1,
-              issue_type: 'epic',
-            },
-          ]),
+          stdout: JSON.stringify({
+            issues: [
+              {
+                id: 'epic1',
+                title: 'Epic 1',
+                status: 'open',
+                priority: 1,
+                issue_type: 'epic',
+              },
+            ],
+          }),
         },
       ];
 
@@ -909,10 +944,12 @@ describe('BeadsRustTrackerPlugin', () => {
         // First: br ready with filters
         {
           exitCode: 0,
-          stdout: JSON.stringify([
-            { id: 't1', title: 'Task 1', status: 'open', priority: 2 },
-            { id: 't2', title: 'Other Task', status: 'open', priority: 1 },
-          ]),
+          stdout: JSON.stringify({
+            issues: [
+              { id: 't1', title: 'Task 1', status: 'open', priority: 2 },
+              { id: 't2', title: 'Other Task', status: 'open', priority: 1 },
+            ],
+          }),
         },
         // Second: br dep list epic --direction up --json (for filtering children)
         {

--- a/src/plugins/trackers/builtin/beads-rust/index.ts
+++ b/src/plugins/trackers/builtin/beads-rust/index.ts
@@ -159,6 +159,20 @@ function isTombstone(brStatus: string): boolean {
 }
 
 /**
+ * Unwrap br JSON output which may be a bare array or an envelope object
+ * with an `issues` key (br ≥ recent versions).
+ */
+function unwrapBrJson(parsed: unknown): BrTaskJson[] {
+  if (Array.isArray(parsed)) {
+    return parsed as BrTaskJson[];
+  }
+  if (parsed && typeof parsed === 'object' && 'issues' in parsed && Array.isArray((parsed as Record<string, unknown>).issues)) {
+    return (parsed as Record<string, unknown>).issues as BrTaskJson[];
+  }
+  return [];
+}
+
+/**
  * Convert TrackerTaskStatus back to br status.
  */
 function mapStatusToBr(status: TrackerTaskStatus): string {
@@ -370,7 +384,7 @@ export class BeadsRustTrackerPlugin extends BaseTrackerPlugin {
 
     let tasksJson: BrTaskJson[];
     try {
-      tasksJson = JSON.parse(stdout) as BrTaskJson[];
+      tasksJson = unwrapBrJson(JSON.parse(stdout));
     } catch (err) {
       console.error('Failed to parse br list output:', err);
       return [];
@@ -424,7 +438,7 @@ export class BeadsRustTrackerPlugin extends BaseTrackerPlugin {
 
     let tasksJson: BrTaskJson[];
     try {
-      tasksJson = JSON.parse(stdout) as BrTaskJson[];
+      tasksJson = unwrapBrJson(JSON.parse(stdout));
     } catch (err) {
       console.error('Failed to parse br list --type epic output:', err);
       return [];
@@ -636,7 +650,7 @@ export class BeadsRustTrackerPlugin extends BaseTrackerPlugin {
 
     let tasksJson: BrTaskJson[];
     try {
-      tasksJson = JSON.parse(stdout) as BrTaskJson[];
+      tasksJson = unwrapBrJson(JSON.parse(stdout));
     } catch (err) {
       console.error('Failed to parse br ready output:', err);
       return undefined;

--- a/src/plugins/trackers/builtin/beads-rust/index.ts
+++ b/src/plugins/trackers/builtin/beads-rust/index.ts
@@ -160,16 +160,25 @@ function isTombstone(brStatus: string): boolean {
 
 /**
  * Unwrap br JSON output which may be a bare array or an envelope object
- * with an `issues` key (br ≥ recent versions).
+ * with an `issues` key (br >= recent versions).
  */
 function unwrapBrJson(parsed: unknown): BrTaskJson[] {
   if (Array.isArray(parsed)) {
     return parsed as BrTaskJson[];
   }
-  if (parsed && typeof parsed === 'object' && 'issues' in parsed && Array.isArray((parsed as Record<string, unknown>).issues)) {
+  if (
+    parsed &&
+    typeof parsed === 'object' &&
+    'issues' in parsed &&
+    Array.isArray((parsed as Record<string, unknown>).issues)
+  ) {
     return (parsed as Record<string, unknown>).issues as BrTaskJson[];
   }
-  return [];
+
+  const unexpectedValue = JSON.stringify(parsed) ?? String(parsed);
+  throw new Error(
+    `unwrapBrJson expected BrTaskJson[] or { issues: BrTaskJson[] } but received: ${unexpectedValue}`
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- `br list --json` now returns `{"issues": [...]}` instead of a bare array
- beads-rust tracker called `.filter()` directly on the parsed object, crashing with `tasksJson.filter is not a function`
- Added `unwrapBrJson()` helper that handles both envelope and bare-array formats
- Applied to `getTasks()`, `getEpics()`, and `getNextTask()`

## Test plan
- [x] Verified `ralph-tui run --tracker beads-rust --epic bd-3r0r` initializes without error
- [ ] Unit tests for `unwrapBrJson` with both formats

Fixes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved output formatting to better handle multi-line fallback values and enforce length constraints.
  * Enhanced tracker plugin to support alternative JSON response structures from external tools.

* **Tests**
  * Expanded test coverage for output formatting fallback behaviour.
  * Added test cases for alternative JSON response format handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->