### PR TITLE
fix: stop review shortcuts from interrupting chat input

### DIFF
--- a/src/tui/components/PrdChatApp.labels.test.ts
+++ b/src/tui/components/PrdChatApp.labels.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   buildBeadsLabelsInstruction,
   classifyPastePayload,
+  isReviewPhaseShortcut,
 } from './PrdChatApp.js';
 
 describe('buildBeadsLabelsInstruction', () => {
@@ -106,5 +107,20 @@ describe('classifyPastePayload', () => {
       intercept: true,
       suppressFallbackInsert: true,
     });
+  });
+});
+
+describe('isReviewPhaseShortcut', () => {
+  test('matches bare tracker shortcuts in review phase', () => {
+    expect(isReviewPhaseShortcut('review', '1')).toBe(true);
+    expect(isReviewPhaseShortcut('review', '3')).toBe(true);
+  });
+
+  test('does not treat in-progress answers like "3A" as shortcuts', () => {
+    expect(isReviewPhaseShortcut('review', '3A')).toBe(false);
+  });
+
+  test('does not run review shortcuts in chat phase', () => {
+    expect(isReviewPhaseShortcut('chat', '3')).toBe(false);
   });
 });

--- a/src/tui/components/PrdChatApp.tsx
+++ b/src/tui/components/PrdChatApp.tsx
@@ -638,11 +638,15 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
       if (isReviewPhaseShortcut(phase, userMessage)) {
         setInputValue('');
         if (userMessage === '1' || userMessage === '2') {
-          const option = trackerOptions.find(
-            (t) => t.key === userMessage && t.available,
-          );
-          if (option) {
+          const option = trackerOptions.find((t) => t.key === userMessage);
+          if (option?.available) {
             void handleTrackerSelect(option);
+          } else {
+            const errorMessage = option
+              ? `${option.name} is not available in this project.`
+              : `Tracker option ${userMessage} is not available.`;
+            setError(errorMessage);
+            onError?.(errorMessage);
           }
           return;
         }

--- a/src/tui/components/PrdChatApp.tsx
+++ b/src/tui/components/PrdChatApp.tsx
@@ -236,6 +236,22 @@ Add the --labels flag to every bd create / br create command.`;
 }
 
 /**
+ * Returns true when a submitted review-phase message should trigger a tracker action.
+ * @internal Exported for testing.
+ */
+export function isReviewPhaseShortcut(
+  phase: 'chat' | 'review',
+  trimmedMessage: string,
+): trimmedMessage is '1' | '2' | '3' {
+  return (
+    phase === 'review' &&
+    (trimmedMessage === '1' ||
+      trimmedMessage === '2' ||
+      trimmedMessage === '3')
+  );
+}
+
+/**
  * Classification result for pasted text.
  */
 export interface PasteClassification {
@@ -494,7 +510,7 @@ Would you like me to create tasks from this PRD?
 ${optionsText}
   [3] Done - I'll create tasks later
 
-Press a number key to select, or continue chatting.`,
+Send "1", "2", or "3" to choose an option, or continue chatting.`,
           timestamp: new Date(),
         };
         setMessages((prev) => [...prev, reviewMessage]);
@@ -581,7 +597,7 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
             const doneMsg: ChatMessage = {
               role: 'assistant',
               content:
-                'Tasks created! Press [3] to finish or select another format.',
+                'Tasks created! Send "3" to finish or select another format.',
               timestamp: new Date(),
             };
             setMessages((prev) => [...prev, doneMsg]);
@@ -616,6 +632,36 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
 
       // Use the message as-is (no zero-width markers to clean)
       const userMessage = rawMessage;
+
+      // In review phase, a bare "1", "2", or "3" is handled on submit, not keydown,
+      // so in-progress typing like "3A" is never swallowed mid-entry.
+      if (isReviewPhaseShortcut(phase, userMessage)) {
+        setInputValue('');
+        if (userMessage === '1' || userMessage === '2') {
+          const option = trackerOptions.find(
+            (t) => t.key === userMessage && t.available,
+          );
+          if (option) {
+            void handleTrackerSelect(option);
+          }
+          return;
+        }
+        // userMessage === '3' → Done
+        if (prdPath && featureName) {
+          void onComplete({
+            prdPath,
+            featureName,
+            selectedTracker: selectedTrackerFormat,
+          }).catch((err) => {
+            const errorMessage =
+              'Failed to complete PRD workflow: ' +
+              (err instanceof Error ? err.message : String(err));
+            setError(errorMessage);
+            onError?.(errorMessage);
+          });
+        }
+        return;
+      }
 
       // Check for slash commands first
       if (isSlashCommand(userMessage)) {
@@ -712,6 +758,14 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
       attachedImages,
       clearImages,
       toast,
+      phase,
+      trackerOptions,
+      handleTrackerSelect,
+      prdPath,
+      featureName,
+      selectedTrackerFormat,
+      onComplete,
+      onError,
     ],
   );
 
@@ -773,8 +827,8 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
   }, [onCancel, reportCallbackError]);
 
   /**
-   * Handle keyboard input (only for non-input keys like Escape and review phase shortcuts)
-   * Text editing is handled by the native OpenTUI input component
+   * Handle keyboard input for non-text shortcuts like paste fallback and Escape.
+   * Text editing is handled by the native OpenTUI input component.
    */
   const handleKeyboard = useCallback(
     (key: KeyEvent) => {
@@ -850,31 +904,6 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
         return;
       }
 
-      // In review phase, handle number keys for tracker selection
-      if (phase === 'review' && key.sequence) {
-        const keyNum = key.sequence;
-        if (keyNum === '1' || keyNum === '2') {
-          const option = trackerOptions.find(
-            (t) => t.key === keyNum && t.available,
-          );
-          if (option) {
-            void handleTrackerSelect(option);
-            return;
-          }
-        }
-        if (keyNum === '3') {
-          // Done - complete and exit
-          if (prdPath && featureName) {
-            void runOnComplete({
-              prdPath,
-              featureName,
-              selectedTracker: selectedTrackerFormat,
-            });
-          }
-          return;
-        }
-      }
-
       // Handle escape key
       if (key.name === 'escape') {
         if (phase === 'review' && prdPath && featureName) {
@@ -894,11 +923,9 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
       showQuitConfirm,
       isLoading,
       phase,
-      trackerOptions,
       performClipboardPasteFallback,
       runOnComplete,
       runOnCancel,
-      handleTrackerSelect,
       prdPath,
       featureName,
       selectedTrackerFormat,
@@ -1007,7 +1034,7 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
   // Determine hint text based on phase
   const hint =
     phase === 'review'
-      ? '[1] JSON  [2] Beads  [3] Done  [Enter] Chat  [Esc] Finish'
+      ? 'Send "1"/"2"/"3" for JSON / Beads / Done, or any other message to continue  [Enter] Send  [Esc] Finish'
       : '[Enter] Send  [Shift+Enter/Ctrl+J] Newline  [Esc] Cancel';
 
   // In review phase, show split pane


### PR DESCRIPTION
### Problem
In create-prd --chat, once the PRD enters review mode, the app still allows the user to keep chatting or choose a tracker action. Those review actions were wired to a global keydown handler: trying to type a normal reply starting with a digit, like "3A", would trigger a shortcut immediately and interrupt the session before the message was finished.

### Solution
Move review tracker actions from keydown to submit-time handling. Now users can type freely in review mode, and only _submitting_ a bare 1, 2, or 3 actually triggers JSON, Beads, or Done. Any other submitted message continues the conversation normally.

IMO a future cleanup should remove `3 = Done` entirely, since `Esc` already finishes the review flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review phase now accepts message-based shortcuts: send "1", "2" or "3" to select trackers or complete the review. Keyboard handling narrowed to non-text shortcuts.

* **Bug Fixes**
  * Improved handling when a chosen tracker isn’t available or completion fails: input is cleared and an error is surfaced.

* **Documentation**
  * Updated on-screen instructions and completion hints to reflect the new "send" interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->