### PR TITLE
Fix incorrect cursor cli command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ Complete this checklist when adding a new agent plugin:
   - [ ] `description` - Brief description
   - [ ] `version` - Plugin version
   - [ ] `author` - Author/organization name
-  - [ ] `defaultCommand` - CLI command name (e.g., `'cursor'`)
+  - [ ] `defaultCommand` - CLI command name (e.g., `'agent'`)
   - [ ] `supportsStreaming` - Whether agent supports streaming output
   - [ ] `supportsInterrupt` - Whether agent can be interrupted
   - [ ] `supportsFileContext` - Whether agent accepts file context

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **AI Agent Loop Orchestrator** - A terminal UI for orchestrating AI coding agents to work through task lists autonomously.
 
-Ralph TUI connects your AI coding assistant (Claude Code, OpenCode, Factory Droid, Gemini CLI, Codex, Kiro CLI) to your task tracker and runs them in an autonomous loop, completing tasks one-by-one with intelligent selection, error handling, and full visibility.
+Ralph TUI connects your AI coding assistant (Claude Code, OpenCode, Factory Droid, Cursor CLI, Gemini CLI, Codex, Kiro CLI) to your task tracker and runs them in an autonomous loop, completing tasks one-by-one with intelligent selection, error handling, and full visibility.
 
 ![Ralph TUI Screenshot](docs/images/ralph-tui.png)
 
@@ -67,7 +67,7 @@ Ralph selects the highest-priority task, builds a prompt, executes your AI agent
 ## Features
 
 - **Task Trackers**: prd.json (simple), Beads (git-backed with dependencies)
