### PR TITLE
[codex] Support secure remote WebSocket URLs

### DIFF
--- a/src/commands/remote.test.ts
+++ b/src/commands/remote.test.ts
@@ -57,6 +57,15 @@ describe('parseRemoteArgs', () => {
       expect(result.token).toBe('xyz');
     });
 
+    test('parses add with secure flag', () => {
+      const result = parseRemoteArgs(['add', 'prod', 'server.com:443', '--secure', '--token', 'abc123']);
+      expect(result.subcommand).toBe('add');
+      expect(result.alias).toBe('prod');
+      expect(result.hostPort).toBe('server.com:443');
+      expect(result.secure).toBe(true);
+      expect(result.token).toBe('abc123');
+    });
+
     test('handles help flag in add', () => {
       const result = parseRemoteArgs(['add', '--help']);
       expect(result.subcommand).toBe('add');

--- a/src/commands/remote.ts
+++ b/src/commands/remote.ts
@@ -12,6 +12,7 @@ import {
   updateLastConnected,
   REMOTES_CONFIG_PATHS,
 } from '../remote/config.js';
+import { buildRemoteWebSocketUrl } from '../remote/url.js';
 
 /**
  * Remote command options
@@ -21,6 +22,7 @@ interface RemoteCommandOptions {
   alias?: string;
   hostPort?: string;
   token?: string;
+  secure?: boolean;
   help?: boolean;
   // push-config options
   scope?: 'global' | 'project';
@@ -57,6 +59,8 @@ export function parseRemoteArgs(args: string[]): RemoteCommandOptions {
     } else if (arg === '--token' && args[i + 1]) {
       options.token = args[i + 1];
       i++;
+    } else if (arg === '--secure') {
+      options.secure = true;
     } else if (arg === '--scope' && args[i + 1]) {
       const scopeValue = args[i + 1];
       if (scopeValue === 'global' || scopeValue === 'project') {
@@ -89,7 +93,8 @@ export function parseRemoteArgs(args: string[]): RemoteCommandOptions {
 async function testRemoteConnection(
   host: string,
   port: number,
-  token: string
+  token: string,
+  secure = false
 ): Promise<{ connected: boolean; error?: string; latencyMs?: number }> {
   const startTime = Date.now();
 
@@ -124,7 +129,7 @@ async function testRemoteConnection(
     }, 5000);
 
     try {
-      ws = new WebSocket(`ws://${host}:${port}`);
+      ws = new WebSocket(buildRemoteWebSocketUrl(host, port, secure));
 
       ws.onopen = () => {
         // Send auth message
@@ -198,7 +203,7 @@ async function executeRemoteAdd(options: RemoteCommandOptions): Promise<void> {
     process.exit(1);
   }
 
-  const result = await addRemote(options.alias, parsed.host, parsed.port, options.token);
+  const result = await addRemote(options.alias, parsed.host, parsed.port, options.token, options.secure);
 
   if (!result.success) {
     console.error(`Error: ${result.error}`);
@@ -210,6 +215,7 @@ async function executeRemoteAdd(options: RemoteCommandOptions): Promise<void> {
   console.log('');
   console.log(`  Host: ${parsed.host}`);
   console.log(`  Port: ${parsed.port}`);
+  console.log(`  URL:  ${buildRemoteWebSocketUrl(parsed.host, parsed.port, options.secure)}`);
   console.log('');
   console.log(`To test: ralph-tui remote test ${options.alias}`);
   console.log('');
@@ -238,7 +244,7 @@ async function executeRemoteList(): Promise<void> {
 
   // Test connections in parallel for status
   const statusPromises = remotes.map(async ([alias, remote]) => {
-    const status = await testRemoteConnection(remote.host, remote.port, remote.token);
+    const status = await testRemoteConnection(remote.host, remote.port, remote.token, remote.secure);
     return { alias, remote, status };
   });
 
@@ -251,7 +257,7 @@ async function executeRemoteList(): Promise<void> {
       : status.error ?? 'disconnected';
 
     console.log(`  ${statusIcon} ${alias}`);
-    console.log(`    URL:    ws://${remote.host}:${remote.port}`);
+    console.log(`    URL:    ${buildRemoteWebSocketUrl(remote.host, remote.port, remote.secure)}`);
     console.log(`    Status: ${statusText}`);
     console.log(`    Token:  ${remote.token.slice(0, 8)}...`);
 
@@ -314,10 +320,10 @@ async function executeRemoteTest(options: RemoteCommandOptions): Promise<void> {
 
   console.log('');
   console.log(`Testing connection to '${options.alias}'...`);
-  console.log(`  URL: ws://${remote.host}:${remote.port}`);
+  console.log(`  URL: ${buildRemoteWebSocketUrl(remote.host, remote.port, remote.secure)}`);
   console.log('');
 
-  const status = await testRemoteConnection(remote.host, remote.port, remote.token);
+  const status = await testRemoteConnection(remote.host, remote.port, remote.token, remote.secure);
 
   if (status.connected) {
     // Update last connected timestamp
@@ -435,13 +441,13 @@ async function executeRemotePushConfig(options: RemoteCommandOptions): Promise<v
   // Process each remote
   for (const [alias, remote] of targetRemotes) {
     console.log('');
-    console.log(`Remote: ${alias} (${remote.host}:${remote.port})`);
+    console.log(`Remote: ${alias} (${buildRemoteWebSocketUrl(remote.host, remote.port, remote.secure)})`);
     console.log('──────────────────────────────────────────────────────────────────');
 
     // Connect to remote
     let client: InstanceType<typeof RemoteClient>;
     try {
-      client = new RemoteClient(remote.host, remote.port, remote.token, () => {});
+      client = new RemoteClient(remote.host, remote.port, remote.token, () => {}, {}, remote.secure);
       await client.connect();
     } catch (error) {
       console.error(`  ✗ Connection failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -622,6 +628,7 @@ Subcommands:
 
 Add Options:
   --token <token>       Authentication token (required)
+  --secure              Use wss:// and omit port 443 in display/connect URLs
 
 Push-Config Options:
   --scope global|project  Which config to push (default: auto-detect)
@@ -631,6 +638,9 @@ Push-Config Options:
 Examples:
   # Add a remote server
   ralph-tui remote add prod server.example.com:7890 --token abc123
+
+  # Add a secure remote behind a TLS proxy
+  ralph-tui remote add prod ralph.example.com:443 --secure --token abc123
 
   # Add with default port (7890)
   ralph-tui remote add staging staging.local --token xyz789
@@ -663,6 +673,7 @@ Configuration:
     [remotes.prod]
     host = "server.example.com"
     port = 7890
+    secure = true
     token = "your-token-here"
     addedAt = "2026-01-19T00:00:00.000Z"
 

--- a/src/remote/client.ts
+++ b/src/remote/client.ts
@@ -48,6 +48,7 @@ import type {
   RemoteOrchestrationState,
 } from './types.js';
 import { TOKEN_LIFETIMES } from './types.js';
+import { buildRemoteWebSocketUrl } from './url.js';
 import type { TokenUsageSummary } from '../plugins/agents/usage.js';
 import type { TrackerTask } from '../plugins/trackers/types.js';
 import type { EngineEvent } from '../engine/types.js';
@@ -132,6 +133,9 @@ export interface InstanceTab {
   /** Port for remote connections */
   port?: number;
 
+  /** Use secure WebSocket connections */
+  secure?: boolean;
+
   /** Last error message (if status is disconnected due to error) */
   lastError?: string;
 
@@ -180,6 +184,7 @@ export class RemoteClient {
   private ws: WebSocket | null = null;
   private host: string;
   private port: number;
+  private secure: boolean;
   /** Server token for initial authentication (long-lived, 90 days) */
   private serverToken: string;
   private eventHandler: RemoteClientEventHandler;
@@ -217,10 +222,12 @@ export class RemoteClient {
     port: number,
     token: string,
     eventHandler: RemoteClientEventHandler,
-    reconnectConfig: Partial<ReconnectConfig> = {}
+    reconnectConfig: Partial<ReconnectConfig> = {},
+    secure = false
   ) {
     this.host = host;
     this.port = port;
+    this.secure = secure;
     this.serverToken = token;
     this.eventHandler = eventHandler;
     this.reconnectConfig = { ...DEFAULT_RECONNECT_CONFIG, ...reconnectConfig };
@@ -271,7 +278,7 @@ export class RemoteClient {
 
     return new Promise<void>((resolve, reject) => {
       try {
-        const url = `ws://${this.host}:${this.port}`;
+        const url = buildRemoteWebSocketUrl(this.host, this.port, this.secure);
         this.ws = new WebSocket(url);
 
         this.ws.onopen = () => {
@@ -1090,7 +1097,7 @@ export class RemoteClient {
    */
   private async attemptReconnect(): Promise<void> {
     try {
-      const url = `ws://${this.host}:${this.port}`;
+      const url = buildRemoteWebSocketUrl(this.host, this.port, this.secure);
       this.ws = new WebSocket(url);
 
       this.ws.onopen = () => {
@@ -1239,7 +1246,8 @@ export function createLocalTab(): InstanceTab {
 export function createRemoteTab(
   alias: string,
   host: string,
-  port: number
+  port: number,
+  secure = false
 ): InstanceTab {
   return {
     id: `remote-${alias}`,
@@ -1249,5 +1257,6 @@ export function createRemoteTab(
     alias,
     host,
     port,
+    secure,
   };
 }

--- a/src/remote/config.test.ts
+++ b/src/remote/config.test.ts
@@ -153,6 +153,7 @@ describe('Config File Format', () => {
           prod: {
             host: 'prod.example.com',
             port: 7890,
+            secure: true,
             token: 'token123',
             addedAt: '2026-01-19T00:00:00.000Z',
           },
@@ -165,6 +166,7 @@ describe('Config File Format', () => {
       expect(toml).toContain('[remotes.prod]');
       expect(toml).toContain('host = "prod.example.com"');
       expect(toml).toContain('port = 7890');
+      expect(toml).toContain('secure = true');
       expect(toml).toContain('token = "token123"');
     });
 
@@ -175,6 +177,7 @@ version = 1
 [remotes.staging]
 host = "staging.local"
 port = 8080
+secure = true
 token = "abc123"
 addedAt = "2026-01-19T12:00:00.000Z"
 `;
@@ -190,11 +193,13 @@ addedAt = "2026-01-19T12:00:00.000Z"
       const staging = parsed.remotes.staging as {
         host: string;
         port: number;
+        secure: boolean;
         token: string;
         addedAt: string;
       };
       expect(staging.host).toBe('staging.local');
       expect(staging.port).toBe(8080);
+      expect(staging.secure).toBe(true);
       expect(staging.token).toBe('abc123');
     });
 

--- a/src/remote/config.ts
+++ b/src/remote/config.ts
@@ -19,6 +19,9 @@ export interface RemoteServerConfig {
   /** Server port */
   port: number;
 
+  /** Use secure WebSocket connections */
+  secure?: boolean;
+
   /** Authentication token for the remote server */
   token: string;
 
@@ -103,7 +106,8 @@ export async function addRemote(
   alias: string,
   host: string,
   port: number,
-  token: string
+  token: string,
+  secure = false
 ): Promise<{ success: boolean; error?: string }> {
   const config = await loadRemotesConfig();
 
@@ -124,6 +128,7 @@ export async function addRemote(
   config.remotes[alias] = {
     host,
     port,
+    ...(secure ? { secure } : {}),
     token,
     addedAt: new Date().toISOString(),
   };

--- a/src/remote/instance-manager.ts
+++ b/src/remote/instance-manager.ts
@@ -68,7 +68,7 @@ export class InstanceManager {
     const remotes = await listRemotes();
     for (const [alias, config] of remotes) {
       this.remoteConfigs.set(alias, config);
-      const tab = createRemoteTab(alias, config.host, config.port);
+      const tab = createRemoteTab(alias, config.host, config.port, config.secure);
       this.tabs.push(tab);
     }
 
@@ -204,7 +204,7 @@ export class InstanceManager {
       this.remoteConfigs.set(alias, config);
       const existingTab = this.tabs.find((t) => t.alias === alias);
       if (!existingTab) {
-        const tab = createRemoteTab(alias, config.host, config.port);
+        const tab = createRemoteTab(alias, config.host, config.port, config.secure);
         this.tabs.push(tab);
       }
     }
@@ -242,7 +242,7 @@ export class InstanceManager {
     if (!client) {
       client = new RemoteClient(tab.host, tab.port, config.token, (event) => {
         this.handleClientEvent(tab.alias!, event);
-      });
+      }, {}, config.secure);
       this.clients.set(tab.alias, client);
     }
 
@@ -663,18 +663,19 @@ export class InstanceManager {
    * @param port The port number
    * @param token The authentication token
    */
-  async addAndConnectRemote(alias: string, host: string, port: number, token: string): Promise<void> {
+  async addAndConnectRemote(alias: string, host: string, port: number, token: string, secure = false): Promise<void> {
     // Store the config in memory
     const config: RemoteServerConfig = {
       host,
       port,
+      ...(secure ? { secure } : {}),
       token,
       addedAt: new Date().toISOString(),
     };
     this.remoteConfigs.set(alias, config);
 
     // Create and add the tab
-    const tab = createRemoteTab(alias, host, port);
+    const tab = createRemoteTab(alias, host, port, secure);
     this.tabs.push(tab);
 
     // Notify listeners of the new tab
@@ -741,7 +742,7 @@ export class InstanceManager {
    * @param port The new port number
    * @param token The new authentication token
    */
-  async reconnectRemote(alias: string, host: string, port: number, token: string): Promise<void> {
+  async reconnectRemote(alias: string, host: string, port: number, token: string, secure = false): Promise<void> {
     // Disconnect existing connection
     this.disconnectRemote(alias);
 
@@ -750,6 +751,7 @@ export class InstanceManager {
     const config: RemoteServerConfig = {
       host,
       port,
+      ...(secure ? { secure } : {}),
       token,
       addedAt: existingConfig?.addedAt ?? new Date().toISOString(),
       lastConnected: existingConfig?.lastConnected,
@@ -761,6 +763,7 @@ export class InstanceManager {
     if (tab) {
       tab.host = host;
       tab.port = port;
+      tab.secure = secure;
       tab.label = alias; // Keep the label as the alias
 
       // Reconnect

--- a/src/remote/url.test.ts
+++ b/src/remote/url.test.ts
@@ -1,0 +1,40 @@
+/**
+ * ABOUTME: Tests for remote WebSocket URL construction.
+ * Verifies secure protocol and default port formatting behavior.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { buildRemoteWebSocketUrl, shouldUseSecureWebSocket } from './url.js';
+
+describe('shouldUseSecureWebSocket', () => {
+  test('uses secure WebSockets when secure is true', () => {
+    expect(shouldUseSecureWebSocket(7890, true)).toBe(true);
+  });
+
+  test('uses secure WebSockets for port 443', () => {
+    expect(shouldUseSecureWebSocket(443)).toBe(true);
+  });
+
+  test('uses plain WebSockets by default for non-443 ports', () => {
+    expect(shouldUseSecureWebSocket(7890)).toBe(false);
+  });
+});
+
+describe('buildRemoteWebSocketUrl', () => {
+  test('builds ws URLs for plain remotes', () => {
+    expect(buildRemoteWebSocketUrl('example.com', 7890)).toBe('ws://example.com:7890');
+  });
+
+  test('builds wss URLs for secure remotes', () => {
+    expect(buildRemoteWebSocketUrl('example.com', 8443, true)).toBe('wss://example.com:8443');
+  });
+
+  test('omits port for secure remotes on 443', () => {
+    expect(buildRemoteWebSocketUrl('example.com', 443, true)).toBe('wss://example.com');
+  });
+
+  test('uses wss and omits port when port is 443 without secure flag', () => {
+    expect(buildRemoteWebSocketUrl('example.com', 443)).toBe('wss://example.com');
+  });
+});

--- a/src/remote/url.ts
+++ b/src/remote/url.ts
@@ -1,0 +1,23 @@
+/**
+ * ABOUTME: WebSocket URL helpers for remote client connections.
+ * Centralizes secure WebSocket protocol and port formatting rules.
+ */
+
+/**
+ * Determine whether a remote should use a secure WebSocket connection.
+ */
+export function shouldUseSecureWebSocket(port: number, secure?: boolean): boolean {
+  return secure === true || port === 443;
+}
+
+/**
+ * Build the WebSocket URL for a remote connection.
+ * Secure remotes on port 443 omit the default port from the URL.
+ */
+export function buildRemoteWebSocketUrl(host: string, port: number, secure?: boolean): string {
+  const useSecureWebSocket = shouldUseSecureWebSocket(port, secure);
+  const protocol = useSecureWebSocket ? 'wss' : 'ws';
+  const portSuffix = useSecureWebSocket && port === 443 ? '' : `:${port}`;
+
+  return `${protocol}://${host}${portSuffix}`;
+}

--- a/src/tui/components/RemoteManagementOverlay.tsx
+++ b/src/tui/components/RemoteManagementOverlay.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from 'react';
 import { useState, useCallback, useEffect } from 'react';
 import { useKeyboard } from '@opentui/react';
 import { colors } from '../theme.js';
+import { buildRemoteWebSocketUrl } from '../../remote/url.js';
 
 /**
  * Mode determines which UI to show
@@ -21,6 +22,7 @@ export interface ExistingRemoteData {
   alias: string;
   host: string;
   port: number;
+  secure?: boolean;
   token: string;
 }
 
@@ -35,7 +37,7 @@ export interface RemoteManagementOverlayProps {
   /** Existing remote data for edit/delete modes */
   existingRemote?: ExistingRemoteData;
   /** Callback when saving (add or edit) */
-  onSave: (data: { alias: string; host: string; port: number; token: string }) => Promise<void>;
+  onSave: (data: { alias: string; host: string; port: number; secure: boolean; token: string }) => Promise<void>;
   /** Callback when deleting */
   onDelete: (alias: string) => Promise<void>;
   /** Callback when closing the overlay */
@@ -48,8 +50,9 @@ export interface RemoteManagementOverlayProps {
 const FIELD_ALIAS = 0;
 const FIELD_HOST = 1;
 const FIELD_PORT = 2;
-const FIELD_TOKEN = 3;
-const FIELD_COUNT = 4;
+const FIELD_SECURE = 3;
+const FIELD_TOKEN = 4;
+const FIELD_COUNT = 5;
 
 /**
  * Validate alias format
@@ -113,6 +116,7 @@ export function RemoteManagementOverlay({
   const [alias, setAlias] = useState('');
   const [host, setHost] = useState('');
   const [port, setPort] = useState('7890');
+  const [secure, setSecure] = useState(false);
   const [token, setToken] = useState('');
 
   // UI state
@@ -128,12 +132,14 @@ export function RemoteManagementOverlay({
         setAlias('');
         setHost('');
         setPort('7890');
+        setSecure(false);
         setToken('');
         setFocusedField(FIELD_ALIAS);
       } else if (existingRemote) {
         setAlias(existingRemote.alias);
         setHost(existingRemote.host);
         setPort(String(existingRemote.port));
+        setSecure(existingRemote.secure ?? existingRemote.port === 443);
         setToken(existingRemote.token);
         setFocusedField(FIELD_ALIAS);
       }
@@ -182,6 +188,7 @@ export function RemoteManagementOverlay({
         alias: alias.trim(),
         host: host.trim(),
         port: parseInt(port, 10),
+        secure,
         token: token.trim(),
       });
       // onClose will be called by parent after successful save
@@ -189,7 +196,7 @@ export function RemoteManagementOverlay({
       setError(err instanceof Error ? err.message : 'Failed to save remote');
       setSaving(false);
     }
-  }, [alias, host, port, token, onSave]);
+  }, [alias, host, port, secure, token, onSave]);
 
   // Handle delete confirmation
   const handleDelete = useCallback(async () => {
@@ -270,6 +277,12 @@ export function RemoteManagementOverlay({
             updateCurrentField((prev) => prev.slice(0, -1));
             break;
 
+          case 'space':
+            if (focusedField === FIELD_SECURE) {
+              setSecure((prev) => !prev);
+            }
+            break;
+
           default:
             // Toggle token visibility with '*'
             if (key.sequence === '*') {
@@ -280,7 +293,14 @@ export function RemoteManagementOverlay({
             // Append printable characters to current field
             if (key.sequence && key.sequence.length === 1) {
               // Only allow digits for port field
-              if (focusedField === FIELD_PORT) {
+              if (focusedField === FIELD_SECURE) {
+                const lowerSequence = key.sequence.toLowerCase();
+                if (lowerSequence === 'y' || lowerSequence === 't') {
+                  setSecure(true);
+                } else if (lowerSequence === 'n' || lowerSequence === 'f') {
+                  setSecure(false);
+                }
+              } else if (focusedField === FIELD_PORT) {
                 if (/^\d$/.test(key.sequence)) {
                   updateCurrentField((prev) => prev + key.sequence);
                 }
@@ -342,7 +362,7 @@ export function RemoteManagementOverlay({
           {/* Remote details */}
           <box style={{ marginBottom: 1 }}>
             <text fg={colors.fg.muted}>
-              Host: {existingRemote.host}:{existingRemote.port}
+              URL: {buildRemoteWebSocketUrl(existingRemote.host, existingRemote.port, existingRemote.secure)}
             </text>
           </box>
 
@@ -413,6 +433,11 @@ export function RemoteManagementOverlay({
           focused={focusedField === FIELD_PORT}
         />
         <FormField
+          label="Secure"
+          value={secure ? 'yes' : 'no'}
+          focused={focusedField === FIELD_SECURE}
+        />
+        <FormField
           label="Token"
           value={showToken ? token : '*'.repeat(token.length || 8)}
           focused={focusedField === FIELD_TOKEN}
@@ -421,7 +446,7 @@ export function RemoteManagementOverlay({
         {/* Token visibility hint */}
         <box style={{ paddingLeft: 10, marginBottom: 1 }}>
           <text fg={colors.fg.muted}>
-            Press * to {showToken ? 'hide' : 'show'} token
+            Press * to {showToken ? 'hide' : 'show'} token, Space to toggle secure
           </text>
         </box>
 

--- a/src/tui/components/RunApp.tsx
+++ b/src/tui/components/RunApp.tsx
@@ -2639,6 +2639,7 @@ export function RunApp({
                     alias: tab.alias!,
                     host: config.host,
                     port: config.port,
+                    secure: config.secure,
                     token: config.token,
                   });
                   setRemoteManagementMode('edit');
@@ -2671,6 +2672,7 @@ export function RunApp({
                     alias: tab.alias!,
                     host: config.host,
                     port: config.port,
+                    secure: config.secure,
                     token: config.token,
                   });
                   setRemoteManagementMode('delete');
@@ -3848,12 +3850,12 @@ export function RunApp({
 
           if (remoteManagementMode === 'add') {
             // Add new remote to config
-            const result = await addRemote(data.alias, data.host, data.port, data.token);
+            const result = await addRemote(data.alias, data.host, data.port, data.token, data.secure);
             if (!result.success) {
               throw new Error(result.error || 'Failed to add remote');
             }
             // Connect to the new remote via InstanceManager
-            await instanceManager.addAndConnectRemote(data.alias, data.host, data.port, data.token);
+            await instanceManager.addAndConnectRemote(data.alias, data.host, data.port, data.token, data.secure);
             // Select the new tab
             const newIndex = instanceManager.getTabIndexByAlias(data.alias);
             if (newIndex !== -1 && onSelectTab) {
@@ -3868,20 +3870,20 @@ export function RunApp({
               // Remove old tab
               instanceManager.removeTab(editingRemote.alias);
               // Add new config
-              const result = await addRemote(data.alias, data.host, data.port, data.token);
+              const result = await addRemote(data.alias, data.host, data.port, data.token, data.secure);
               if (!result.success) {
                 throw new Error(result.error || 'Failed to add remote');
               }
               // Connect with new alias
-              await instanceManager.addAndConnectRemote(data.alias, data.host, data.port, data.token);
+              await instanceManager.addAndConnectRemote(data.alias, data.host, data.port, data.token, data.secure);
             } else {
               // Same alias - just update config and reconnect
               await removeRemote(data.alias);
-              const result = await addRemote(data.alias, data.host, data.port, data.token);
+              const result = await addRemote(data.alias, data.host, data.port, data.token, data.secure);
               if (!result.success) {
                 throw new Error(result.error || 'Failed to update remote');
               }
-              await instanceManager.reconnectRemote(data.alias, data.host, data.port, data.token);
+              await instanceManager.reconnectRemote(data.alias, data.host, data.port, data.token, data.secure);
             }
           }
           setShowRemoteManagement(false);

--- a/website/content/docs/cli/overview.mdx
+++ b/website/content/docs/cli/overview.mdx
@@ -127,6 +127,9 @@ ralph-tui run --listen --prd ./prd.json
 # Add the remote server
 ralph-tui remote add prod server.example.com:7890 --token OGQwNTcxMjM0NTY3...
 
+# Or add a TLS-terminated remote
+ralph-tui remote add prod ralph.example.com:443 --secure --token OGQwNTcxMjM0NTY3...
+
 # Test the connection
 ralph-tui remote test prod
 

--- a/website/content/docs/cli/remote.mdx
+++ b/website/content/docs/cli/remote.mdx
@@ -18,13 +18,14 @@ The `remote` command manages connections to ralph-tui instances running on other
 Add a new remote server configuration.
 
 ```bash
-ralph-tui remote add <alias> <host:port> --token <token>
+ralph-tui remote add <alias> <host:port> --token <token> [--secure]
 ```
 
 **Arguments:**
 - `<alias>` - A unique name for this remote (e.g., `prod`, `staging`, `dev`)
 - `<host:port>` - Server hostname and port (port defaults to 7890 if omitted)
 - `--token <token>` - Authentication token from the remote server
+- `--secure` - Use `wss://` for TLS-terminated remote connections
 
 **Examples:**
 
@@ -32,12 +33,17 @@ ralph-tui remote add <alias> <host:port> --token <token>
 # Add a remote server with explicit port
 ralph-tui remote add prod server.example.com:7890 --token OGQwNTcxMjM0NTY3...
 
+# Add a secure remote behind a TLS proxy
+ralph-tui remote add prod ralph.example.com:443 --secure --token OGQwNTcxMjM0NTY3...
+
 # Add with default port (7890)
 ralph-tui remote add staging staging.local --token YWJjZGVmMDEyMzQ1...
 
 # Add localhost for testing
 ralph-tui remote add local localhost --token dGVzdDEyMzQ1Njc4...
 ```
+
+Remotes marked with `--secure` connect with `wss://`. Port `443` also uses `wss://` automatically and is omitted from displayed URLs.
 
 **Alias naming rules:**
 - Must start with a letter
@@ -73,7 +79,7 @@ Configured Remotes
     Last:   1/19/2026, 3:30:00 PM
 
   ✗ staging
-    URL:    ws://staging.local:7890
+    URL:    wss://staging.local
     Status: Connection timed out (5s)
     Token:  YWJjZGVm...
 
@@ -196,10 +202,13 @@ lastConnected = "2026-01-19T15:30:00.000Z"
 
 [remotes.staging]
 host = "staging.local"
-port = 7890
+port = 443
+secure = true
 token = "YWJjZGVmMDEyMzQ1Njc4OTBhYmNkZWYwMTIzNDU2Nzg5"
 addedAt = "2026-01-18T10:00:00.000Z"
 ```
+
+Set `secure = true` when a remote is exposed through a TLS-terminating reverse proxy such as Caddy or nginx. Secure remotes use `wss://`; when the port is `443`, the port is omitted from the URL.
 
 ## Remote Parallel Orchestration
 
@@ -325,8 +334,9 @@ Tokens are stored in plain text in `remotes.toml`. Ensure appropriate file permi
 - Server is not running (`ralph-tui run --listen`)
 - Firewall blocking port 7890
 - Incorrect hostname or port
+- TLS reverse proxy requires a secure remote configuration
 
-**Solution:** Verify the server is running and the port is accessible.
+**Solution:** Verify the server is running and the port is accessible. For TLS-terminated remotes, add or edit the remote with `--secure` or `secure = true`.
 
 ### Authentication Failed
 

--- a/website/content/docs/cli/run.mdx
+++ b/website/content/docs/cli/run.mdx
@@ -228,10 +228,15 @@ After starting with `--listen`, connect from another machine:
 # Add remote connection
 ralph-tui remote add prod server.example.com:7890 --token <token>
 
+# Add a TLS-terminated remote behind a reverse proxy
+ralph-tui remote add prod ralph.example.com:443 --secure --token <token>
+
 # View remote in TUI
 ralph-tui run
 # Then press number keys to switch between local and remote tabs
 ```
+
+Use `--secure` for remotes exposed through TLS-terminating proxies such as Caddy or nginx. Secure remotes connect with `wss://`; port `443` is omitted from displayed URLs.
 
 ### Security Model
 


### PR DESCRIPTION
## Summary
- add shared remote WebSocket URL construction for ws/wss behavior
- support `secure = true` in remotes config and `ralph-tui remote add --secure`
- thread secure remotes through CLI list/test/push-config, RemoteClient reconnects, and the TUI remote manager
- update website CLI docs for secure remotes and TLS-terminated reverse proxy setup

Closes #372

## Validation
- `bun test src/remote/url.test.ts src/remote/config.test.ts src/commands/remote.test.ts`
- `bun run typecheck && bun run build`
- `bun run lint` (existing warnings only in unrelated tests)
- `bun run website:build`
- `bun run website:lint` (existing warnings only in unrelated website files)
- `git diff --check`