### PR TITLE
[codex] Fix shared skill install detection

### DIFF
--- a/src/commands/create-prd-utils.ts
+++ b/src/commands/create-prd-utils.ts
@@ -7,6 +7,7 @@ import { constants } from "node:fs";
 import { access, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { AgentPlugin } from "../plugins/agents/types.js";
+import { getSkillSearchPaths } from "../setup/skill-installer.js";
 
 /**
  * Command-line arguments for the create-prd command.
@@ -150,10 +151,10 @@ export async function loadBundledPrdSkill(
 ): Promise<string | undefined> {
   const skillsPaths = agent.meta.skillsPaths;
   if (!skillsPaths) return undefined;
+  const searchPaths = getSkillSearchPaths(skillsPaths, process.cwd(), agent.meta.id);
 
-  if (skillsPaths.personal) {
-    const personalPath = skillsPaths.personal.replace(/^~/, process.env.HOME || "");
-    const skillFile = join(personalPath, "ralph-tui-prd", "SKILL.md");
+  for (const dir of [...searchPaths.personal, ...searchPaths.repo]) {
+    const skillFile = join(dir, "ralph-tui-prd", "SKILL.md");
     try {
       await access(skillFile, constants.R_OK);
       const content = await readFile(skillFile, "utf-8");
@@ -161,25 +162,7 @@ export async function loadBundledPrdSkill(
         return content;
       }
     } catch {
-      // Not found in personal, try repo.
-    }
-  }
-
-  if (skillsPaths.repo) {
-    const skillFile = join(
-      process.cwd(),
-      skillsPaths.repo,
-      "ralph-tui-prd",
-      "SKILL.md",
-    );
-    try {
-      await access(skillFile, constants.R_OK);
-      const content = await readFile(skillFile, "utf-8");
-      if (content.trim()) {
-        return content;
-      }
-    } catch {
-      // Not found.
+      // Try the next discovery path.
     }
   }
 

--- a/src/commands/info.test.ts
+++ b/src/commands/info.test.ts
@@ -57,8 +57,8 @@ describe('formatSystemInfo', () => {
           id: 'claude',
           name: 'Claude Code',
           available: true,
-          personalDir: '/home/user/.claude/skills',
-          repoDir: '.claude/skills',
+          personalDir: ['/home/user/.claude/skills'],
+          repoDir: ['.claude/skills'],
           personalSkills: ['ralph-tui-prd'],
         },
       ],
@@ -123,6 +123,23 @@ describe('formatSystemInfo', () => {
     expect(output).toContain('Claude Code:');
     expect(output).toContain('Path: /home/user/.claude/skills');
     expect(output).toContain('Installed: ralph-tui-prd');
+  });
+
+  test('joins multiple discovery paths only for display', () => {
+    const output = formatSystemInfo({
+      ...mockInfo,
+      skills: {
+        ...mockInfo.skills,
+        agents: [
+          {
+            ...mockInfo.skills.agents[0],
+            personalDir: ['/home/user/.agents/skills', '/home/user/.codex/skills'],
+          },
+        ],
+      },
+    });
+
+    expect(output).toContain('Paths: /home/user/.agents/skills, /home/user/.codex/skills');
   });
 
   test('shows no project config when missing', () => {
@@ -276,8 +293,8 @@ describe('formatForBugReport', () => {
           id: 'claude',
           name: 'Claude Code',
           available: true,
-          personalDir: '/home/user/.claude/skills',
-          repoDir: '.claude/skills',
+          personalDir: ['/home/user/.claude/skills'],
+          repoDir: ['.claude/skills'],
           personalSkills: ['ralph-tui-prd'],
         },
       ],

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -64,10 +64,10 @@ export interface AgentSkillsInfo {
   name: string;
   /** Whether the agent is available/detected */
   available: boolean;
-  /** Personal skills directory path */
-  personalDir: string;
-  /** Repo skills directory pattern */
-  repoDir: string;
+  /** Personal skills discovery directories */
+  personalDir: string[];
+  /** Repo skills discovery directories */
+  repoDir: string[];
   /** Skills installed in personal directory */
   personalSkills: string[];
 }
