### PR TITLE
feat: add --model and --variant flags to create-prd command

### DIFF
--- a/src/chat/engine.test.ts
+++ b/src/chat/engine.test.ts
@@ -5,8 +5,13 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { ChatEngine, buildPrdSystemPromptFromSkillSource } from './engine.js';
-import type { AgentPlugin, AgentExecutionHandle, AgentExecutionResult, AgentPluginMeta } from '../plugins/agents/types.js';
+import {
+  ChatEngine,
+  buildPrdSystemPromptFromSkillSource,
+  createPrdChatEngine,
+  createTaskChatEngine,
+} from './engine.js';
+import type { AgentExecuteOptions, AgentPlugin, AgentExecutionHandle, AgentExecutionResult, AgentPluginMeta } from '../plugins/agents/types.js';
 
 describe('buildPrdSystemPromptFromSkillSource', () => {
   test('includes plain text description guidance', () => {
@@ -45,13 +50,16 @@ describe('buildPrdSystemPromptFromSkillSource', () => {
 });
 
 /**
- * Create a mock agent that captures the prompt passed to execute().
+ * Create a mock agent that captures the prompt and execute options
+ * (so tests can assert on flags propagation, etc.).
  */
 function createMockAgent(responseText = 'mock response'): {
   agent: AgentPlugin;
   getCapturedPrompt: () => string | undefined;
+  getCapturedOptions: () => AgentExecuteOptions | undefined;
 } {
   let capturedPrompt: string | undefined;
+  let capturedOptions: AgentExecuteOptions | undefined;
 
   const meta: AgentPluginMeta = {
     id: 'mock',
@@ -72,6 +80,7 @@ function createMockAgent(responseText = 'mock response'): {
     detect: async () => ({ available: true }),
     execute: (prompt: string, _files?, options?) => {
       capturedPrompt = prompt;
+      capturedOptions = options;
       const result: AgentExecutionResult = {
         executionId: 'mock-exec',
         status: 'completed',
@@ -111,7 +120,11 @@ function createMockAgent(responseText = 'mock response'): {
     preflight: async () => ({ success: true, durationMs: 0 }),
   };
 
-  return { agent, getCapturedPrompt: () => capturedPrompt };
+  return {
+    agent,
+    getCapturedPrompt: () => capturedPrompt,
+    getCapturedOptions: () => capturedOptions,
+  };
 }
 
 describe('ChatEngine buildPrompt format', () => {
@@ -272,5 +285,67 @@ describe('ChatEngine buildPrompt format', () => {
     expect(prompt).not.toContain('User: Message 2');
     // Current user message (Message 3) is in history (pushed before buildPrompt)
     expect(prompt).toContain('User: Message 3');
+  });
+});
+
+describe('createPrdChatEngine model propagation', () => {
+  test('forwards --model to the agent via execute flags', async () => {
+    const { agent, getCapturedOptions } = createMockAgent();
+    const engine = createPrdChatEngine(agent, { model: 'opus' });
+
+    await engine.sendMessage('Build a login page');
+
+    const flags = getCapturedOptions()?.flags;
+    expect(flags).toEqual(['--model', 'opus']);
+  });
+
+  test('forwards provider/model format unchanged', async () => {
+    const { agent, getCapturedOptions } = createMockAgent();
+    const engine = createPrdChatEngine(agent, {
+      model: 'moonshotai/kimi-k2.6:siliconflow/fp8',
+    });
+
+    await engine.sendMessage('Build a login page');
+
+    const flags = getCapturedOptions()?.flags;
+    expect(flags).toEqual([
+      '--model',
+      'moonshotai/kimi-k2.6:siliconflow/fp8',
+    ]);
+  });
+
+  test('does not inject --model flag when model is omitted', async () => {
+    const { agent, getCapturedOptions } = createMockAgent();
+    const engine = createPrdChatEngine(agent, {});
+
+    await engine.sendMessage('Hello');
+
+    const flags = getCapturedOptions()?.flags;
+    // Either undefined or an array without --model is acceptable
+    expect(flags === undefined || !flags.includes('--model')).toBe(true);
+  });
+});
+
+describe('createTaskChatEngine model propagation', () => {
+  test('forwards --model to the agent via execute flags', async () => {
+    const { agent, getCapturedOptions } = createMockAgent();
+    const engine = createTaskChatEngine(agent, {
+      model: 'anthropic/claude-3-5-sonnet',
+    });
+
+    await engine.sendMessage('Create tasks');
+
+    const flags = getCapturedOptions()?.flags;
+    expect(flags).toEqual(['--model', 'anthropic/claude-3-5-sonnet']);
+  });
+
+  test('does not inject --model flag when model is omitted', async () => {
+    const { agent, getCapturedOptions } = createMockAgent();
+    const engine = createTaskChatEngine(agent, {});
+
+    await engine.sendMessage('Create tasks');
+
+    const flags = getCapturedOptions()?.flags;
+    expect(flags === undefined || !flags.includes('--model')).toBe(true);
   });
 });

--- a/src/chat/engine.ts
+++ b/src/chat/engine.ts
@@ -374,6 +374,15 @@ export class ChatEngine {
 }
 
 /**
+ * Build agent-execute flags for the chat engine.
+ * Mirrors run.tsx engine which injects --model at execute time.
+ */
+function buildAgentFlags(options: { model?: string }): string[] | undefined {
+  if (!options.model) return undefined;
+  return ['--model', options.model];
+}
+
+/**
  * Create a chat engine configured for PRD generation.
  */
 export function createPrdChatEngine(
@@ -383,6 +392,7 @@ export function createPrdChatEngine(
     timeout?: number;
     prdSkill?: string;
     prdSkillSource?: string;
+    model?: string;
   } = {}
 ): ChatEngine {
   const systemPrompt = options.prdSkillSource
@@ -391,11 +401,14 @@ export function createPrdChatEngine(
       ? buildPrdSystemPrompt(options.prdSkill)
       : PRD_SYSTEM_PROMPT;
 
+  const flags = buildAgentFlags(options);
+
   return new ChatEngine({
     agent,
     systemPrompt,
     cwd: options.cwd,
     timeout: options.timeout ?? 0,
+    ...(flags ? { agentOptions: { flags } } : {}),
   });
 }
 
@@ -404,13 +417,17 @@ export function createTaskChatEngine(
   options: {
     cwd?: string;
     timeout?: number;
+    model?: string;
   } = {}
 ): ChatEngine {
+  const flags = buildAgentFlags(options);
+
   return new ChatEngine({
     agent,
     systemPrompt: TASK_SYSTEM_PROMPT,
     cwd: options.cwd,
     timeout: options.timeout ?? 0,
+    ...(flags ? { agentOptions: { flags } } : {}),
   });
 }
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -111,6 +111,15 @@ Convert Options:
   --branch, -b <name> Git branch name (prompts if not provided)
   --force, -f         Overwrite existing files
 
+Create-PRD Options:
+  --agent, -a <name>  Override agent plugin (e.g., claude, opencode)
+  --model <name>      Override model (e.g., opus, anthropic/claude-3-5-sonnet)
+  --variant <level>   Model variant/reasoning effort (e.g., minimal, high, max)
+  --output, -o <dir>  Output directory for PRD files (default: ./tasks)
+  --prd-skill <name>  PRD skill folder inside skills_dir
+  --timeout, -t <ms>  Timeout for AI agent calls (0 = no timeout)
+  --force, -f         Overwrite existing files
+
 Examples:
   ralph-tui                              # Start execution (same as 'run')
   ralph-tui create-prd                   # Create a new PRD interactively

--- a/src/commands/create-prd-utils.ts
+++ b/src/commands/create-prd-utils.ts
@@ -28,6 +28,12 @@ export interface CreatePrdArgs {
   /** Override agent plugin */
   agent?: string;
 
+  /** Override model for the agent (e.g., opus, sonnet, anthropic/claude-3-5-sonnet) */
+  model?: string;
+
+  /** Override model variant for the agent (e.g., minimal, high, max for Gemini) */
+  variant?: string;
+
   /** Timeout for agent calls in milliseconds */
   timeout?: number;
 
@@ -61,6 +67,10 @@ export function parseCreatePrdArgs(args: string[]): CreatePrdArgs {
       result.force = true;
     } else if (arg === "--agent" || arg === "-a") {
       result.agent = args[++i];
+    } else if (arg === "--model") {
+      result.model = args[++i];
+    } else if (arg === "--variant") {
+      result.variant = args[++i];
     } else if (arg === "--timeout" || arg === "-t") {
       const timeout = parseInt(args[++i] ?? "", 10);
       if (!isNaN(timeout)) {
@@ -118,6 +128,8 @@ Options:
   --cwd, -C <path>       Working directory (default: current directory)
   --output, -o <dir>     Output directory for PRD files (default: ./tasks)
   --agent, -a <name>     Agent plugin to use (default: from config)
+  --model <name>         Override model (e.g., opus, sonnet, anthropic/claude-3-5-sonnet)
+  --variant <level>      Model variant/reasoning effort (e.g., minimal, high, max)
   --timeout, -t <ms>     Timeout for AI agent calls in ms (default: 0 = no timeout)
   --prd-skill <name>     PRD skill folder inside skills_dir
   --force, -f            Overwrite existing files without prompting
@@ -138,6 +150,8 @@ Examples:
   ralph-tui create-prd                      # Start AI-powered PRD creation
   ralph-tui prime                           # Alias for create-prd
   ralph-tui create-prd --agent claude       # Use specific agent
+  ralph-tui create-prd --agent claude --model opus
+  ralph-tui create-prd --agent opencode --model anthropic/claude-3-5-sonnet
   ralph-tui create-prd --output ./docs      # Save PRD to custom directory
 `);
 }

--- a/src/commands/create-prd.test.tsx
+++ b/src/commands/create-prd.test.tsx
@@ -84,6 +84,21 @@ describe('parseCreatePrdArgs', () => {
     expect(args.agent).toBe('opencode');
   });
 
+  test('parses --model flag', () => {
+    const args = parseCreatePrdArgs(['--model', 'opus']);
+    expect(args.model).toBe('opus');
+  });
+
+  test('parses --model with provider/model format', () => {
+    const args = parseCreatePrdArgs(['--model', 'anthropic/claude-3-5-sonnet']);
+    expect(args.model).toBe('anthropic/claude-3-5-sonnet');
+  });
+
+  test('parses --variant flag', () => {
+    const args = parseCreatePrdArgs(['--variant', 'high']);
+    expect(args.variant).toBe('high');
+  });
+
   test('parses --timeout flag', () => {
     const args = parseCreatePrdArgs(['--timeout', '5000']);
     expect(args.timeout).toBe(5000);
@@ -108,11 +123,15 @@ describe('parseCreatePrdArgs', () => {
     const args = parseCreatePrdArgs([
       '--cwd', '/test',
       '--agent', 'claude',
+      '--model', 'opus',
+      '--variant', 'high',
       '--timeout', '3000',
       '--force',
     ]);
     expect(args.cwd).toBe('/test');
     expect(args.agent).toBe('claude');
+    expect(args.model).toBe('opus');
+    expect(args.variant).toBe('high');
     expect(args.timeout).toBe(3000);
     expect(args.force).toBe(true);
   });

--- a/src/commands/create-prd.tsx
+++ b/src/commands/create-prd.tsx
@@ -109,7 +109,11 @@ async function loadPrdSkillSource(
 /**
  * Get the configured agent plugin.
  */
-async function getAgent(agentName?: string): Promise<AgentPlugin | null> {
+async function getAgent(options: {
+  agent?: string;
+  model?: string;
+  variant?: string;
+}): Promise<AgentPlugin | null> {
   try {
     const cwd = process.cwd();
     const storedConfig = await loadStoredConfig(cwd);
@@ -121,13 +125,24 @@ async function getAgent(agentName?: string): Promise<AgentPlugin | null> {
 
     // Determine target agent
     const targetAgent =
-      agentName || storedConfig.agent || storedConfig.defaultAgent || "claude";
+      options.agent ||
+      storedConfig.agent ||
+      storedConfig.defaultAgent ||
+      "claude";
 
-    // Build agent config
+    // Build agent config. CLI --variant is injected into plugin options so the
+    // agent picks it up during initialize(), mirroring run's applyAgentOptions.
+    const agentOptions: Record<string, unknown> = {
+      ...(storedConfig.agentOptions || {}),
+    };
+    if (options.variant) {
+      agentOptions.variant = options.variant;
+    }
+
     const agentConfig: AgentPluginConfig = {
       name: targetAgent,
       plugin: targetAgent,
-      options: storedConfig.agentOptions || {},
+      options: agentOptions,
       command: storedConfig.command,
       envExclude: storedConfig.envExclude,
       envPassthrough: storedConfig.envPassthrough,
@@ -135,6 +150,15 @@ async function getAgent(agentName?: string): Promise<AgentPlugin | null> {
 
     // Get agent instance
     const agent = await registry.getInstance(agentConfig);
+
+    // Validate model if specified, mirroring the engine's preflight in run.
+    if (options.model) {
+      const modelError = agent.validateModel(options.model);
+      if (modelError) {
+        console.error(`Invalid --model value: ${modelError}`);
+        return null;
+      }
+    }
 
     // Check if agent is ready
     const isReady = await agent.isReady();
@@ -166,7 +190,11 @@ async function runChatMode(
   parsedArgs: CreatePrdArgs,
 ): Promise<PrdCreationResult | null> {
   // Get agent
-  const agent = await getAgent(parsedArgs.agent);
+  const agent = await getAgent({
+    agent: parsedArgs.agent,
+    model: parsedArgs.model,
+    variant: parsedArgs.variant,
+  });
   if (!agent) {
     console.error("");
     console.error("Chat mode requires an AI agent. Options:");
@@ -310,6 +338,7 @@ async function runChatMode(
         timeout={timeout}
         prdSkill={parsedArgs.prdSkill}
         prdSkillSource={parsedArgs.prdSkillSource}
+        model={parsedArgs.model}
         trackerLabels={parsedArgs.trackerLabels}
         onComplete={handleComplete}
         onCancel={handleCancel}

--- a/src/tui/components/PrdChatApp.tsx
+++ b/src/tui/components/PrdChatApp.tsx
@@ -75,6 +75,12 @@ export interface PrdChatAppProps {
 
   prdSkillSource?: string;
 
+  /**
+   * Override model passed to the agent via --model at execute time.
+   * Used to match `ralph-tui run --model <name>` behavior in PRD chat mode.
+   */
+  model?: string;
+
   /** Labels to apply to created beads issues (from config trackerOptions) */
   trackerLabels?: string[];
 
@@ -350,6 +356,7 @@ export function PrdChatApp({
   timeout = 0,
   prdSkill,
   prdSkillSource,
+  model,
   trackerLabels,
   onComplete,
   onCancel,
@@ -431,8 +438,9 @@ export function PrdChatApp({
       timeout,
       prdSkill,
       prdSkillSource,
+      model,
     });
-    const taskEngine = createTaskChatEngine(agent, { cwd, timeout });
+    const taskEngine = createTaskChatEngine(agent, { cwd, timeout, model });
 
     // Subscribe to events
     const unsubscribe = engine.on((event: ChatEvent) => {
@@ -461,7 +469,7 @@ export function PrdChatApp({
       isMountedRef.current = false;
       unsubscribe();
     };
-  }, [agent, cwd, timeout, prdSkill, prdSkillSource, onError]);
+  }, [agent, cwd, timeout, prdSkill, prdSkillSource, model, onError]);
 
   /**
    * Handle PRD detection - save file and switch to review phase

--- a/tests/commands/create-prd.test.ts
+++ b/tests/commands/create-prd.test.ts
@@ -27,6 +27,8 @@ describe('create-prd command', () => {
       expect(logs[0]).toContain('create-prd');
       expect(logs[0]).toContain('--output');
       expect(logs[0]).toContain('--agent');
+      expect(logs[0]).toContain('--model');
+      expect(logs[0]).toContain('--variant');
     });
   });
 
@@ -49,6 +51,53 @@ describe('create-prd command', () => {
     test('parses -a shorthand', () => {
       const result = parseCreatePrdArgs(['-a', 'claude']);
       expect(result.agent).toBe('claude');
+    });
+
+    test('parses --model with simple name', () => {
+      const result = parseCreatePrdArgs(['--model', 'opus']);
+      expect(result.model).toBe('opus');
+    });
+
+    test('parses --model with provider/model format', () => {
+      const result = parseCreatePrdArgs([
+        '--model',
+        'anthropic/claude-3-5-sonnet',
+      ]);
+      expect(result.model).toBe('anthropic/claude-3-5-sonnet');
+    });
+
+    test('parses --model with OpenRouter triple format', () => {
+      // From issue #383 — exact value the user wanted to pass through
+      const result = parseCreatePrdArgs([
+        '--model',
+        'moonshotai/kimi-k2.6:siliconflow/fp8',
+      ]);
+      expect(result.model).toBe('moonshotai/kimi-k2.6:siliconflow/fp8');
+    });
+
+    test('parses --variant', () => {
+      const result = parseCreatePrdArgs(['--variant', 'high']);
+      expect(result.variant).toBe('high');
+    });
+
+    test('parses --model alongside --agent and --variant', () => {
+      const result = parseCreatePrdArgs([
+        '--agent',
+        'opencode',
+        '--model',
+        'anthropic/claude-3-5-sonnet',
+        '--variant',
+        'max',
+      ]);
+      expect(result.agent).toBe('opencode');
+      expect(result.model).toBe('anthropic/claude-3-5-sonnet');
+      expect(result.variant).toBe('max');
+    });
+
+    test('model and variant are undefined when not provided', () => {
+      const result = parseCreatePrdArgs(['--agent', 'claude']);
+      expect(result.model).toBeUndefined();
+      expect(result.variant).toBeUndefined();
     });
 
     test('parses --stories with count', () => {

--- a/website/content/docs/cli/create-prd.mdx
+++ b/website/content/docs/cli/create-prd.mdx
@@ -27,6 +27,8 @@ ralph-tui prime    # Same as create-prd
 |--------|-------------|
 | `--chat`, `--ai` | Use AI-powered chat mode (recommended) |
 | `--agent <name>` | Override agent for chat mode |
+| `--model <name>` | Override model (e.g., `opus`, `anthropic/claude-3-5-sonnet`) |
+| `--variant <level>` | Model variant / reasoning effort (e.g., `minimal`, `high`, `max`) |
 | `--prd-skill <name>` | Use custom PRD skill from `skills_dir` |
 | `--output, -o <dir>` | Output directory for PRD files (default: `./tasks`) |
 | `--stories, -n <count>` | Number of user stories (template mode only) |
@@ -44,6 +46,25 @@ ralph-tui create-prd --chat
 # Use a specific agent
 ralph-tui create-prd --chat --agent opencode
 ```
+
+### Selecting a Model or Variant
+
+`--model` and `--variant` work the same way they do for [`ralph-tui run`](/docs/cli/run). They let you pin the agent to a specific model or reasoning effort for the PRD conversation:
+
+```bash
+# Claude Code with the opus model
+ralph-tui create-prd --agent claude --model opus
+
+# OpenCode + OpenRouter (provider/model format)
+ralph-tui create-prd --agent opencode --model moonshotai/kimi-k2.6:siliconflow/fp8
+
+# Pair a model with a reasoning-effort variant
+ralph-tui create-prd --agent opencode --model google/gemini-2.5-pro --variant high
+```
+
+<Callout type="tip">
+The `--model` value is validated by the selected agent before the chat starts. If the agent doesn't recognize the model name, you'll get an error before the PRD session opens. `--variant` is forwarded to the agent CLI as-is (validation is delegated to the agent).
+</Callout>
 
 ### Template Mode
 


### PR DESCRIPTION
## Summary

- Adds `--model` and `--variant` CLI flags to `create-prd` / `prime` command, mirroring the existing flags on `ralph-tui run`
- `--model` is forwarded to the agent at execute time via `agentOptions.flags`, supporting simple names (`opus`), provider/model format (`anthropic/claude-3-5-sonnet`), and OpenRouter triple format (`moonshotai/kimi-k2.6:siliconflow/fp8`)
- `--variant` is injected into agent plugin options during `initialize()` so agents like Gemini can apply reasoning-effort levels (`minimal`, `high`, `max`)
- Model value is validated by the agent before the chat session opens; invalid values produce an early error
- `createPrdChatEngine` and `createTaskChatEngine` both accept a `model` option and build the `--model` flag internally via a shared `buildAgentFlags` helper
- `PrdChatApp` accepts and threads through the `model` prop; dependency array updated accordingly
- CLI help text and docs site (`create-prd.mdx`) updated with new flags and usage examples

## Testing

- Unit tests added in `src/chat/engine.test.ts` covering `createPrdChatEngine` and `createTaskChatEngine` model propagation (with model, without model, provider/model format, OpenRouter format)
- Unit tests added in `src/commands/create-prd.test.tsx` and `tests/commands/create-prd.test.ts` covering `parseCreatePrdArgs` for `--model` and `--variant` individually and in combination with `--agent`
- Help output test updated to assert `--model` and `--variant` appear in the help string
- End-to-end UI path (agent preflight + chat session with model flag) not run in CI; manual verification recommended with `ralph-tui create-prd --agent claude --model opus`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--model` flag to override the AI agent model for PRD creation.
  * Added `--variant` flag to select model variant/reasoning effort.
  * Models are validated by the agent before sessions start.

* **Documentation**
  * Updated CLI help and documentation with examples of using the new `--model` and `--variant` options.

* **Tests**
  * Expanded test coverage for model and variant flag parsing and propagation across chat engines.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/subsy/ralph-tui/pull/388)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->