-- **AI Agents**: Claude Code, OpenCode, Factory Droid, Gemini CLI, Codex, Kiro CLI
+- **AI Agents**: Claude Code, OpenCode, Factory Droid, Cursor CLI, Gemini CLI, Codex, Kiro CLI
 - **Session Persistence**: Pause anytime, resume later, survive crashes
 - **Real-time TUI**: Watch agent output, control execution with keyboard shortcuts
 - **Subagent Tracing**: See nested agent calls in real-time

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ralph-tui": "./dist/cli.js"
   },
   "scripts": {
-    "build": "bun build ./src/cli.tsx --outdir ./dist --target bun --sourcemap=external --external @opentui/core --external @opentui/react --external react && bun build ./src/index.ts --outdir ./dist --target bun --sourcemap=external --external @opentui/core --external @opentui/react --external react && cp -r assets dist/ && cp -r skills dist/ && bun run build:templates",
+    "build": "bun build ./src/cli.tsx --outdir ./dist --target bun --sourcemap=external --external @opentui/core --external @opentui/react --external react && bun build ./src/index.ts --outdir ./dist --target bun --sourcemap=external --external @opentui/core --external @opentui/react --external react && cp -R assets dist/ && cp -R skills dist/ && bun run build:templates",
     "build:templates": "mkdir -p dist/plugins/trackers/builtin/beads dist/plugins/trackers/builtin/beads-bv dist/plugins/trackers/builtin/json dist/plugins/trackers/builtin/beads-rust && cp src/plugins/trackers/builtin/beads/template.hbs dist/plugins/trackers/builtin/beads/ && cp src/plugins/trackers/builtin/beads-bv/template.hbs dist/plugins/trackers/builtin/beads-bv/ && cp src/plugins/trackers/builtin/json/template.hbs dist/plugins/trackers/builtin/json/ && cp src/plugins/trackers/builtin/beads-rust/template.hbs dist/plugins/trackers/builtin/beads-rust/",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
     "typecheck": "tsc --noEmit",

--- a/src/commands/create-prd.test.tsx
+++ b/src/commands/create-prd.test.tsx
@@ -17,7 +17,9 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
+// @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+const actualAgentRegistryModule =
+  (await import('../plugins/agents/registry.js?test-reload-create-prd-registry')) as typeof import('../plugins/agents/registry.js');
 
 // Mock agent instance
 const createMockAgentInstance = () => ({

--- a/src/commands/create-prd.test.tsx
+++ b/src/commands/create-prd.test.tsx
@@ -17,6 +17,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
+
 // Mock agent instance
 const createMockAgentInstance = () => ({
   meta: { id: 'claude', name: 'Claude Code' },
@@ -29,6 +31,7 @@ const createMockAgentInstance = () => ({
 
 // Mock the agent registry
 mock.module('../plugins/agents/registry.js', () => ({
+  ...actualAgentRegistryModule,
   getAgentRegistry: () => ({
     getInstance: () => Promise.resolve(createMockAgentInstance()),
     hasPlugin: (name: string) => name === 'claude' || name === 'opencode',

--- a/src/commands/create-prd.test.tsx
+++ b/src/commands/create-prd.test.tsx
@@ -18,8 +18,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-const actualAgentRegistryModule =
-  (await import('../plugins/agents/registry.js?test-reload-create-prd-registry')) as typeof import('../plugins/agents/registry.js');
+const actualAgentRegistryModule = await import('../plugins/agents/registry.js?test-reload') as typeof import('../plugins/agents/registry.js');
 
 // Mock agent instance
 const createMockAgentInstance = () => ({

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -17,7 +17,9 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
+// @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+const actualAgentRegistryModule =
+  (await import('../plugins/agents/registry.js?test-reload-doctor-registry')) as typeof import('../plugins/agents/registry.js');
 
 // Types for mock results
 interface MockDetectResult {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -17,6 +17,8 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
+
 // Types for mock results
 interface MockDetectResult {
   available: boolean;
@@ -49,6 +51,7 @@ const createMockAgentInstance = () => ({
 
 // Mock the agent registry
 mock.module('../plugins/agents/registry.js', () => ({
+  ...actualAgentRegistryModule,
   getAgentRegistry: () => ({
     getInstance: (config: unknown) => {
       lastGetInstanceConfig = config;

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -18,8 +18,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-const actualAgentRegistryModule =
-  (await import('../plugins/agents/registry.js?test-reload-doctor-registry')) as typeof import('../plugins/agents/registry.js');
+const actualAgentRegistryModule = await import('../plugins/agents/registry.js?test-reload') as typeof import('../plugins/agents/registry.js');
 
 // Types for mock results
 interface MockDetectResult {

--- a/src/plugins/agents/builtin/cursor.test.ts
+++ b/src/plugins/agents/builtin/cursor.test.ts
@@ -32,7 +32,7 @@ describe('CursorAgentPlugin', () => {
     });
 
     test('has correct default command', () => {
-      expect(plugin.meta.defaultCommand).toBe('cursor');
+      expect(plugin.meta.defaultCommand).toBe('agent');
     });
 
     test('supports streaming', () => {

--- a/src/plugins/agents/builtin/cursor.ts
+++ b/src/plugins/agents/builtin/cursor.ts
@@ -117,7 +117,7 @@ export class CursorAgentPlugin extends BaseAgentPlugin {
     description: 'Cursor Agent CLI for AI-assisted coding',
     version: '1.0.0',
     author: 'Cursor',
-    defaultCommand: 'cursor',
+    defaultCommand: 'agent',
     supportsStreaming: true,
     supportsInterrupt: true,
     supportsFileContext: false,
@@ -476,8 +476,8 @@ export class CursorAgentPlugin extends BaseAgentPlugin {
   protected override getPreflightSuggestion(): string {
     return (
       'Common fixes for Cursor Agent:\n' +
-      '  1. Test Cursor directly: cursor --print "hello"\n' +
-      '  2. Check Cursor is installed: cursor --version\n' +
+      '  1. Test Cursor directly: agent --print "hello"\n' +
+      '  2. Check Cursor is installed: agent --version\n' +
       '  3. Install from: https://docs.cursor.com/cli\n' +
       '  4. Verify your model configuration if using a specific model'
     );

--- a/src/setup/migration-install.test.ts
+++ b/src/setup/migration-install.test.ts
@@ -9,6 +9,8 @@ import { join } from 'node:path';
 import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
+const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
+
 let mockInstallResult = { success: true, output: '' };
 let mockAgentAvailable = true;
 
@@ -27,6 +29,7 @@ mock.module('../plugins/agents/builtin/index.js', () => ({
 }));
 
 mock.module('../plugins/agents/registry.js', () => ({
+  ...actualAgentRegistryModule,
   getAgentRegistry: () => ({
     getRegisteredPlugins: () => [
       {

--- a/src/setup/migration-install.test.ts
+++ b/src/setup/migration-install.test.ts
@@ -9,7 +9,12 @@ import { join } from 'node:path';
 import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
-const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
+// @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+const actualAgentRegistryModule =
+  (await import('../plugins/agents/registry.js?test-reload-migration-install-registry')) as typeof import('../plugins/agents/registry.js');
+// @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+const actualTemplateEngineModule =
+  (await import('../templates/engine.js?test-reload-migration-install-templates')) as typeof import('../templates/engine.js');
 
 let mockInstallResult = { success: true, output: '' };
 let mockAgentAvailable = true;
@@ -20,6 +25,7 @@ mock.module('./skill-installer.js', () => ({
 }));
 
 mock.module('../templates/engine.js', () => ({
+  ...actualTemplateEngineModule,
   installBuiltinTemplates: () => {},
   installGlobalTemplatesIfMissing: () => false,
 }));

--- a/src/setup/migration-install.test.ts
+++ b/src/setup/migration-install.test.ts
@@ -10,11 +10,9 @@ import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
 // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-const actualAgentRegistryModule =
-  (await import('../plugins/agents/registry.js?test-reload-migration-install-registry')) as typeof import('../plugins/agents/registry.js');
+const actualAgentRegistryModule = await import('../plugins/agents/registry.js?test-reload') as typeof import('../plugins/agents/registry.js');
 // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-const actualTemplateEngineModule =
-  (await import('../templates/engine.js?test-reload-migration-install-templates')) as typeof import('../templates/engine.js');
+const actualTemplateEngineModule = await import('../templates/engine.js?test-reload') as typeof import('../templates/engine.js');
 
 let mockInstallResult = { success: true, output: '' };
 let mockAgentAvailable = true;

--- a/src/setup/migration.test.ts
+++ b/src/setup/migration.test.ts
@@ -87,7 +87,11 @@ beforeAll(async () => {
   }));
 
   // Mock template engine to avoid file system operations
+  // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+  const realTemplateEngine =
+    (await import('../templates/engine.js?test-reload-migration-templates')) as typeof import('../templates/engine.js');
   mock.module('../templates/engine.js', () => ({
+    ...realTemplateEngine,
     installBuiltinTemplates: () => ({
       success: true,
       templatesDir: '/mock/templates',
@@ -101,7 +105,9 @@ beforeAll(async () => {
     registerBuiltinAgents: () => {},
   }));
 
-  const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
+  // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+  const actualAgentRegistryModule =
+    (await import('../plugins/agents/registry.js?test-reload-migration-registry')) as typeof import('../plugins/agents/registry.js');
   mock.module('../plugins/agents/registry.js', () => ({
     ...actualAgentRegistryModule,
     getAgentRegistry: () => ({

--- a/src/setup/migration.test.ts
+++ b/src/setup/migration.test.ts
@@ -101,7 +101,9 @@ beforeAll(async () => {
     registerBuiltinAgents: () => {},
   }));
 
+  const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
   mock.module('../plugins/agents/registry.js', () => ({
+    ...actualAgentRegistryModule,
     getAgentRegistry: () => ({
       getRegisteredPlugins: () => [
         {
@@ -314,4 +316,3 @@ describe('CURRENT_CONFIG_VERSION', () => {
     expect(CURRENT_CONFIG_VERSION).toBe('2.1');
   });
 });
-

--- a/src/setup/migration.test.ts
+++ b/src/setup/migration.test.ts
@@ -88,8 +88,7 @@ beforeAll(async () => {
 
   // Mock template engine to avoid file system operations
   // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-  const realTemplateEngine =
-    (await import('../templates/engine.js?test-reload-migration-templates')) as typeof import('../templates/engine.js');
+  const realTemplateEngine = await import('../templates/engine.js?test-reload') as typeof import('../templates/engine.js');
   mock.module('../templates/engine.js', () => ({
     ...realTemplateEngine,
     installBuiltinTemplates: () => ({
@@ -106,8 +105,7 @@ beforeAll(async () => {
   }));
 
   // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-  const actualAgentRegistryModule =
-    (await import('../plugins/agents/registry.js?test-reload-migration-registry')) as typeof import('../plugins/agents/registry.js');
+  const actualAgentRegistryModule = await import('../plugins/agents/registry.js?test-reload') as typeof import('../plugins/agents/registry.js');
   mock.module('../plugins/agents/registry.js', () => ({
     ...actualAgentRegistryModule,
     getAgentRegistry: () => ({

--- a/src/setup/wizard.test.ts
+++ b/src/setup/wizard.test.ts
@@ -131,7 +131,9 @@ describe('wizard', () => {
     }));
 
     // Mock tracker registry
+    const actualTrackerRegistryModule = await import('../plugins/trackers/registry.js');
     mock.module('../plugins/trackers/registry.js', () => ({
+      ...actualTrackerRegistryModule,
       getTrackerRegistry: () => ({
         initialize: () => Promise.resolve(),
         getRegisteredPlugins: () => trackerPluginMeta,
@@ -147,7 +149,9 @@ describe('wizard', () => {
     }));
 
     // Mock the agent registry to return our mock instance
+    const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
     mock.module('../plugins/agents/registry.js', () => ({
+      ...actualAgentRegistryModule,
       getAgentRegistry: () => ({
         getInstance: () => Promise.resolve(createMockAgentInstance('claude', 'Claude Code')),
         initialize: () => Promise.resolve(),

--- a/src/setup/wizard.test.ts
+++ b/src/setup/wizard.test.ts
@@ -131,7 +131,9 @@ describe('wizard', () => {
     }));
 
     // Mock tracker registry
-    const actualTrackerRegistryModule = await import('../plugins/trackers/registry.js');
+    // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+    const actualTrackerRegistryModule =
+      (await import('../plugins/trackers/registry.js?test-reload-wizard-tracker-registry')) as typeof import('../plugins/trackers/registry.js');
     mock.module('../plugins/trackers/registry.js', () => ({
       ...actualTrackerRegistryModule,
       getTrackerRegistry: () => ({
@@ -149,7 +151,9 @@ describe('wizard', () => {
     }));
 
     // Mock the agent registry to return our mock instance
-    const actualAgentRegistryModule = await import('../plugins/agents/registry.js');
+    // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+    const actualAgentRegistryModule =
+      (await import('../plugins/agents/registry.js?test-reload-wizard-agent-registry')) as typeof import('../plugins/agents/registry.js');
     mock.module('../plugins/agents/registry.js', () => ({
       ...actualAgentRegistryModule,
       getAgentRegistry: () => ({

--- a/src/setup/wizard.test.ts
+++ b/src/setup/wizard.test.ts
@@ -132,8 +132,7 @@ describe('wizard', () => {
 
     // Mock tracker registry
     // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-    const actualTrackerRegistryModule =
-      (await import('../plugins/trackers/registry.js?test-reload-wizard-tracker-registry')) as typeof import('../plugins/trackers/registry.js');
+    const actualTrackerRegistryModule = await import('../plugins/trackers/registry.js?test-reload') as typeof import('../plugins/trackers/registry.js');
     mock.module('../plugins/trackers/registry.js', () => ({
       ...actualTrackerRegistryModule,
       getTrackerRegistry: () => ({
@@ -152,8 +151,7 @@ describe('wizard', () => {
 
     // Mock the agent registry to return our mock instance
     // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-    const actualAgentRegistryModule =
-      (await import('../plugins/agents/registry.js?test-reload-wizard-agent-registry')) as typeof import('../plugins/agents/registry.js');
+    const actualAgentRegistryModule = await import('../plugins/agents/registry.js?test-reload') as typeof import('../plugins/agents/registry.js');
     mock.module('../plugins/agents/registry.js', () => ({
       ...actualAgentRegistryModule,
       getAgentRegistry: () => ({

--- a/tests/engine/execution-engine.test.ts
+++ b/tests/engine/execution-engine.test.ts
@@ -25,6 +25,9 @@ import {
   createDetectResult,
 } from '../mocks/agent-responses.js';
 
+const actualAgentRegistryModule = await import('../../src/plugins/agents/registry.js');
+const actualTrackerRegistryModule = await import('../../src/plugins/trackers/registry.js');
+
 // Mock the registry modules
 const mockAgentInstance = createMockAgentPlugin();
 const mockTrackerInstance: Partial<TrackerPlugin> = {
@@ -45,12 +48,14 @@ const mockUpdateSessionMaxIterations = mock(() => Promise.resolve());
 
 // Override module imports
 mock.module('../../src/plugins/agents/registry.js', () => ({
+  ...actualAgentRegistryModule,
   getAgentRegistry: () => ({
     getInstance: () => Promise.resolve(mockAgentInstance),
   }),
 }));
 
 mock.module('../../src/plugins/trackers/registry.js', () => ({
+  ...actualTrackerRegistryModule,
   getTrackerRegistry: () => ({
     getInstance: () => Promise.resolve(mockTrackerInstance),
   }),

--- a/tests/engine/execution-engine.test.ts
+++ b/tests/engine/execution-engine.test.ts
@@ -25,8 +25,12 @@ import {
   createDetectResult,
 } from '../mocks/agent-responses.js';
 
-const actualAgentRegistryModule = await import('../../src/plugins/agents/registry.js');
-const actualTrackerRegistryModule = await import('../../src/plugins/trackers/registry.js');
+// @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+const actualAgentRegistryModule =
+  (await import('../../src/plugins/agents/registry.js?test-reload-execution-engine-agent-registry')) as typeof import('../../src/plugins/agents/registry.js');
+// @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+const actualTrackerRegistryModule =
+  (await import('../../src/plugins/trackers/registry.js?test-reload-execution-engine-tracker-registry')) as typeof import('../../src/plugins/trackers/registry.js');
 
 // Mock the registry modules
 const mockAgentInstance = createMockAgentPlugin();

--- a/tests/engine/execution-engine.test.ts
+++ b/tests/engine/execution-engine.test.ts
@@ -26,11 +26,9 @@ import {
 } from '../mocks/agent-responses.js';
 
 // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-const actualAgentRegistryModule =
-  (await import('../../src/plugins/agents/registry.js?test-reload-execution-engine-agent-registry')) as typeof import('../../src/plugins/agents/registry.js');
+const actualAgentRegistryModule = await import('../../src/plugins/agents/registry.js?test-reload') as typeof import('../../src/plugins/agents/registry.js');
 // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-const actualTrackerRegistryModule =
-  (await import('../../src/plugins/trackers/registry.js?test-reload-execution-engine-tracker-registry')) as typeof import('../../src/plugins/trackers/registry.js');
+const actualTrackerRegistryModule = await import('../../src/plugins/trackers/registry.js?test-reload') as typeof import('../../src/plugins/trackers/registry.js');
 
 // Mock the registry modules
 const mockAgentInstance = createMockAgentPlugin();

--- a/tests/engine/integration.test.ts
+++ b/tests/engine/integration.test.ts
@@ -220,15 +220,20 @@ describe('ExecutionEngine Integration', () => {
     // Reset mocks for each test
     mockAgentRegistry = createControllableAgent();
     mockTrackerRegistry = createControllableTracker();
+
+    const actualAgentRegistryModule = await import('../../src/plugins/agents/registry.js');
+    const actualTrackerRegistryModule = await import('../../src/plugins/trackers/registry.js');
     
     // Mock the modules
     mock.module('../../src/plugins/agents/registry.js', () => ({
+      ...actualAgentRegistryModule,
       getAgentRegistry: () => ({
         getInstance: () => Promise.resolve(mockAgentRegistry.agent),
       }),
     }));
 
     mock.module('../../src/plugins/trackers/registry.js', () => ({
+      ...actualTrackerRegistryModule,
       getTrackerRegistry: () => ({
         getInstance: () => Promise.resolve(mockTrackerRegistry.tracker),
       }),

--- a/tests/engine/integration.test.ts
+++ b/tests/engine/integration.test.ts
@@ -221,8 +221,12 @@ describe('ExecutionEngine Integration', () => {
     mockAgentRegistry = createControllableAgent();
     mockTrackerRegistry = createControllableTracker();
 
-    const actualAgentRegistryModule = await import('../../src/plugins/agents/registry.js');
-    const actualTrackerRegistryModule = await import('../../src/plugins/trackers/registry.js');
+    // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+    const actualAgentRegistryModule =
+      (await import('../../src/plugins/agents/registry.js?test-reload-integration-agent-registry')) as typeof import('../../src/plugins/agents/registry.js');
+    // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
+    const actualTrackerRegistryModule =
+      (await import('../../src/plugins/trackers/registry.js?test-reload-integration-tracker-registry')) as typeof import('../../src/plugins/trackers/registry.js');
     
     // Mock the modules
     mock.module('../../src/plugins/agents/registry.js', () => ({

--- a/tests/engine/integration.test.ts
+++ b/tests/engine/integration.test.ts
@@ -222,11 +222,9 @@ describe('ExecutionEngine Integration', () => {
     mockTrackerRegistry = createControllableTracker();
 
     // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-    const actualAgentRegistryModule =
-      (await import('../../src/plugins/agents/registry.js?test-reload-integration-agent-registry')) as typeof import('../../src/plugins/agents/registry.js');
+    const actualAgentRegistryModule = await import('../../src/plugins/agents/registry.js?test-reload') as typeof import('../../src/plugins/agents/registry.js');
     // @ts-expect-error - Bun supports query strings in imports to get fresh module instances
-    const actualTrackerRegistryModule =
-      (await import('../../src/plugins/trackers/registry.js?test-reload-integration-tracker-registry')) as typeof import('../../src/plugins/trackers/registry.js');
+    const actualTrackerRegistryModule = await import('../../src/plugins/trackers/registry.js?test-reload') as typeof import('../../src/plugins/trackers/registry.js');
     
     // Mock the modules
     mock.module('../../src/plugins/agents/registry.js', () => ({

--- a/website/content/docs/plugins/agents/cursor.mdx
+++ b/website/content/docs/plugins/agents/cursor.mdx
@@ -5,7 +5,7 @@ description: Integrate Cursor's CLI with Ralph TUI for AI-assisted coding.
 
 ## Cursor Agent
 
-The Cursor agent plugin integrates with Cursor's `cursor` CLI to execute AI coding tasks. It supports multiple execution modes, auto-approve for autonomous operation, and model selection.
+The Cursor agent plugin integrates with Cursor's `agent` CLI command to execute AI coding tasks. It supports multiple execution modes, auto-approve for autonomous operation, and model selection.
 
 <Callout type="tip">
 Cursor supports **subagent tracing** via JSONL output - Ralph TUI can show tool calls in real-time as Cursor works.
@@ -18,7 +18,7 @@ Install Cursor CLI from [docs.cursor.com/cli](https://docs.cursor.com/cli).
 Verify installation:
 
 ```bash
-cursor --version
+agent --version
 ```
 
 ## Basic Usage
@@ -73,7 +73,7 @@ For advanced control:
 name = "my-cursor"
 plugin = "cursor"
 default = true
-command = "cursor"
+command = "agent"
 timeout = 300000
 
 [agents.options]
@@ -90,7 +90,7 @@ mode = "agent"
 | `force` | boolean | `true` | Auto-approve file modifications for autonomous operation |
 | `mode` | string | `"agent"` | Execution mode: `agent`, `plan`, or `ask` |
 | `timeout` | number | `0` | Execution timeout in ms (0 = no timeout) |
-| `command` | string | `"cursor"` | Path to Cursor CLI executable |
+| `command` | string | `"agent"` | Path to Cursor CLI executable |
 
 ## Execution Modes
 
@@ -143,7 +143,7 @@ Or toggle in TUI:
 
 When Ralph TUI executes a task with Cursor:
 
-1. **Build command**: Constructs `cursor [options]`
+1. **Build command**: Constructs `agent [options]`
 2. **Pass prompt via stdin**: Avoids shell escaping issues with special characters
 3. **Stream output**: Captures stdout/stderr in real-time
 4. **Parse JSONL**: Extracts structured tool call data (always enabled)
@@ -155,7 +155,7 @@ When Ralph TUI executes a task with Cursor:
 Ralph TUI builds these arguments:
 
 ```bash
-cursor \
+agent \
   --print \                        # Non-interactive output mode
   --force \                        # When force enabled (default)
   --output-format stream-json \    # Always used for structured output
@@ -171,8 +171,8 @@ cursor \
 Ensure Cursor is installed and in your PATH:
 
 ```bash
-which cursor
-# Should output: /path/to/cursor
+which agent
+# Should output: /path/to/agent
 
 # If not found, install from:
 # https://docs.cursor.com/cli


### PR DESCRIPTION
Previously the command for the Cursor CLI was set to `cursor`. However, the command according to the documentation is `agent` (https://cursor.com/docs/cli/headless). This PR changes the default command to the correct one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guide, README and plugin docs to use the Cursor agent’s "agent" CLI in examples and verification steps.

* **Tests**
  * Updated tests and mocks to expect the new default agent command and to preload real modules for more stable, isolated test runs.

* **Chores**
  * Minor build script tweak to ensure assets and skills are copied into the build output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->