@@ -248,8 +248,8 @@ async function collectSkillsInfo(
       id: meta.id,
       name: meta.name,
       available,
-      personalDir: searchPaths.personal.join(', '),
-      repoDir: searchPaths.repo.join(', '),
+      personalDir: searchPaths.personal,
+      repoDir: searchPaths.repo,
       personalSkills,
     });
   }
@@ -445,7 +445,7 @@ export function formatSystemInfo(info: SystemInfo): string {
   for (const agent of info.skills.agents) {
     const status = agent.available ? '' : ' (not detected)';
     lines.push(`  ${agent.name}${status}:`);
-    lines.push(`    Path: ${agent.personalDir}`);
+    lines.push(`    Path${agent.personalDir.length === 1 ? '' : 's'}: ${agent.personalDir.join(', ')}`);
     lines.push(`    Installed: ${agent.personalSkills.length > 0 ? agent.personalSkills.join(', ') : '(none)'}`);
   }
 

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -14,7 +14,7 @@ import { getAgentRegistry } from '../plugins/agents/registry.js';
 import { registerBuiltinAgents } from '../plugins/agents/builtin/index.js';
 import { registerBuiltinTrackers } from '../plugins/trackers/builtin/index.js';
 import { getUserConfigDir } from '../templates/engine.js';
-import { listBundledSkills, resolveSkillsPath } from '../setup/skill-installer.js';
+import { getSkillSearchPaths, listBundledSkills, resolveSkillsPath } from '../setup/skill-installer.js';
 import { getEnvExclusionReport, formatEnvExclusionReport, type EnvExclusionReport } from '../plugins/agents/base.js';
 
 /**
@@ -181,6 +181,22 @@ async function listSkillsInDir(skillsDir: string): Promise<string[]> {
 }
 
 /**
+ * List installed skills across multiple candidate directories.
+ */
+async function listSkillsInDirs(skillsDirs: string[]): Promise<string[]> {
+  const installed = new Set<string>();
+
+  for (const skillsDir of skillsDirs) {
+    const skills = await listSkillsInDir(skillsDir);
+    for (const skill of skills) {
+      installed.add(skill);
+    }
+  }
+
+  return [...installed].sort();
+}
+
+/**
  * Collect skills information from all sources.
  */
 async function collectSkillsInfo(
@@ -225,15 +241,15 @@ async function collectSkillsInfo(
     }
 
     // Get installed skills in personal directory
-    const personalDir = resolveSkillsPath(meta.skillsPaths.personal);
-    const personalSkills = await listSkillsInDir(personalDir);
+    const searchPaths = getSkillSearchPaths(meta.skillsPaths, cwd, meta.id);
+    const personalSkills = await listSkillsInDirs(searchPaths.personal);
 
     agents.push({
       id: meta.id,
       name: meta.name,
       available,
-      personalDir,
-      repoDir: meta.skillsPaths.repo,
+      personalDir: searchPaths.personal.join(', '),
+      repoDir: searchPaths.repo.join(', '),
       personalSkills,
     });
   }

--- a/src/commands/skills-install.test.ts
+++ b/src/commands/skills-install.test.ts
@@ -59,7 +59,9 @@ describe('skills install command (spawn)', () => {
     mock.module('../setup/skill-installer.js', () => ({
       listBundledSkills: realSkillInstaller.listBundledSkills,
       isSkillInstalledAt: realSkillInstaller.isSkillInstalledAt,
+      isSkillInstalledAtAnyPath: realSkillInstaller.isSkillInstalledAtAnyPath,
       resolveSkillsPath: realSkillInstaller.resolveSkillsPath,
+      getSkillSearchPaths: realSkillInstaller.getSkillSearchPaths,
       installViaAddSkill: realSkillInstaller.installViaAddSkill,
       resolveAddSkillAgentId: realSkillInstaller.resolveAddSkillAgentId,
       buildAddSkillInstallArgs: realSkillInstaller.buildAddSkillInstallArgs,

--- a/src/commands/skills.test.ts
+++ b/src/commands/skills.test.ts
@@ -31,7 +31,9 @@ beforeAll(async () => {
   mock.module('../setup/skill-installer.js', () => ({
     listBundledSkills: realSkillInstaller.listBundledSkills,
     isSkillInstalledAt: realSkillInstaller.isSkillInstalledAt,
+    isSkillInstalledAtAnyPath: realSkillInstaller.isSkillInstalledAtAnyPath,
     resolveSkillsPath: realSkillInstaller.resolveSkillsPath,
+    getSkillSearchPaths: realSkillInstaller.getSkillSearchPaths,
     installViaAddSkill: realSkillInstaller.installViaAddSkill,
     resolveAddSkillAgentId: realSkillInstaller.resolveAddSkillAgentId,
     buildAddSkillInstallArgs: realSkillInstaller.buildAddSkillInstallArgs,

--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -6,8 +6,8 @@
 
 import { spawn } from 'node:child_process';
 import {
+  getSkillSearchPaths,
   listBundledSkills,
-  resolveSkillsPath,
   getSkillStatusForAgent,
   AGENT_ID_MAP,
   resolveAddSkillAgentId,
@@ -33,6 +33,11 @@ interface SkillCapableAgent {
   meta: AgentPluginMeta;
   available: boolean;
   skillsPaths: AgentSkillsPaths;
+}
+
+interface VerifiedInstallSummary {
+  skillCount: number;
+  agentNames: string[];
 }
 
 /**
@@ -74,6 +79,55 @@ async function getSkillCapableAgents(): Promise<SkillCapableAgent[]> {
   }
 
   return agents;
+}
+
+/**
+ * Format one or more discovery paths for display.
+ */
+function formatSkillPaths(paths: string[]): string {
+  return paths.join(', ');
+}
+
+/**
+ * Verify install results against the actual agent discovery paths we support.
+ * This is used as a fallback when the upstream skills CLI output is not parseable.
+ */
+async function verifyInstalledSkills(options: {
+  skillName: string | null;
+  agentId: string | null;
+  local: boolean;
+}, agents: SkillCapableAgent[]): Promise<VerifiedInstallSummary | null> {
+  const targetAgents = options.agentId
+    ? agents.filter((agent) => agent.available && agent.meta.id === options.agentId)
+    : agents.filter((agent) => agent.available);
+
+  if (targetAgents.length === 0) {
+    return null;
+  }
+
+  const skillNames = options.skillName
+    ? [options.skillName]
+    : (await listBundledSkills()).map((skill) => skill.name);
+
+  const agentNames: string[] = [];
+  for (const agent of targetAgents) {
+    const status = await getSkillStatusForAgent(agent.skillsPaths, process.cwd(), agent.meta.id);
+    const installedInRequestedScope = skillNames.every((skillName) => {
+      const skillStatus = status.get(skillName);
+      return options.local
+        ? skillStatus?.repo === true
+        : skillStatus?.personal === true;
+    });
+
+    if (installedInRequestedScope) {
+      agentNames.push(agent.meta.name);
+    }
+  }
+
+  return {
+    skillCount: skillNames.length,
+    agentNames,
+  };
 }
 
 /**
@@ -181,12 +235,13 @@ async function handleListSkills(): Promise<void> {
   for (const agent of agents) {
     const statusIcon = agent.available ? `${GREEN}✓${RESET}` : `${DIM}○${RESET}`;
     const availableText = agent.available ? '' : ` ${DIM}(not installed)${RESET}`;
+    const searchPaths = getSkillSearchPaths(agent.skillsPaths, cwd, agent.meta.id);
     console.log(`${statusIcon} ${BOLD}${agent.meta.name}${RESET}${availableText}`);
-    console.log(`  ${DIM}Global: ${resolveSkillsPath(agent.skillsPaths.personal)}${RESET}`);
-    console.log(`  ${DIM}Local:  ${resolveSkillsPath(agent.skillsPaths.repo, cwd)}${RESET}`);
+    console.log(`  ${DIM}Global: ${formatSkillPaths(searchPaths.personal)}${RESET}`);
+    console.log(`  ${DIM}Local:  ${formatSkillPaths(searchPaths.repo)}${RESET}`);
 
     if (agent.available) {
-      const status = await getSkillStatusForAgent(agent.skillsPaths, cwd);
+      const status = await getSkillStatusForAgent(agent.skillsPaths, cwd, agent.meta.id);
       for (const skill of skills) {
         const skillStatus = status.get(skill.name);
         const globalInstalled = skillStatus?.personal ?? false;
@@ -401,11 +456,29 @@ async function handleInstallSkills(args: string[]): Promise<void> {
   }
 
   const result = parseAddSkillOutput(output);
+  const agents = result.installed && result.agentCount === 0
+    ? await getSkillCapableAgents()
+    : [];
+  const verifiedResult = agents.length > 0
+    ? await verifyInstalledSkills(options, agents)
+    : null;
 
   if (result.installed) {
-    console.log(`${GREEN}✓${RESET} ${BOLD}Installed ${result.skillCount} skill${result.skillCount !== 1 ? 's' : ''} to ${result.agentCount} agent${result.agentCount !== 1 ? 's' : ''}${RESET}`);
-    if (result.agents.length > 0) {
-      console.log(`  ${DIM}Agents: ${result.agents.join(', ')}${RESET}`);
+    const summary = verifiedResult && verifiedResult.agentNames.length > 0
+      ? {
+          skillCount: verifiedResult.skillCount,
+          agentCount: verifiedResult.agentNames.length,
+          agents: verifiedResult.agentNames,
+        }
+      : {
+          skillCount: result.skillCount,
+          agentCount: result.agentCount,
+          agents: result.agents,
+        };
+
+    console.log(`${GREEN}✓${RESET} ${BOLD}Installed ${summary.skillCount} skill${summary.skillCount !== 1 ? 's' : ''} to ${summary.agentCount} agent${summary.agentCount !== 1 ? 's' : ''}${RESET}`);
+    if (summary.agents.length > 0) {
+      console.log(`  ${DIM}Agents: ${summary.agents.join(', ')}${RESET}`);
     }
     if (result.eloopOnly) {
       console.log(`  ${DIM}(Some agents share skill directories via symlinks — skills already accessible)${RESET}`);

--- a/src/setup/skill-installer.test.ts
+++ b/src/setup/skill-installer.test.ts
@@ -15,7 +15,7 @@ import {
   beforeEach,
   afterEach,
 } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -31,6 +31,9 @@ const {
   computeSkillsPath,
   expandTilde,
   resolveSkillsPath,
+  getSkillSearchPaths,
+  getSkillStatusForAgent,
+  isSkillInstalledAtAnyPath,
   AGENT_ID_MAP,
   resolveAddSkillAgentId,
   buildAddSkillInstallArgs,
@@ -262,6 +265,84 @@ describe('isSkillInstalledAt', () => {
   });
 });
 
+describe('isSkillInstalledAtAnyPath', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'ralph-tui-skill-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('returns true when skill exists in any candidate directory', async () => {
+    const sharedDir = join(tempDir, '.agents', 'skills', 'ralph-tui-prd');
+    await mkdir(sharedDir, { recursive: true });
+
+    const result = await isSkillInstalledAtAnyPath('ralph-tui-prd', [
+      join(tempDir, '.codex', 'skills'),
+      join(tempDir, '.agents', 'skills'),
+    ]);
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('getSkillSearchPaths', () => {
+  test('adds shared .agents aliases for codex', () => {
+    const result = getSkillSearchPaths(
+      { personal: '~/.codex/skills', repo: '.codex/skills' },
+      '/tmp/project',
+      'codex'
+    );
+
+    expect(result.personal).toEqual([
+      join(homedir(), '.agents/skills'),
+      join(homedir(), '.codex/skills'),
+    ]);
+    expect(result.repo).toEqual([
+      '/tmp/project/.agents/skills',
+      '/tmp/project/.codex/skills',
+    ]);
+  });
+
+  test('keeps native-only paths for claude', () => {
+    const result = getSkillSearchPaths(
+      { personal: '~/.claude/skills', repo: '.claude/skills' },
+      '/tmp/project',
+      'claude'
+    );
+
+    expect(result.personal).toEqual([join(homedir(), '.claude/skills')]);
+    expect(result.repo).toEqual(['/tmp/project/.claude/skills']);
+  });
+});
+
+describe('getSkillStatusForAgent', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'ralph-tui-skill-status-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('detects repo-installed skills in shared .agents alias paths', async () => {
+    await mkdir(join(tempDir, '.agents', 'skills', 'ralph-tui-prd'), { recursive: true });
+
+    const status = await getSkillStatusForAgent(
+      { personal: '~/.codex/skills', repo: '.codex/skills' },
+      tempDir,
+      'codex'
+    );
+
+    expect(status.get('ralph-tui-prd')?.repo).toBe(true);
+  });
+});
+
 describe('AGENT_ID_MAP', () => {
   test('maps claude to claude-code', () => {
     expect(AGENT_ID_MAP['claude']).toBe('claude-code');
@@ -275,8 +356,8 @@ describe('AGENT_ID_MAP', () => {
     expect(AGENT_ID_MAP['codex']).toBe('codex');
   });
 
-  test('maps gemini to gemini', () => {
-    expect(AGENT_ID_MAP['gemini']).toBe('gemini');
+  test('maps gemini to gemini-cli', () => {
+    expect(AGENT_ID_MAP['gemini']).toBe('gemini-cli');
   });
 
   test('maps kiro to kiro-cli', () => {

--- a/src/setup/skill-installer.test.ts
+++ b/src/setup/skill-installer.test.ts
@@ -188,6 +188,18 @@ describe('expandTilde', () => {
     const result = expandTilde('.claude/skills');
     expect(result).toBe('.claude/skills');
   });
+
+  test('uses runtime HOME overrides when expanding paths', () => {
+    const originalHome = process.env.HOME;
+    process.env.HOME = '/tmp/ralph-test-home';
+
+    try {
+      const result = expandTilde('~/.claude/skills');
+      expect(result).toBe('/tmp/ralph-test-home/.claude/skills');
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
 });
 
 describe('resolveSkillsPath', () => {

--- a/src/setup/skill-installer.ts
+++ b/src/setup/skill-installer.ts
@@ -17,13 +17,26 @@ export const AGENT_ID_MAP: Record<string, string> = {
   claude: 'claude-code',
   opencode: 'opencode',
   codex: 'codex',
-  gemini: 'gemini',
+  gemini: 'gemini-cli',
   kimi: 'kimi-cli',
   kiro: 'kiro-cli',
   cursor: 'cursor',
   'github-copilot': 'github-copilot',
   pi: 'pi',
 };
+
+/**
+ * Agents whose skills are also discovered from the shared .agents/skills locations.
+ * These aliases are used by the current upstream skills CLI during install/sync flows.
+ */
+const SHARED_SKILLS_AGENT_IDS = new Set([
+  'codex',
+  'cursor',
+  'gemini',
+  'github-copilot',
+  'kimi',
+  'opencode',
+]);
 
 /**
  * Information about an available skill.
@@ -90,6 +103,31 @@ export function resolveSkillsPath(skillsPath: string, cwd?: string): string {
     return join(cwd, skillsPath);
   }
   return join(process.cwd(), skillsPath);
+}
+
+/**
+ * Resolve every skills discovery path for an agent, including shared aliases.
+ * Shared aliases are checked first because upstream skills tooling gives them precedence.
+ */
+export function getSkillSearchPaths(
+  skillsPaths: { personal: string; repo: string },
+  cwd?: string,
+  agentId?: string
+): { personal: string[]; repo: string[] } {
+  const personalPaths = [
+    ...(agentId && SHARED_SKILLS_AGENT_IDS.has(agentId) ? ['~/.agents/skills'] : []),
+    skillsPaths.personal,
+  ].map((path) => resolveSkillsPath(path));
+
+  const repoPaths = [
+    ...(agentId && SHARED_SKILLS_AGENT_IDS.has(agentId) ? ['.agents/skills'] : []),
+    skillsPaths.repo,
+  ].map((path) => resolveSkillsPath(path, cwd));
+
+  return {
+    personal: [...new Set(personalPaths)],
+    repo: [...new Set(repoPaths)],
+  };
 }
 
 /**
@@ -181,6 +219,18 @@ export async function isSkillInstalledAt(skillName: string, targetDir: string): 
   } catch {
     return false;
   }
+}
+
+/**
+ * Check if a skill is installed in any of the given directories.
+ */
+export async function isSkillInstalledAtAnyPath(skillName: string, targetDirs: string[]): Promise<boolean> {
+  for (const targetDir of targetDirs) {
+    if (await isSkillInstalledAt(skillName, targetDir)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -286,17 +336,16 @@ export async function installViaAddSkill(options: AddSkillInstallOptions): Promi
  */
 export async function getSkillStatusForAgent(
   skillsPaths: { personal: string; repo: string },
-  cwd?: string
+  cwd?: string,
+  agentId?: string
 ): Promise<Map<string, { personal: boolean; repo: boolean }>> {
   const status = new Map<string, { personal: boolean; repo: boolean }>();
   const bundledSkills = await listBundledSkills();
-
-  const personalDir = resolveSkillsPath(skillsPaths.personal);
-  const repoDir = resolveSkillsPath(skillsPaths.repo, cwd);
+  const searchPaths = getSkillSearchPaths(skillsPaths, cwd, agentId);
 
   for (const skill of bundledSkills) {
-    const personalInstalled = await isSkillInstalledAt(skill.name, personalDir);
-    const repoInstalled = await isSkillInstalledAt(skill.name, repoDir);
+    const personalInstalled = await isSkillInstalledAtAnyPath(skill.name, searchPaths.personal);
+    const repoInstalled = await isSkillInstalledAtAnyPath(skill.name, searchPaths.repo);
     status.set(skill.name, { personal: personalInstalled, repo: repoInstalled });
   }
 

--- a/src/setup/skill-installer.ts
+++ b/src/setup/skill-installer.ts
@@ -71,12 +71,19 @@ export interface AddSkillInstallOptions {
  * Supports both POSIX (~/) and Windows (~\) style paths.
  */
 export function expandTilde(path: string): string {
+  const runtimeHome =
+    process.env.HOME ||
+    process.env.USERPROFILE ||
+    (process.env.HOMEDRIVE && process.env.HOMEPATH
+      ? join(process.env.HOMEDRIVE, process.env.HOMEPATH)
+      : homedir());
+
   // Handle ~/ (POSIX) and ~\ (Windows)
   if (path.startsWith('~/') || path.startsWith('~\\')) {
-    return join(homedir(), path.slice(2));
+    return join(runtimeHome, path.slice(2));
   }
   if (path === '~') {
-    return homedir();
+    return runtimeHome;
   }
   return path;
 }

--- a/src/setup/wizard.test.ts
+++ b/src/setup/wizard.test.ts
@@ -600,6 +600,25 @@ describe('wizard output messages', () => {
     expect(output).toContain('Failed');
     expect(output).toContain('ENOENT');
   });
+
+  test('describes skill discovery paths without implying install targets', async () => {
+    mockBundledSkills = [
+      { name: 'ralph-tui-prd', description: 'PRD generator', path: '/skills/ralph-tui-prd' },
+    ];
+
+    mockPromptSelect = (prompt) => {
+      if (prompt.includes('tracker')) return Promise.resolve('json');
+      if (prompt.includes('agent')) return Promise.resolve('gemini');
+      return Promise.resolve('');
+    };
+    mockPromptBoolean = () => Promise.resolve(false);
+
+    await runSetupWizard({ cwd: tempDir });
+
+    const output = capturedOutput.join('\n');
+    expect(output).toContain('Checking for already installed skills in:');
+    expect(output).not.toContain('Skills will be installed to:');
+  });
 });
 
 describe('tracker detection and unavailability', () => {

--- a/src/setup/wizard.test.ts
+++ b/src/setup/wizard.test.ts
@@ -118,7 +118,12 @@ describe('wizard', () => {
     mock.module('./skill-installer.js', () => ({
       listBundledSkills: () => Promise.resolve(mockBundledSkills),
       isSkillInstalledAt: () => Promise.resolve(false),
+      isSkillInstalledAtAnyPath: () => Promise.resolve(false),
       resolveSkillsPath: (p: string) => p.replace(/^~/, '/home/test'),
+      getSkillSearchPaths: (skillsPaths: { personal: string; repo: string }, cwd?: string) => ({
+        personal: [skillsPaths.personal.replace(/^~/, '/home/test')],
+        repo: [cwd ? `${cwd}/${skillsPaths.repo}` : skillsPaths.repo],
+      }),
       installViaAddSkill: () => Promise.resolve(mockInstallViaAddSkillResult),
       resolveAddSkillAgentId: (id: string) => (id === 'claude' ? 'claude-code' : id),
       buildAddSkillInstallArgs: () => [],

--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -429,7 +429,7 @@ export async function runSetupWizard(
         const searchPaths = getSkillSearchPaths(skillsPaths, cwd, selectedAgent);
         const personalDir = searchPaths.personal.join(', ');
         printInfo('Ralph TUI includes AI skills that enhance agent capabilities.');
-        printInfo(`Skills will be installed to: ${personalDir}`);
+        printInfo(`Checking for already installed skills in: ${personalDir}`);
         console.log();
 
         for (const skill of bundledSkills) {

--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -30,9 +30,9 @@ import {
   isInteractiveTerminal,
 } from './prompts.js';
 import {
+  getSkillSearchPaths,
   listBundledSkills,
-  isSkillInstalledAt,
-  resolveSkillsPath,
+  isSkillInstalledAtAnyPath,
   installViaAddSkill,
 } from './skill-installer.js';
 import { CURRENT_CONFIG_VERSION } from './migration.js';
@@ -426,13 +426,14 @@ export async function runSetupWizard(
       const bundledSkills = await listBundledSkills();
 
       if (bundledSkills.length > 0) {
-        const personalDir = resolveSkillsPath(skillsPaths.personal);
+        const searchPaths = getSkillSearchPaths(skillsPaths, cwd, selectedAgent);
+        const personalDir = searchPaths.personal.join(', ');
         printInfo('Ralph TUI includes AI skills that enhance agent capabilities.');
         printInfo(`Skills will be installed to: ${personalDir}`);
         console.log();
 
         for (const skill of bundledSkills) {
-          const alreadyInstalled = await isSkillInstalledAt(skill.name, personalDir);
+          const alreadyInstalled = await isSkillInstalledAtAnyPath(skill.name, searchPaths.personal);
           const actionLabel = alreadyInstalled ? 'Update' : 'Install';
 
           const installThisSkill = await promptBoolean(

--- a/tests/commands/info.test.ts
+++ b/tests/commands/info.test.ts
@@ -98,6 +98,18 @@ describe('collectSystemInfo', () => {
     expect(Array.isArray(info.skills.agents)).toBe(true)
   })
 
+  test('keeps agent skill discovery paths machine-readable in JSON output', async () => {
+    await writeConfig(tempDir, {
+      agent: 'claude',
+    })
+
+    const info = await collectSystemInfo(tempDir)
+    const claudeSkills = info.skills.agents.find((agent) => agent.id === 'claude')
+
+    expect(Array.isArray(claudeSkills?.personalDir)).toBe(true)
+    expect(Array.isArray(claudeSkills?.repoDir)).toBe(true)
+  })
+
   test('collects custom skills from symlinked skill directories', async () => {
     const customSkillsDir = join(tempDir, 'custom-skills')
     const realSkillDir = join(tempDir, 'real-skills', 'ralph-tui-prd')


### PR DESCRIPTION
## Summary
This updates Ralph TUI's skills integration to account for the shared `.agents/skills` discovery paths now used by the upstream `skills` CLI for Codex, Gemini, and similar agents.
It fixes false "not installed" reports in `skills list`, setup and info output, and bundled PRD skill loading, and it adds a fallback verification path when modern `skills` output no longer reports agent counts cleanly.
It also updates the Gemini agent mapping to `gemini-cli` and adds regression tests around shared-path detection.
Validation: `bun test src/setup/skill-installer.test.ts src/commands/skills-install.test.ts src/commands/skills.test.ts`, `bun test src/plugins/agents/builtin/codex.test.ts src/plugins/agents/builtin/gemini.test.ts src/plugins/agents/builtin/cursor.test.ts src/plugins/agents/builtin/kimi.test.ts`, `bun run typecheck`, and `bun run build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discovery now searches multiple personal and repository locations per agent (including shared agent skill locations) and displays all discovered paths in system info and setup flows.
  * Installation flow verifies installed skills across candidate directories and updates install/update prompts and success messaging to reflect actual agent coverage.

* **Chores**
  * Adjusted Gemini agent identifier mapping.
  * Improved runtime home-directory resolution for tilde expansion.

* **Tests**
  * Expanded tests for multi-path discovery, tilde expansion, verification logic and updated system-info formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->