### PR TITLE
Fix OpenCode Windows execution path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,29 @@ jobs:
       - name: Build
         run: bun run build
 
+  windows-smoke:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Build
+        run: bun run build
+
+      - name: Run Windows-focused agent tests
+        run: bun test src/plugins/agents/base.test.ts tests/plugins/opencode-agent.test.ts
+
   test:
     runs-on: ubuntu-latest
     needs: build

--- a/src/plugins/agents/base.test.ts
+++ b/src/plugins/agents/base.test.ts
@@ -22,6 +22,7 @@ import {
   findCommandPath,
   getEnvExclusionReport,
   formatEnvExclusionReport,
+  shouldUseWindowsShell,
 } from './base.js';
 import type {
   AgentPluginMeta,
@@ -172,6 +173,24 @@ describe('BaseAgentPlugin', () => {
 
       expect(result.found).toBe(false);
       expect(result.path).toBe('');
+    });
+  });
+
+  describe('shouldUseWindowsShell', () => {
+    test('returns false for native Windows executables', () => {
+      expect(shouldUseWindowsShell('C:\\Tools\\opencode.exe', 'win32')).toBe(false);
+      expect(shouldUseWindowsShell('"C:\\Program Files\\OpenCode\\opencode.exe"', 'win32')).toBe(false);
+    });
+
+    test('returns true for Windows wrapper scripts', () => {
+      expect(shouldUseWindowsShell('C:\\Tools\\opencode.cmd', 'win32')).toBe(true);
+      expect(shouldUseWindowsShell('C:\\Tools\\opencode.bat', 'win32')).toBe(true);
+      expect(shouldUseWindowsShell('C:\\Tools\\opencode.ps1', 'win32')).toBe(true);
+    });
+
+    test('returns false outside Windows', () => {
+      expect(shouldUseWindowsShell('/usr/local/bin/opencode', 'linux')).toBe(false);
+      expect(shouldUseWindowsShell('/usr/local/bin/opencode', 'darwin')).toBe(false);
     });
   });
 

--- a/src/plugins/agents/base.ts
+++ b/src/plugins/agents/base.ts
@@ -105,6 +105,39 @@ export function quoteForWindowsShell(commandPath: string): string {
   return `"${commandPath}"`;
 }
 
