### PR TITLE
feat: make preflight timeout configurable

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -41,11 +41,17 @@ let mockPreflightResult: MockPreflightResult = { success: true, durationMs: 100 
 // Capture the last config passed to getInstance for verification
 let lastGetInstanceConfig: unknown = null;
 
+// Capture the options passed to preflight() for verification (e.g. timeout)
+let lastPreflightOptions: { timeout?: number } | null = null;
+
 // Mock agent instance
 const createMockAgentInstance = () => ({
   meta: { id: 'claude', name: 'Claude Code' },
   detect: () => Promise.resolve(mockDetectResult),
-  preflight: () => Promise.resolve(mockPreflightResult),
+  preflight: (opts?: { timeout?: number }) => {
+    lastPreflightOptions = opts ?? null;
+    return Promise.resolve(mockPreflightResult);
+  },
   initialize: () => Promise.resolve(),
   dispose: () => Promise.resolve(),
 });
@@ -396,6 +402,7 @@ describe('doctor config propagation', () => {
   beforeEach(async () => {
     tempDir = await createTempDir();
     lastGetInstanceConfig = null;
+    lastPreflightOptions = null;
     mockDetectResult = { available: true, version: '1.0.0', executablePath: '/usr/bin/mock' };
     mockPreflightResult = { success: true, durationMs: 100 };
 
@@ -506,6 +513,66 @@ envPassthrough = ["CUSTOM_VAR"]
     expect(config.plugin).toBe('claude');
     expect(config.command).toBe('claude-glm');
     expect(config.envPassthrough).toEqual(['CUSTOM_VAR']);
+  });
+
+  test('uses default 30s preflight timeout when not configured', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeTomlConfig(join(projectConfigDir, 'config.toml'), {
+      agent: 'claude',
+    });
+
+    try {
+      await executeDoctorCommand(['--json', '--cwd', tempDir]);
+    } catch {
+      // Expected - process.exit is called
+    }
+
+    expect(lastPreflightOptions?.timeout).toBe(30000);
+  });
+
+  test('uses top-level preflightTimeoutMs from config', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeTomlConfig(join(projectConfigDir, 'config.toml'), {
+      agent: 'claude',
+      preflightTimeoutMs: 90000,
+    });
+
+    try {
+      await executeDoctorCommand(['--json', '--cwd', tempDir]);
+    } catch {
+      // Expected - process.exit is called
+    }
+
+    expect(lastPreflightOptions?.timeout).toBe(90000);
+  });
+
+  test('uses per-agent preflightTimeoutMs over top-level', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeFile(
+      join(projectConfigDir, 'config.toml'),
+      `
+preflightTimeoutMs = 60000
+tracker = "beads-bv"
+
+[[agents]]
+name = "claude-local"
+plugin = "claude"
+default = true
+preflightTimeoutMs = 180000
+`,
+      'utf-8'
+    );
+
+    try {
+      await executeDoctorCommand(['--json', '--cwd', tempDir]);
+    } catch {
+      // Expected - process.exit is called
+    }
+
+    expect(lastPreflightOptions?.timeout).toBe(180000);
   });
 
   test('agent-level command in [[agents]] takes precedence over top-level command', async () => {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -121,7 +121,7 @@ async function runDiagnostics(
   log('\n  Step 2: Preflight (testing if agent can respond)...');
   log('    Running test prompt...');
 
-  const preflight = await agent.preflight({ timeout: 30000 });
+  const preflight = await agent.preflight({ timeout: agentConfig.preflightTimeoutMs ?? 30000 });
 
   if (!preflight.success) {
     return {

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -1128,3 +1128,100 @@ envPassthrough = ["MY_API_KEY"]
     expect(config!.agent.envPassthrough).toEqual(['MY_API_KEY']);
   });
 });
+
+describe('buildConfig - preflightTimeoutMs shorthand', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('applies top-level preflightTimeoutMs to default agent', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeFile(
+      join(projectConfigDir, 'config.toml'),
+      `
+agent = "claude"
+tracker = "beads-bv"
+preflightTimeoutMs = 60000
+`,
+      'utf-8'
+    );
+
+    const config = await buildConfig({ cwd: tempDir });
+
+    expect(config).not.toBeNull();
+    expect(config!.agent.preflightTimeoutMs).toBe(60000);
+  });
+
+  test('agent-level preflightTimeoutMs takes precedence over top-level', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeFile(
+      join(projectConfigDir, 'config.toml'),
+      `
+preflightTimeoutMs = 60000
+tracker = "beads-bv"
+
+[[agents]]
+name = "claude"
+plugin = "claude"
+default = true
+preflightTimeoutMs = 120000
+`,
+      'utf-8'
+    );
+
+    const config = await buildConfig({ cwd: tempDir });
+
+    expect(config).not.toBeNull();
+    expect(config!.agent.preflightTimeoutMs).toBe(120000);
+  });
+
+  test('top-level preflightTimeoutMs not applied when agent already has it set', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeFile(
+      join(projectConfigDir, 'config.toml'),
+      `
+preflightTimeoutMs = 60000
+tracker = "beads-bv"
+
+[[agents]]
+name = "custom-claude"
+plugin = "claude"
+default = true
+preflightTimeoutMs = 90000
+`,
+      'utf-8'
+    );
+
+    const config = await buildConfig({ cwd: tempDir });
+
+    expect(config).not.toBeNull();
+    expect(config!.agent.preflightTimeoutMs).toBe(90000);
+  });
+
+  test('leaves preflightTimeoutMs undefined when neither level sets it', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeFile(
+      join(projectConfigDir, 'config.toml'),
+      `
+agent = "claude"
+tracker = "beads-bv"
+`,
+      'utf-8'
+    );
+
+    const config = await buildConfig({ cwd: tempDir });
+
+    expect(config).not.toBeNull();
+    expect(config!.agent.preflightTimeoutMs).toBeUndefined();
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -441,6 +441,14 @@ export function getDefaultAgentConfig(
       };
     }
 
