### PR TITLE
feat: make auto-commit message template configurable

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -247,6 +247,8 @@ function mergeConfigs(
   if (project.progressFile !== undefined)
     merged.progressFile = project.progressFile;
   if (project.autoCommit !== undefined) merged.autoCommit = project.autoCommit;
+  if (project.commitMessageTemplate !== undefined)
+    merged.commitMessageTemplate = project.commitMessageTemplate;
   if (project.subagentTracingDetail !== undefined) {
     merged.subagentTracingDetail = project.subagentTracingDetail;
   }
@@ -703,6 +705,7 @@ export async function buildConfig(
     // CLI --prompt takes precedence over config file prompt_template
     promptTemplate: options.promptPath ?? storedConfig.prompt_template,
     autoCommit: storedConfig.autoCommit ?? false,
+    commitMessageTemplate: storedConfig.commitMessageTemplate,
   };
 }
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -522,6 +522,22 @@ describe('StoredConfigSchema', () => {
     expect(result.envPassthrough).toEqual(['MY_API_KEY']);
   });
 
+  test('accepts commitMessageTemplate as an optional string', () => {
+    const result = StoredConfigSchema.parse({
+      commitMessageTemplate: '{{taskType}}({{taskId}}): {{taskTitle}}',
+    });
+    expect(result.commitMessageTemplate).toBe('{{taskType}}({{taskId}}): {{taskTitle}}');
+  });
+
+  test('accepts empty config without commitMessageTemplate', () => {
+    const result = StoredConfigSchema.parse({});
+    expect(result.commitMessageTemplate).toBeUndefined();
+  });
+
+  test('rejects commitMessageTemplate when set to a non-string', () => {
+    expect(() => StoredConfigSchema.parse({ commitMessageTemplate: 42 })).toThrow();
+  });
+
   test('accepts top-level preflightTimeoutMs within bounds', () => {
     const result = StoredConfigSchema.parse({ preflightTimeoutMs: 60000 });
     expect(result.preflightTimeoutMs).toBe(60000);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -154,6 +154,7 @@ export const StoredConfigSchema = z
     iterationDelay: z.number().int().min(0).max(300000).optional(),
     outputDir: z.string().optional(),
     autoCommit: z.boolean().optional(),
+    commitMessageTemplate: z.string().optional(),
 
     // Plugin configurations
     agents: z.array(AgentPluginConfigSchema).optional(),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -326,6 +326,13 @@ export interface StoredConfig {
   /** Whether to auto-commit after successful tasks */
   autoCommit?: boolean;
 
+  /**
+   * Handlebars template for auto-commit subject lines. Available variables:
+   * `{{taskId}}`, `{{taskTitle}}`, `{{taskType}}` (falls back to `chore` when
+   * the tracker omits a type). Defaults to `"{{taskType}}: {{taskId}} {{taskTitle}}"`.
+   */
+  commitMessageTemplate?: string;
+
   /** Custom prompt template path (relative to cwd or absolute) */
   prompt_template?: string;
 
@@ -397,6 +404,13 @@ export interface RalphConfig {
 
   /** Whether to auto-commit after successful task completion (default: false) */
   autoCommit?: boolean;
+
+  /**
+   * Handlebars template for auto-commit subject lines. When omitted, the default
+   * `"{{taskType}}: {{taskId}} {{taskTitle}}"` is used (with `taskType` falling
+   * back to `chore` when the tracker omits a type).
+   */
+  commitMessageTemplate?: string;
 
   /**
    * Optional list of task IDs to execute. When provided, only tasks with these

--- a/src/engine/auto-commit.ts
+++ b/src/engine/auto-commit.ts
@@ -1,8 +1,10 @@
 /**
  * ABOUTME: Auto-commit utility for committing changes after successful task completion.
- * Provides git operations to stage and commit changes when autoCommit is enabled.
+ * Provides git operations to stage and commit changes when autoCommit is enabled,
+ * plus Handlebars-based rendering of configurable commit subject templates.
  */
 
+import Handlebars from 'handlebars';
 import { runProcess } from '../utils/process.js';
 
 /**
@@ -22,6 +24,94 @@ export interface AutoCommitResult {
 }
 
 /**
+ * Default commit subject template used when the user has not set
+ * `commitMessageTemplate` in their config. Uses the tracker-reported task type
+ * (with a `chore` fallback) so commits look Conventional-Commits-shaped without
+ * mis-labeling everything as `feat:`.
+ */
+export const DEFAULT_COMMIT_MESSAGE_TEMPLATE = '{{taskType}}: {{taskId}} {{taskTitle}}';
+
+/**
+ * Fallback used when a task's `type` is missing or empty so user templates
+ * always render to a non-empty subject.
+ */
+export const DEFAULT_TASK_TYPE = 'chore';
+
+/**
+ * Inputs for {@link renderCommitMessage}.
+ */
+export interface CommitMessageContext {
+  taskId: string;
+  taskTitle: string;
+  taskType?: string;
+}
+
+/**
+ * Result of rendering a commit message template.
+ */
+export interface RenderCommitMessageResult {
+  /** The rendered commit subject. Always non-empty. */
+  message: string;
+  /**
+   * True when the caller-supplied template rendered to an empty/whitespace
+   * string (or failed to compile) and we fell back to the default template.
+   */
+  usedFallback: boolean;
+  /** Compile/render error message when {@link usedFallback} is true. */
+  fallbackReason?: string;
+}
+
+function buildHandlebarsContext(ctx: CommitMessageContext): Record<string, string> {
+  const type = ctx.taskType?.trim();
+  return {
+    taskId: ctx.taskId,
+    taskTitle: ctx.taskTitle,
+    taskType: type && type.length > 0 ? type : DEFAULT_TASK_TYPE,
+  };
+}
+
+function compileAndRender(template: string, ctx: Record<string, string>): string {
+  const compiled = Handlebars.compile(template, { noEscape: true, strict: false });
+  return compiled(ctx).trim();
+}
+
+/**
+ * Render a Handlebars commit subject template. Falls back to the default
+ * template when the user-supplied template renders empty/whitespace-only or
+ * throws while compiling.
+ */
+export function renderCommitMessage(
+  template: string | undefined,
+  ctx: CommitMessageContext
+): RenderCommitMessageResult {
+  const handlebarsCtx = buildHandlebarsContext(ctx);
+  const effectiveTemplate = template ?? DEFAULT_COMMIT_MESSAGE_TEMPLATE;
+
+  let rendered: string;
+  try {
+    rendered = compileAndRender(effectiveTemplate, handlebarsCtx);
+  } catch (err) {
+    const fallback = compileAndRender(DEFAULT_COMMIT_MESSAGE_TEMPLATE, handlebarsCtx);
+    return {
+      message: fallback,
+      usedFallback: true,
+      fallbackReason: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  if (rendered.length === 0) {
+    const fallback = compileAndRender(DEFAULT_COMMIT_MESSAGE_TEMPLATE, handlebarsCtx);
+    return {
+      message: fallback,
+      usedFallback: true,
+      fallbackReason: 'template rendered to empty string',
+    };
+  }
+
+  return { message: rendered, usedFallback: false };
+}
+
+/**
  * Check if there are uncommitted changes in the working directory.
  * Throws if git status cannot be determined (not a git repo, git not installed, etc.).
  */
@@ -34,13 +124,12 @@ export async function hasUncommittedChanges(cwd: string): Promise<boolean> {
 }
 
 /**
- * Stage all changes and create a commit with a standardized message format.
- * Returns the result of the operation including commit SHA on success.
+ * Stage all changes and create a commit using the supplied subject line.
+ * The caller is responsible for rendering any template — see {@link renderCommitMessage}.
  */
 export async function performAutoCommit(
   cwd: string,
-  taskId: string,
-  taskTitle: string
+  commitMessage: string
 ): Promise<AutoCommitResult> {
   // Check for uncommitted changes first
   let hasChanges: boolean;
@@ -68,8 +157,7 @@ export async function performAutoCommit(
     };
   }
 
-  // Create commit with standardized message
-  const commitMessage = `feat: ${taskId} - ${taskTitle}`;
+  // Create commit with supplied message
   const commitResult = await runProcess(
     'git',
     ['commit', '-m', commitMessage],

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -56,7 +56,7 @@ import {
 } from '../plugins/agents/usage.js';
 import { updateSessionIteration, updateSessionStatus, updateSessionMaxIterations } from '../session/index.js';
 import { saveIterationLog, buildSubagentTrace, getRecentProgressSummary, getCodebasePatternsForPrompt } from '../logs/index.js';
-import { performAutoCommit } from './auto-commit.js';
+import { performAutoCommit, renderCommitMessage } from './auto-commit.js';
 import type { AgentSwitchEntry } from '../logs/index.js';
 import { renderPrompt } from '../templates/index.js';
 import { appendWithCharLimit as appendWithSharedCharLimit } from '../utils/buffer-limits.js';
@@ -2225,7 +2225,17 @@ export class ExecutionEngine {
    */
   private async handleAutoCommit(task: TrackerTask, iteration: number): Promise<void> {
     try {
-      const result = await performAutoCommit(this.config.cwd, task.id, task.title);
+      const rendered = renderCommitMessage(this.config.commitMessageTemplate, {
+        taskId: task.id,
+        taskTitle: task.title,
+        taskType: task.type,
+      });
+      if (rendered.usedFallback) {
+        console.warn(
+          `[auto-commit] commitMessageTemplate fell back to the default for task ${task.id}: ${rendered.fallbackReason}`
+        );
+      }
+      const result = await performAutoCommit(this.config.cwd, rendered.message);
       if (result.committed) {
         this.emit({
           type: 'task:auto-committed',
@@ -2234,6 +2244,7 @@ export class ExecutionEngine {
           iteration,
           commitMessage: result.commitMessage!,
           commitSha: result.commitSha,
+          templateFallbackReason: rendered.usedFallback ? rendered.fallbackReason : undefined,
         });
       } else if (result.error) {
         this.emit({

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -479,6 +479,13 @@ export interface TaskAutoCommittedEvent extends EngineEventBase {
   commitMessage: string;
   /** Short SHA of the commit (if available) */
   commitSha?: string;
+  /**
+   * Populated when a configured `commitMessageTemplate` failed to render
+   * (Handlebars error or empty/whitespace result) and the engine fell back
+   * to the default template. Always undefined when no template was set or
+   * the template rendered cleanly.
+   */
+  templateFallbackReason?: string;
 }
 
 /**

--- a/tests/engine/auto-commit.test.ts
+++ b/tests/engine/auto-commit.test.ts
@@ -1,6 +1,7 @@
 /**
  * ABOUTME: Tests for the auto-commit utility module.
- * Verifies git staging/commit behavior after task completion using real temporary git repos.
+ * Verifies git staging/commit behavior after task completion using real temporary git repos,
+ * plus Handlebars-based rendering of configurable commit message templates.
  *
  * This test file uses Bun.spawn directly for all git operations to avoid mock pollution
  * from other test files. Bun's mock.restore() does not reliably restore builtin modules.
@@ -9,13 +10,19 @@
  * NOTE: The functions hasUncommittedChanges and performAutoCommit are re-implemented
  * locally using Bun.spawn because of the mock restoration issue above. Replace these
  * with imports from src/engine/auto-commit.ts when Bun's module mock restoration is
- * fixed, to keep tests in sync with production.
+ * fixed, to keep tests in sync with production. `renderCommitMessage` is pure and is
+ * imported directly from production.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import {
+  renderCommitMessage,
+  DEFAULT_COMMIT_MESSAGE_TEMPLATE,
+  DEFAULT_TASK_TYPE,
+} from '../../src/engine/auto-commit.js';
 
 let tempDir: string;
 
@@ -53,11 +60,13 @@ async function hasUncommittedChanges(cwd: string): Promise<boolean> {
 /**
  * Test-local implementation of performAutoCommit using Bun.spawn.
  * This mirrors the logic in src/engine/auto-commit.ts but bypasses node:child_process.
+ *
+ * Signature matches the production function: callers pass a pre-rendered subject
+ * (commit message templates are rendered in the engine via renderCommitMessage).
  */
 async function performAutoCommit(
   cwd: string,
-  taskId: string,
-  taskTitle: string
+  commitMessage: string
 ): Promise<{
   committed: boolean;
   commitMessage?: string;
@@ -89,7 +98,6 @@ async function performAutoCommit(
     };
   }
 
-  const commitMessage = `feat: ${taskId} - ${taskTitle}`;
   const commitResult = await runProcess('git', ['commit', '-m', commitMessage], cwd);
   if (!commitResult.success) {
     return {
@@ -165,13 +173,13 @@ describe('hasUncommittedChanges', () => {
 });
 
 describe('performAutoCommit', () => {
-  test('creates commit with correct message format', async () => {
+  test('creates commit with supplied subject line', async () => {
     await writeFile(join(tempDir, 'task-output.txt'), 'done');
 
-    const result = await performAutoCommit(tempDir, 'TASK-42', 'Fix the login bug');
+    const result = await performAutoCommit(tempDir, 'feature: TASK-42 Fix the login bug');
 
     expect(result.committed).toBe(true);
-    expect(result.commitMessage).toBe('feat: TASK-42 - Fix the login bug');
+    expect(result.commitMessage).toBe('feature: TASK-42 Fix the login bug');
     expect(result.commitSha).toBeDefined();
     expect(result.commitSha!.length).toBeGreaterThan(0);
     expect(result.error).toBeUndefined();
@@ -179,7 +187,7 @@ describe('performAutoCommit', () => {
   });
 
   test('skips when there are no changes', async () => {
-    const result = await performAutoCommit(tempDir, 'TASK-1', 'No-op task');
+    const result = await performAutoCommit(tempDir, 'chore: TASK-1 No-op task');
 
     expect(result.committed).toBe(false);
     expect(result.skipReason).toBe('no uncommitted changes');
@@ -190,7 +198,7 @@ describe('performAutoCommit', () => {
     await writeFile(join(tempDir, 'new.ts'), 'export const x = 1;');
     await writeFile(join(tempDir, '.gitkeep'), 'modified');
 
-    const result = await performAutoCommit(tempDir, 'TASK-5', 'Multi-file change');
+    const result = await performAutoCommit(tempDir, 'chore: TASK-5 Multi-file change');
 
     expect(result.committed).toBe(true);
 
@@ -203,7 +211,7 @@ describe('performAutoCommit', () => {
   test('commit SHA matches HEAD after commit', async () => {
     await writeFile(join(tempDir, 'file.txt'), 'content');
 
-    const result = await performAutoCommit(tempDir, 'TASK-10', 'Verify SHA');
+    const result = await performAutoCommit(tempDir, 'chore: TASK-10 Verify SHA');
 
     expect(result.committed).toBe(true);
 
@@ -218,7 +226,7 @@ describe('performAutoCommit', () => {
     await writeFile(join(nonGitDir, 'file.txt'), 'content');
 
     try {
-      const result = await performAutoCommit(nonGitDir, 'TASK-99', 'Should fail');
+      const result = await performAutoCommit(nonGitDir, 'chore: TASK-99 Should fail');
       // Should not throw - returns error in result
       expect(result.committed).toBe(false);
       expect(result.error).toBeDefined();
@@ -231,9 +239,96 @@ describe('performAutoCommit', () => {
   test('leaves working tree clean after commit', async () => {
     await writeFile(join(tempDir, 'file.txt'), 'content');
 
-    await performAutoCommit(tempDir, 'TASK-7', 'Clean tree');
+    await performAutoCommit(tempDir, 'chore: TASK-7 Clean tree');
 
     const hasChanges = await hasUncommittedChanges(tempDir);
     expect(hasChanges).toBe(false);
+  });
+});
+
+describe('renderCommitMessage', () => {
+  test('default template uses task.type when present', () => {
+    const result = renderCommitMessage(undefined, {
+      taskId: 'TASK-42',
+      taskTitle: 'Fix the login bug',
+      taskType: 'feature',
+    });
+
+    expect(result.message).toBe('feature: TASK-42 Fix the login bug');
+    expect(result.usedFallback).toBe(false);
+    expect(result.fallbackReason).toBeUndefined();
+  });
+
+  test('default template falls back to "chore" when task.type missing', () => {
+    const result = renderCommitMessage(undefined, {
+      taskId: 'TASK-1',
+      taskTitle: 'Untyped work',
+    });
+
+    expect(result.message).toBe('chore: TASK-1 Untyped work');
+    expect(result.usedFallback).toBe(false);
+  });
+
+  test('default template falls back to "chore" when task.type is whitespace', () => {
+    const result = renderCommitMessage(undefined, {
+      taskId: 'TASK-2',
+      taskTitle: 'Empty type',
+      taskType: '   ',
+    });
+
+    expect(result.message).toBe(`${DEFAULT_TASK_TYPE}: TASK-2 Empty type`);
+    expect(result.usedFallback).toBe(false);
+  });
+
+  test('custom template references taskId, taskTitle, and taskType', () => {
+    const result = renderCommitMessage('{{taskType}}({{taskId}}): {{taskTitle}}', {
+      taskId: 'US-001',
+      taskTitle: 'Prepare fs',
+      taskType: 'feat',
+    });
+
+    expect(result.message).toBe('feat(US-001): Prepare fs');
+    expect(result.usedFallback).toBe(false);
+  });
+
+  test('custom template that renders to whitespace falls back to default', () => {
+    const result = renderCommitMessage('   ', {
+      taskId: 'TASK-3',
+      taskTitle: 'Whitespace template',
+      taskType: 'bug',
+    });
+
+    expect(result.message).toBe('bug: TASK-3 Whitespace template');
+    expect(result.usedFallback).toBe(true);
+    expect(result.fallbackReason).toBeDefined();
+  });
+
+  test('invalid Handlebars syntax falls back to default and surfaces reason', () => {
+    // Unclosed mustache triggers a Handlebars parse error.
+    const result = renderCommitMessage('{{taskId', {
+      taskId: 'TASK-4',
+      taskTitle: 'Broken template',
+      taskType: 'bug',
+    });
+
+    expect(result.message).toBe('bug: TASK-4 Broken template');
+    expect(result.usedFallback).toBe(true);
+    expect(result.fallbackReason).toBeDefined();
+    expect(result.fallbackReason!.length).toBeGreaterThan(0);
+  });
+
+  test('does not HTML-escape characters in task titles', () => {
+    const result = renderCommitMessage(undefined, {
+      taskId: 'TASK-5',
+      taskTitle: `Handle "quotes" & <brackets>`,
+      taskType: 'fix',
+    });
+
+    expect(result.message).toBe(`fix: TASK-5 Handle "quotes" & <brackets>`);
+    expect(result.usedFallback).toBe(false);
+  });
+
+  test('exports DEFAULT_COMMIT_MESSAGE_TEMPLATE matching the documented default', () => {
+    expect(DEFAULT_COMMIT_MESSAGE_TEMPLATE).toBe('{{taskType}}: {{taskId}} {{taskTitle}}');
   });
 });

--- a/website/content/docs/configuration/config-file.mdx
+++ b/website/content/docs/configuration/config-file.mdx
@@ -58,6 +58,15 @@ progressFile = ".ralph-tui/progress.md"
 # may still commit on their own if instructed by templates or CLAUDE.md).
 autoCommit = false
 
+# Optional Handlebars template for the auto-commit subject line. Variables:
+#   {{taskId}}    - tracker-supplied task identifier
+#   {{taskTitle}} - tracker-supplied task title
+#   {{taskType}}  - task type (e.g. "bug", "feature"); falls back to "chore"
+# If unset, the default below is used. To restore the legacy `feat:` prefix used
+# in pre-#384 releases, set:
+#   commitMessageTemplate = "feat: {{taskId}} - {{taskTitle}}"
+# commitMessageTemplate = "{{taskType}}: {{taskId}} {{taskTitle}}"
+
 # Custom prompt template path (relative or absolute)
 # prompt_template = "./my-template.hbs"
 

--- a/website/content/docs/configuration/options.mdx
+++ b/website/content/docs/configuration/options.mdx
@@ -25,6 +25,7 @@ These control basic execution behavior.
 | `outputDir` | string | `.ralph-tui/iterations` | Directory for iteration log files |
 | `progressFile` | string | `.ralph-tui/progress.md` | Progress file for cross-iteration context |
 | `autoCommit` | boolean | `false` | Ensures a git commit after each successful task. When `true`, ralph-tui stages and commits all uncommitted changes after task completion. When `false`, no automatic commit is made by ralph-tui, though the agent may still commit on its own if instructed by templates or CLAUDE.md. |
+| `commitMessageTemplate` | string | `"{{taskType}}: {{taskId}} {{taskTitle}}"` | Handlebars template used for the auto-commit subject when `autoCommit = true`. Available variables: `{{taskId}}`, `{{taskTitle}}`, `{{taskType}}` (falls back to `chore` when the tracker omits a type). If the rendered string is empty/whitespace or the template fails to compile, ralph-tui falls back to the default and logs a warning. |
 | `prompt_template` | string | - | Custom Handlebars template path |
 | `subagentTracingDetail` | string | `"off"` | Subagent visibility level |
 | `skills_dir` | string | - | Directory containing custom PRD skills |

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -94,6 +94,7 @@ iterationDelay = 1000    # Delay between iterations (ms)
 outputDir = ".ralph-tui/iterations"
 progressFile = ".ralph-tui/progress.md"
 autoCommit = false       # Auto-commit after task completion
+# commitMessageTemplate = "{{taskType}}: {{taskId}} {{taskTitle}}"  # default; Handlebars
 ```
 
 ### Agent Settings

--- a/website/content/docs/templates/customization.mdx
+++ b/website/content/docs/templates/customization.mdx
@@ -251,7 +251,7 @@ We are working in a project to implement the following Product Requirements Docu
 2. Study `.ralph-tui/progress.md` to understand overall status, implementation progress, and learnings including codebase patterns and gotchas
 3. Implement this task following acceptance criteria
 4. Run quality checks: typecheck, lint, etc.
-5. Commit with message: `feat: \{\{taskId\}\} - \{\{taskTitle\}\}`
+5. Commit with message: `\{\{taskType\}\}: \{\{taskId\}\} \{\{taskTitle\}\}` (default; configurable via [`commitMessageTemplate`](../configuration/options.mdx))
 6. Close the task (for beads): `bd close \{\{taskId\}\} --db \{\{beadsDbPath\}\} --reason "..."`
 7. Document learnings (see below)
 8. Signal completion

--- a/website/content/docs/templates/overview.mdx
+++ b/website/content/docs/templates/overview.mdx
@@ -110,7 +110,7 @@ We are working in a project to implement the following Product Requirements Docu
 2. Study `.ralph-tui/progress.md` to understand overall status, implementation progress, and learnings including codebase patterns and gotchas
 3. Implement this single story following acceptance criteria
 4. Run quality checks: typecheck, lint, etc.
-5. Commit with message: `feat: \{\{taskId\}\} - \{\{taskTitle\}\}`
+5. Commit with message: `\{\{taskType\}\}: \{\{taskId\}\} \{\{taskTitle\}\}` (default; `taskType` falls back to `chore`. Override via the [`commitMessageTemplate`](../configuration/options.mdx) config option.)
 6. Document learnings in `.ralph-tui/progress.md`
 7. Signal completion
 
@@ -165,7 +165,7 @@ We are working in a project to implement the following Product Requirements Docu
 2. Study `.ralph-tui/progress.md` to understand overall status, implementation progress, and learnings including codebase patterns and gotchas
 3. Implement the requirements (stay on current branch)
 4. Run your project's quality checks
-5. Commit: `feat: \{\{taskId\}\} - \{\{taskTitle\}\}`
+5. Commit: `\{\{taskType\}\}: \{\{taskId\}\} \{\{taskTitle\}\}` (default; configurable via [`commitMessageTemplate`](../configuration/options.mdx))
 6. Close the bead: `bd close \{\{taskId\}\} --db \{\{beadsDbPath\}\} --reason "..."`
 7. Document learnings in `.ralph-tui/progress.md`
 8. Signal completion


### PR DESCRIPTION
## Summary

Closes #384.

- Adds a `commitMessageTemplate` config option (Handlebars syntax) exposing `{{taskId}}`, `{{taskTitle}}`, and `{{taskType}}`, letting each project pick a commit subject convention that matches its tracker and merge strategy.
- Changes the default auto-commit subject from the hardcoded `feat: {{taskId}} - {{taskTitle}}` to `{{taskType}}: {{taskId}} {{taskTitle}}`, falling back to `chore` when the tracker omits a task type. Users who prefer the legacy format can restore it with `commitMessageTemplate = "feat: {{taskId}} - {{taskTitle}}"` (documented in `config-file.mdx`).
- Empty/whitespace renders and Handlebars compile errors fall back to the default and emit a warning; the fallback reason is surfaced on the `task:auto-committed` event for observability.

### Why not the format proposed in the issue?

The issue proposed `({branchName-storyNumber}): {storyTitle}` as a new fixed default. Two concerns with that:

1. Dropping the type entirely makes the subject *less* Conventional-Commits-compliant, not more.
2. Embedding the branch name in the subject duplicates information git already tracks (branch ref / merge commits).

A configurable template addresses both complaints in the issue (hardcoded `feat:`, US-XYZ collisions) without forcing one opinionated format. Users who want the branch in the subject can set `commitMessageTemplate = "({{taskType}}-{{taskId}}): {{taskTitle}}"` themselves.

### Files touched

- `src/config/{schema,types,index}.ts` — new `commitMessageTemplate?: string` field, merge/resolve plumbing.
- `src/engine/auto-commit.ts` — new `renderCommitMessage` helper (Handlebars with `noEscape: true`); `performAutoCommit` signature changed to `(cwd, commitMessage)`.
- `src/engine/index.ts` — `handleAutoCommit` renders the template and logs/surfaces fallback warnings.
- `src/engine/types.ts` — optional `templateFallbackReason` on `TaskAutoCommittedEvent`.
- `tests/engine/auto-commit.test.ts` — new `renderCommitMessage` describe block; existing tests updated for the new signature.
- `src/config/schema.test.ts` — coverage for the new optional field.
- Docs updated: `options.mdx`, `config-file.mdx`, `overview.mdx`, `templates/overview.mdx`, `templates/customization.mdx`.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors (warnings are pre-existing).
- [x] `bun run build` — clean.
- [x] `bun test tests/engine/auto-commit.test.ts` — 18/18 pass, including new `renderCommitMessage` cases (type fallback, custom templates, whitespace/invalid template fallback, no HTML escaping).
- [x] `bun test src/config/schema.test.ts` — 93/93 pass.
- [x] Engine/config/parallel-worker suite — 367/367 pass.
- [ ] Manual end-to-end in a scratch repo:
  - [ ] `autoCommit = true`, task with `type: "bug"` → commit subject `bug: <id> <title>`.
  - [ ] `autoCommit = true`, task with no `type` → commit subject `chore: <id> <title>`.
  - [ ] `commitMessageTemplate = "{{taskType}}({{taskId}}): {{taskTitle}}"` → custom subject.
  - [ ] Whitespace-only template → fallback to default + warning in `task:auto-committed`.
  - [ ] Title with `"` and `&` → characters preserved (no HTML escape).

## Migration note

Default changes for existing users with `autoCommit = true`: subjects switch from `feat: TASK-1 - Fix login` to `bug: TASK-1 Fix login` (or `chore: ...` if the tracker omits type). Setting `commitMessageTemplate = "feat: {{taskId}} - {{taskTitle}}"` restores the previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customisable `commitMessageTemplate` configuration option for auto-commit messages using Handlebars templates with support for task variables (ID, title, and type)
  * Automatic fallback to default template with warning if configured template fails to render

* **Documentation**
  * Updated configuration documentation with examples and guidance for using the new `commitMessageTemplate` option
  * Added template customisation examples showing configurable commit message formats

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/subsy/ralph-tui/pull/387)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->