+/**
+ * Determine whether a Windows command needs shell execution.
+ * Native executables can be spawned directly, while wrapper scripts require the shell.
+ */
+export function shouldUseWindowsShell(
+  commandPath: string,
+  currentPlatform: NodeJS.Platform = platform()
+): boolean {
+  if (currentPlatform !== 'win32') {
+    return false;
+  }
+
+  const trimmedCommand = commandPath.trim();
+  const normalizedCommand = trimmedCommand.startsWith('"') && trimmedCommand.endsWith('"')
+    ? trimmedCommand.slice(1, -1)
+    : trimmedCommand;
+  const lowerCommand = normalizedCommand.toLowerCase();
+
+  if (lowerCommand.endsWith('.exe') || lowerCommand.endsWith('.com')) {
+    return false;
+  }
+
+  if (
+    lowerCommand.endsWith('.cmd') ||
+    lowerCommand.endsWith('.bat') ||
+    lowerCommand.endsWith('.ps1')
+  ) {
+    return true;
+  }
+
+  return true;
+}
+
 import { randomUUID } from 'node:crypto';
 import type {
   AgentPlugin,
@@ -492,11 +525,11 @@ export abstract class BaseAgentPlugin implements AgentPlugin {
     const commandPath = resolvedCommand.executablePath;
 
     return new Promise((resolve) => {
-      const isWindows = platform() === 'win32';
-      const spawnCmd = isWindows ? quoteForWindowsShell(commandPath) : commandPath;
+      const useShell = shouldUseWindowsShell(commandPath);
+      const spawnCmd = useShell ? quoteForWindowsShell(commandPath) : commandPath;
       const proc = spawn(spawnCmd, ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
-        shell: true,
+        shell: useShell,
       });
 
       let stdout = '';
@@ -630,16 +663,16 @@ export abstract class BaseAgentPlugin implements AgentPlugin {
 
     const startProcess = (spawnCommand: string, spawnArgs: string[]): void => {
       // Spawn the process
-      // Note: On Windows, we need shell: true to execute wrapper scripts (.cmd, .bat, .ps1)
-      // On Unix, shell: false avoids shell interpretation of special characters in args
+      // On Windows, only wrapper scripts need shell execution.
+      // Native executables can be spawned directly to avoid cmd.exe argument rewriting.
       // The prompt will be passed via stdin if getStdinInput returns content
-      const isWindows = platform() === 'win32';
-      const quotedCommand = isWindows ? quoteForWindowsShell(spawnCommand) : spawnCommand;
-      const proc = spawn(quotedCommand, spawnArgs, {
+      const useShell = shouldUseWindowsShell(spawnCommand);
+      const resolvedCommand = useShell ? quoteForWindowsShell(spawnCommand) : spawnCommand;
+      const proc = spawn(resolvedCommand, spawnArgs, {
         cwd: options?.cwd ?? process.cwd(),
         env,
         stdio: ['pipe', 'pipe', 'pipe'],
-        shell: isWindows,
+        shell: useShell,
       });
 
       // Write to stdin if subclass provides input (e.g., prompt content)

--- a/src/plugins/agents/base.ts
+++ b/src/plugins/agents/base.ts
@@ -111,7 +111,7 @@ export function quoteForWindowsShell(commandPath: string): string {
  */
 export function shouldUseWindowsShell(
   commandPath: string,
-  currentPlatform: NodeJS.Platform = platform()
+  currentPlatform: NodeJS.Platform = process.platform
 ): boolean {
   if (currentPlatform !== 'win32') {
     return false;

--- a/src/plugins/agents/builtin/opencode.ts
+++ b/src/plugins/agents/builtin/opencode.ts
@@ -6,7 +6,12 @@
  */
 
 import { spawn } from 'node:child_process';
-import { BaseAgentPlugin, findCommandPath, quoteForWindowsShell } from '../base.js';
+import {
+  BaseAgentPlugin,
+  findCommandPath,
+  quoteForWindowsShell,
+  shouldUseWindowsShell,
+} from '../base.js';
 import { processAgentEvents, processAgentEventsToSegments, type AgentDisplayEvent } from '../output-formatting.js';
 import type {
   AgentPluginMeta,
@@ -94,6 +99,17 @@ export function createOpenCodeJsonlBuffer(
       }
     },
   };
+}
+
+/**
+ * Determine when OpenCode prompts should be sent via stdin instead of argv.
+ * Only Windows shell wrappers need stdin; native executables can accept positional args safely.
+ */
+export function shouldPassOpenCodePromptViaStdin(
+  commandPath: string | undefined,
+  currentPlatform: NodeJS.Platform = process.platform
+): boolean {
+  return shouldUseWindowsShell(commandPath ?? 'opencode', currentPlatform);
 }
 
 /**
@@ -303,7 +319,7 @@ export class OpenCodeAgentPlugin extends BaseAgentPlugin {
     command: string
   ): Promise<{ success: boolean; version?: string; error?: string }> {
     return new Promise((resolve) => {
-      const useShell = process.platform === 'win32';
+      const useShell = shouldUseWindowsShell(command);
       const proc = spawn(useShell ? quoteForWindowsShell(command) : command, ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: useShell,
@@ -396,7 +412,7 @@ export class OpenCodeAgentPlugin extends BaseAgentPlugin {
   }
 
   protected buildArgs(
-    _prompt: string,
+    prompt: string,
     files?: AgentFileContext[],
     _options?: AgentExecuteOptions
   ): string[] {
@@ -431,9 +447,9 @@ export class OpenCodeAgentPlugin extends BaseAgentPlugin {
       }
     }
 
-    // NOTE: Prompt is NOT added here - it's passed via stdin to avoid
-    // shell interpretation of special characters on Windows where shell: true
-    // is required for wrapper script execution.
+    if (!shouldPassOpenCodePromptViaStdin(this.commandPath)) {
+      args.push(prompt);
+    }
 
     return args;
   }
@@ -447,8 +463,11 @@ export class OpenCodeAgentPlugin extends BaseAgentPlugin {
     prompt: string,
     _files?: AgentFileContext[],
     _options?: AgentExecuteOptions
-  ): string {
-    return prompt;
+  ): string | undefined {
+    if (shouldPassOpenCodePromptViaStdin(this.commandPath)) {
+      return prompt;
+    }
+    return undefined;
   }
 
   /**

--- a/tests/plugins/agents/runversion-shell.test.ts
+++ b/tests/plugins/agents/runversion-shell.test.ts
@@ -150,7 +150,7 @@ describe('runVersion conditional shell behavior (PR #187)', () => {
       await plugin.dispose();
     });
 
-    test('uses shell: true on Windows platform', async () => {
+    test('uses shell: false for native Windows executables', async () => {
       // Mock platform as win32
       Object.defineProperty(process, 'platform', {
         value: 'win32',
@@ -341,13 +341,36 @@ describe('runVersion conditional shell behavior (PR #187)', () => {
 
       expect(spawnCalls.length).toBe(2);
 
-      // Verify the runVersion call (second call) uses shell: true on Windows
+      // Native .exe binaries can be spawned directly without cmd.exe.
+      const runVersionCall = spawnCalls[1];
+      expect(runVersionCall.args).toContain('--version');
+      expect(runVersionCall.options?.shell).toBe(false);
+      expect(runVersionCall.cmd).toBe('C:\\Program Files\\opencode\\opencode.exe');
+
+      await plugin.dispose();
+    });
+
+    test('uses shell: true for Windows wrapper scripts', async () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+
+      spawnResponses = [
+        { stdout: 'C:\\Program Files\\opencode\\opencode.cmd', exitCode: 0 },
+        { stdout: 'opencode 0.5.2', exitCode: 0 },
+      ];
+
+      const plugin = new OpenCodeAgentPlugin();
+      await plugin.initialize({});
+
+      await plugin.detect();
+
+      expect(spawnCalls.length).toBe(2);
       const runVersionCall = spawnCalls[1];
       expect(runVersionCall.args).toContain('--version');
       expect(runVersionCall.options?.shell).toBe(true);
-
-      // Verify path with spaces is quoted for Windows shell (issue #206)
-      expect(runVersionCall.cmd).toBe('"C:\\Program Files\\opencode\\opencode.exe"');
+      expect(runVersionCall.cmd).toBe('"C:\\Program Files\\opencode\\opencode.cmd"');
 
       await plugin.dispose();
     });

--- a/tests/plugins/opencode-agent.test.ts
+++ b/tests/plugins/opencode-agent.test.ts
@@ -9,6 +9,7 @@ import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:
 import {
   OpenCodeAgentPlugin,
   createOpenCodeJsonlBuffer,
+  shouldPassOpenCodePromptViaStdin,
 } from '../../src/plugins/agents/builtin/opencode.js';
 import type { AgentFileContext, AgentExecuteOptions, AgentExecutionResult } from '../../src/plugins/agents/types.js';
 
@@ -328,7 +329,22 @@ describe('OpenCodeAgentPlugin', () => {
     });
   });
 
-  describe('buildArgs (stdin input for Windows safety)', () => {
+  describe('shouldPassOpenCodePromptViaStdin', () => {
+    test('returns false for native Windows executables', () => {
+      expect(shouldPassOpenCodePromptViaStdin('C:\\Tools\\opencode.exe', 'win32')).toBe(false);
+    });
+
+    test('returns true for Windows shell wrappers', () => {
+      expect(shouldPassOpenCodePromptViaStdin('C:\\Tools\\opencode.cmd', 'win32')).toBe(true);
+      expect(shouldPassOpenCodePromptViaStdin('C:\\Tools\\opencode.bat', 'win32')).toBe(true);
+    });
+
+    test('returns false on non-Windows platforms', () => {
+      expect(shouldPassOpenCodePromptViaStdin('/usr/local/bin/opencode', 'linux')).toBe(false);
+    });
+  });
+
+  describe('buildArgs (prompt transport)', () => {
     let testablePlugin: TestableOpenCodePlugin;
 
     beforeEach(async () => {
@@ -340,30 +356,33 @@ describe('OpenCodeAgentPlugin', () => {
       await testablePlugin.dispose();
     });
 
-    test('does NOT include prompt in args (passed via stdin instead)', () => {
+    test('matches the current-platform prompt transport strategy', () => {
       const prompt = 'Hello world';
       const args = testablePlugin.testBuildArgs(prompt);
 
-      // The prompt should NOT be in args - it's passed via stdin
-      expect(args).not.toContain(prompt);
-      // Should still have basic args
+      if (shouldPassOpenCodePromptViaStdin(undefined)) {
+        expect(args).not.toContain(prompt);
+      } else {
+        expect(args).toContain(prompt);
+      }
       expect(args).toContain('run');
       expect(args).toContain('--format');
       expect(args).toContain('json');
     });
 
-    test('does NOT include prompt with special characters in args', () => {
-      // These characters would cause "syntax error" on Windows cmd.exe
+    test('keeps special characters out of argv only when stdin transport is active', () => {
       const prompt = 'feature with & special | characters > test "quoted"';
       const args = testablePlugin.testBuildArgs(prompt);
 
-      // The prompt with special chars should NOT be in args
-      expect(args).not.toContain(prompt);
-      // None of the special chars should appear in any arg
-      for (const arg of args) {
-        expect(arg).not.toContain('&');
-        expect(arg).not.toContain('|');
-        expect(arg).not.toContain('>');
+      if (shouldPassOpenCodePromptViaStdin(undefined)) {
+        expect(args).not.toContain(prompt);
+        for (const arg of args) {
+          expect(arg).not.toContain('&');
+          expect(arg).not.toContain('|');
+          expect(arg).not.toContain('>');
+        }
+      } else {
+        expect(args).toContain(prompt);
       }
     });
 
@@ -406,35 +425,49 @@ describe('OpenCodeAgentPlugin', () => {
       await testablePlugin.dispose();
     });
 
-    test('returns the prompt for stdin', () => {
+    test('matches the current-platform prompt transport strategy', () => {
       const prompt = 'Hello world';
       const stdinInput = testablePlugin.testGetStdinInput(prompt);
 
-      expect(stdinInput).toBe(prompt);
+      if (shouldPassOpenCodePromptViaStdin(undefined)) {
+        expect(stdinInput).toBe(prompt);
+      } else {
+        expect(stdinInput).toBeUndefined();
+      }
     });
 
-    test('returns prompt with special characters unchanged', () => {
-      // These characters would cause issues if passed as CLI args on Windows
+    test('returns special-character prompts only when stdin transport is active', () => {
       const prompt = 'feature with & special | characters > test "quoted"';
       const stdinInput = testablePlugin.testGetStdinInput(prompt);
 
-      // Stdin should contain the prompt exactly as-is (no escaping needed)
-      expect(stdinInput).toBe(prompt);
+      if (shouldPassOpenCodePromptViaStdin(undefined)) {
+        expect(stdinInput).toBe(prompt);
+      } else {
+        expect(stdinInput).toBeUndefined();
+      }
     });
 
-    test('returns prompt with newlines', () => {
+    test('returns multiline prompts only when stdin transport is active', () => {
       const prompt = 'Line 1\nLine 2\nLine 3';
       const stdinInput = testablePlugin.testGetStdinInput(prompt);
 
-      expect(stdinInput).toBe(prompt);
-      expect(stdinInput).toContain('\n');
+      if (shouldPassOpenCodePromptViaStdin(undefined)) {
+        expect(stdinInput).toBe(prompt);
+        expect(stdinInput).toContain('\n');
+      } else {
+        expect(stdinInput).toBeUndefined();
+      }
     });
 
-    test('returns prompt with unicode characters', () => {
+    test('returns unicode prompts only when stdin transport is active', () => {
       const prompt = 'Hello 世界 🎉 émojis';
       const stdinInput = testablePlugin.testGetStdinInput(prompt);
 
-      expect(stdinInput).toBe(prompt);
+      if (shouldPassOpenCodePromptViaStdin(undefined)) {
+        expect(stdinInput).toBe(prompt);
+      } else {
+        expect(stdinInput).toBeUndefined();
+      }
     });
   });
 


### PR DESCRIPTION
This fixes the Windows OpenCode execution path behind #371 by avoiding `cmd.exe` for native executables and only using stdin prompt transport for shell wrappers. It also adds focused tests for shell selection and OpenCode prompt transport. Finally, it adds a `windows-smoke` GitHub Actions job to typecheck, build, and run the Windows-focused agent tests on `windows-latest`. Local validation: `bun test src/plugins/agents/base.test.ts`, `bun test tests/plugins/opencode-agent.test.ts`, and `bun run typecheck && bun run build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Windows process execution: native executables spawn directly (no unnecessary shell), while wrapper scripts use the shell when required—leading to more reliable command launches on Windows.
  * OpenCode plugin adjusted to pass prompts via stdin when needed for Windows wrapper scripts.

* **Tests**
  * Expanded unit and integration tests covering Windows executable vs wrapper behaviour and prompt delivery.

* **Chores**
  * Added a Windows smoke test job to CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->