+    // Apply preflightTimeoutMs shorthand (only if not already set on agent config)
+    if (storedConfig.preflightTimeoutMs && !result.preflightTimeoutMs) {
+      result = {
+        ...result,
+        preflightTimeoutMs: storedConfig.preflightTimeoutMs,
+      };
+    }
+
     return result;
   };
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -256,6 +256,8 @@ function mergeConfigs(
     merged.fallbackAgents = project.fallbackAgents;
   if (project.envExclude !== undefined) merged.envExclude = project.envExclude;
   if (project.envPassthrough !== undefined) merged.envPassthrough = project.envPassthrough;
+  if (project.preflightTimeoutMs !== undefined)
+    merged.preflightTimeoutMs = project.preflightTimeoutMs;
 
   // Merge nested objects
   if (project.rateLimitHandling !== undefined) {

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -344,6 +344,44 @@ describe('AgentPluginConfigSchema', () => {
     expect(result.envExclude).toEqual(['*_TOKEN']);
     expect(result.envPassthrough).toEqual(['ANTHROPIC_API_KEY']);
   });
+
+  test('accepts preflightTimeoutMs within bounds', () => {
+    const result = AgentPluginConfigSchema.parse({
+      name: 'test',
+      plugin: 'claude',
+      preflightTimeoutMs: 60000,
+    });
+    expect(result.preflightTimeoutMs).toBe(60000);
+  });
+
+  test('accepts preflightTimeoutMs at exact boundaries', () => {
+    expect(
+      AgentPluginConfigSchema.parse({ name: 'test', plugin: 'claude', preflightTimeoutMs: 1000 })
+        .preflightTimeoutMs
+    ).toBe(1000);
+    expect(
+      AgentPluginConfigSchema.parse({ name: 'test', plugin: 'claude', preflightTimeoutMs: 300000 })
+        .preflightTimeoutMs
+    ).toBe(300000);
+  });
+
+  test('rejects preflightTimeoutMs below minimum', () => {
+    expect(() =>
+      AgentPluginConfigSchema.parse({ name: 'test', plugin: 'claude', preflightTimeoutMs: 999 })
+    ).toThrow();
+  });
+
+  test('rejects preflightTimeoutMs above maximum', () => {
+    expect(() =>
+      AgentPluginConfigSchema.parse({ name: 'test', plugin: 'claude', preflightTimeoutMs: 300001 })
+    ).toThrow();
+  });
+
+  test('rejects non-integer preflightTimeoutMs', () => {
+    expect(() =>
+      AgentPluginConfigSchema.parse({ name: 'test', plugin: 'claude', preflightTimeoutMs: 30000.5 })
+    ).toThrow();
+  });
 });
 
 describe('TrackerOptionsSchema', () => {
@@ -482,6 +520,19 @@ describe('StoredConfigSchema', () => {
     });
     expect(result.envExclude).toEqual(['*_TOKEN']);
     expect(result.envPassthrough).toEqual(['MY_API_KEY']);
+  });
+
+  test('accepts top-level preflightTimeoutMs within bounds', () => {
+    const result = StoredConfigSchema.parse({ preflightTimeoutMs: 60000 });
+    expect(result.preflightTimeoutMs).toBe(60000);
+  });
+
+  test('rejects top-level preflightTimeoutMs below minimum', () => {
+    expect(() => StoredConfigSchema.parse({ preflightTimeoutMs: 999 })).toThrow();
+  });
+
+  test('rejects top-level preflightTimeoutMs above maximum', () => {
+    expect(() => StoredConfigSchema.parse({ preflightTimeoutMs: 300001 })).toThrow();
   });
 
   test('accepts progressFile field', () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -112,6 +112,7 @@ export const AgentPluginConfigSchema = z.object({
   command: z.string().optional(),
   defaultFlags: z.array(z.string()).optional(),
   timeout: z.number().int().min(0).optional(),
+  preflightTimeoutMs: z.number().int().min(1000).max(300000).optional(),
   options: AgentOptionsSchema.optional().default({}),
   fallbackAgents: z.array(z.string().min(1)).optional(),
   rateLimitHandling: RateLimitHandlingConfigSchema.optional(),
@@ -204,6 +205,9 @@ export const StoredConfigSchema = z
 
     // Environment variables to pass through despite matching default exclusion patterns
     envPassthrough: z.array(z.string().min(1)).optional(),
+
+    // Preflight check timeout in milliseconds (shorthand for default agent)
+    preflightTimeoutMs: z.number().int().min(1000).max(300000).optional(),
 
     // Custom prompt template path
     prompt_template: z.string().optional(),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -320,6 +320,9 @@ export interface StoredConfig {
    */
   envPassthrough?: string[];
 
+  /** Shorthand: preflight check timeout in milliseconds for the default agent (default: 30000) */
+  preflightTimeoutMs?: number;
+
   /** Whether to auto-commit after successful tasks */
   autoCommit?: boolean;
 

--- a/src/plugins/agents/types.ts
+++ b/src/plugins/agents/types.ts
@@ -231,6 +231,9 @@ export interface AgentPluginConfig {
   /** Default timeout in milliseconds */
   timeout?: number;
 
+  /** Timeout in milliseconds for preflight checks (default: 30000) */
+  preflightTimeoutMs?: number;
+
   /** Plugin-specific configuration options */
   options: Record<string, unknown>;
 

--- a/src/setup/wizard.test.ts
+++ b/src/setup/wizard.test.ts
@@ -35,9 +35,15 @@ let mockInstallViaAddSkillResult = { success: true, output: '' };
 // Override mockTrackerDetectOverride per-test to change detect() behavior.
 let mockTrackerDetectOverride: ((id: string) => Promise<{ available: boolean; error?: string }>) | null = null;
 
+// Capture the options passed to preflight() for verification (e.g. timeout)
+let lastPreflightOptions: { timeout?: number } | null = null;
+
 // Create a function to generate mock agent instances
 const createMockAgentInstance = (id: string, name: string) => ({
-  preflight: () => Promise.resolve({ success: true, durationMs: 100 }),
+  preflight: (opts?: { timeout?: number }) => {
+    lastPreflightOptions = opts ?? null;
+    return Promise.resolve({ success: true, durationMs: 100 });
+  },
   meta: { id, name, description: `${name} AI`, version: '1.0.0' },
   detect: () => Promise.resolve({ available: true, version: '1.0.0' }),
   initialize: () => Promise.resolve(),
@@ -240,6 +246,7 @@ describe('runSetupWizard', () => {
   beforeEach(async () => {
     tempDir = await createTempDir();
     capturedOutput = [];
+    lastPreflightOptions = null;
 
     // Spy on console.log to capture output
     consoleLogSpy = spyOn(console, 'log').mockImplementation((...args) => {
@@ -285,6 +292,19 @@ describe('runSetupWizard', () => {
     // Verify file was created
     const configContent = await readFile(result.configPath!, 'utf-8');
     expect(configContent).toContain('tracker');
+  });
+
+  test('preflight uses default 30s timeout when no preflightTimeoutMs is configured', async () => {
+    mockPromptSelect = (prompt) => {
+      if (prompt.includes('tracker')) return Promise.resolve('json');
+      if (prompt.includes('agent')) return Promise.resolve('claude');
+      return Promise.resolve('');
+    };
+
+    const result = await runSetupWizard({ cwd: tempDir });
+
+    expect(result.success).toBe(true);
+    expect(lastPreflightOptions?.timeout).toBe(30000);
   });
 
   test('saves correct tracker and agent in config', async () => {

--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -36,6 +36,7 @@ import {
   installViaAddSkill,
 } from './skill-installer.js';
 import { CURRENT_CONFIG_VERSION } from './migration.js';
+import { loadStoredConfig } from '../config/index.js';
 
 /**
  * Config directory and filename
@@ -498,8 +499,9 @@ export async function runSetupWizard(
       options: agentOptions,
     });
 
+    const savedConfig = await loadStoredConfig(cwd);
     // Run preflight check
-    const preflightResult = await agentInstance.preflight({ timeout: 30000 });
+    const preflightResult = await agentInstance.preflight({ timeout: savedConfig.preflightTimeoutMs ?? 30000 });
 
     if (preflightResult.success) {
       printSuccess(`✓ Agent is configured correctly and responding`);

--- a/website/content/docs/cli/doctor.mdx
+++ b/website/content/docs/cli/doctor.mdx
@@ -40,6 +40,13 @@ Sends a test prompt to verify the agent can respond:
 - Verifies network connectivity
 - Tests actual agent responsiveness
 
+The preflight check defaults to a **30 second timeout**. If you're using a local reasoning model or a slow wrapper that can legitimately take longer to produce its first response, raise the limit with [`preflightTimeoutMs`](/docs/configuration/options#preflight-timeout):
+
+```toml
+# .ralph-tui/config.toml
+preflightTimeoutMs = 120000  # 2 minutes
+```
+
 ## Examples
 
 ### Basic Usage

--- a/website/content/docs/configuration/config-file.mdx
+++ b/website/content/docs/configuration/config-file.mdx
@@ -64,6 +64,10 @@ autoCommit = false
 # Subagent tracing detail: "off", "minimal", "moderate", "full"
 subagentTracingDetail = "minimal"
 
+# Preflight check timeout in ms (1000-300000, default 30000).
+# Increase for local reasoning models that need longer to respond.
+# preflightTimeoutMs = 60000
+
 # ─────────────────────────────────────────────
 # Agent Options (shorthand)
 # ─────────────────────────────────────────────
@@ -236,6 +240,20 @@ tracker = "beads-bv"
 ```
 
 This uses the Claude agent plugin (for output parsing, flags, etc.) but executes through CCR which handles provider routing.
+
+### Local Reasoning Model
+
+When pointing Ralph TUI at a locally hosted thinking model, the preflight health check may legitimately take longer than the default 30 seconds. Raise the limit:
+
+```toml
+agent = "opencode"
+preflightTimeoutMs = 120000  # 2 minutes for local model warm-up
+
+[agentOptions]
+model = "qwen2.5-coder:32b"
+```
+
+See [Preflight Timeout](/docs/configuration/options#preflight-timeout) for the full reference.
 
 ## Advanced: Plugin Arrays
 

--- a/website/content/docs/configuration/options.mdx
+++ b/website/content/docs/configuration/options.mdx
@@ -28,6 +28,7 @@ These control basic execution behavior.
 | `prompt_template` | string | - | Custom Handlebars template path |
 | `subagentTracingDetail` | string | `"off"` | Subagent visibility level |
 | `skills_dir` | string | - | Directory containing custom PRD skills |
+| `preflightTimeoutMs` | number | `30000` | Preflight check timeout in ms for the default agent (1000–300000). See [Preflight Timeout](#preflight-timeout). |
 
 ### subagentTracingDetail Values
 
@@ -115,11 +116,49 @@ timeout = 300000
 | `command` | string | (from plugin) | Override executable command |
 | `defaultFlags` | string[] | `[]` | Additional CLI flags |
 | `timeout` | number | `0` | Execution timeout (ms, 0 = no timeout) |
+| `preflightTimeoutMs` | number | `30000` | Preflight check timeout in ms (1000–300000). See [Preflight Timeout](#preflight-timeout). |
 | `options` | object | `{}` | Plugin-specific options |
 | `fallbackAgents` | string[] | `[]` | Agents to try on rate limit |
 | `rateLimitHandling` | object | - | Rate limit configuration |
 | `envExclude` | string[] | `[]` | Additional env var patterns to exclude |
 | `envPassthrough` | string[] | `[]` | Env vars to allow through despite exclusion patterns |
+
+### Preflight Timeout
+
+`preflightTimeoutMs` controls how long Ralph TUI waits for the agent to respond during the preflight health check run by [`ralph-tui doctor`](/docs/cli/doctor) and [`ralph-tui setup`](/docs/cli/setup).
+
+The default is **30 seconds**, which is plenty for hosted models. Increase it when:
+
+- You're running a **local reasoning model** (e.g. via Ollama, LM Studio, or a self-hosted endpoint) whose first response can legitimately exceed 30s while it warms up or thinks.
+- You're routing through a wrapper (such as Claude Code Router) that adds latency on cold start.
+- You see intermittent `preflight check failed` errors on a setup that is otherwise healthy.
+
+```toml
+# Top-level shorthand — applies to the default agent
+preflightTimeoutMs = 60000
+```
+
+Or per-agent for finer control:
+
+```toml
+[[agents]]
+name = "my-local-model"
+plugin = "opencode"
+preflightTimeoutMs = 120000  # 2 minutes for a slow local reasoning model
+
+  [agents.options]
+  model = "qwen2.5-coder:32b"
+```
+
+| Constraint | Value |
+|------------|-------|
+| Minimum | `1000` (1 second) |
+| Maximum | `300000` (5 minutes) |
+| Default | `30000` (30 seconds) |
+
+<Callout type="tip">
+The top-level `preflightTimeoutMs` only applies to the default agent. Per-agent settings in `[[agents]]` override the shorthand.
+</Callout>
 
 ## Tracker Options
 
@@ -594,6 +633,7 @@ All numeric options have validation constraints:
 | `errorHandling.retryDelayMs` | 0 | 300000 |
 | `rateLimitHandling.maxRetries` | 0 | 10 |
 | `rateLimitHandling.baseBackoffMs` | 0 | 300000 |
+| `preflightTimeoutMs` | 1000 | 300000 |
 
 ## Environment Variables
 

--- a/website/content/docs/troubleshooting/common-issues.mdx
+++ b/website/content/docs/troubleshooting/common-issues.mdx
@@ -155,6 +155,33 @@ If you don't see real-time output from the agent:
   </TabsContent>
 </TabsRoot>
 
+### Preflight Check Times Out
+
+`ralph-tui doctor` or `ralph-tui setup` reports that the agent failed to respond, but the same agent works fine when you invoke it directly.
+
+The preflight check enforces a 30-second timeout by default. Local reasoning models, slow wrappers, and cold-start scenarios can all exceed this on a perfectly healthy setup.
+
+**Solution:** Raise [`preflightTimeoutMs`](/docs/configuration/options#preflight-timeout) in your config:
+
+```toml
+# .ralph-tui/config.toml
+
+# Global default for the configured agent
+preflightTimeoutMs = 60000  # 60 seconds
+
+# Or set it per-agent (overrides the shorthand)
+[[agents]]
+name = "my-local-model"
+plugin = "opencode"
+preflightTimeoutMs = 180000  # 3 minutes
+```
+
+Valid range: `1000`–`300000` milliseconds (1 second to 5 minutes).
+
+<Callout type="tip">
+If preflight passes but real runs still feel slow, that's a separate concern — `preflightTimeoutMs` only affects the one-shot health check, not iteration execution. For execution timeouts, see the per-agent `timeout` option.
+</Callout>
+
 ---
 
 ## Session Issues


### PR DESCRIPTION
### Summary
The preflight check sends a test prompt to verify the agent is responsive before starting work. With local thinking models (e.g. locally-hosted reasoning models), this check can legitimately take well beyond the previous hardcoded 30s limit — causing false failures on perfectly healthy setups.

This PR makes the timeout configurable at two levels:

    Per-agent via preflightTimeoutMs in an [[agents]] block
    Top-level shorthand via preflightTimeoutMs in the root config, which propagates to the default agent

The default remains 30s, so existing configs are unaffected.

### Usage
# Global default for the configured agent
preflightTimeoutMs = 60000

# Or per-agent
[[agents]]
name = "my-local-model"
plugin = "opencode"
preflightTimeoutMs = 120000

### Changes
    AgentPluginConfig / AgentPluginConfigSchema — new preflightTimeoutMs field
    StoredConfig / StoredConfigSchema — top-level shorthand, propagated via getDefaultAgentConfig
    doctor.ts, wizard.ts — use configured value with 30s fallback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preflight timeout for agent diagnostics and setup verification is now configurable (1,000–300,000 ms; default 30,000 ms). Top-level and per-agent values supported, with per-agent taking precedence.

* **Documentation**
  * Docs, config reference and troubleshooting updated with the Preflight Timeout option, examples, allowed range and guidance for increasing timeouts for slow/local models.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/subsy/ralph-tui/pull/385)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->