### PR TITLE
Add multi-epic orchestration support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,10 @@ jobs:
           bun test src/commands/run.test.ts --coverage --coverage-reporter=text --coverage-reporter=lcov 2>&1 | tee -a coverage-output.txt
           cp coverage/lcov.info coverage-parts/run.lcov
 
+          echo "=== Running remote server tests ===" | tee -a coverage-output.txt
+          bun test src/remote/server.test.ts --coverage --coverage-reporter=text --coverage-reporter=lcov 2>&1 | tee -a coverage-output.txt
+          cp coverage/lcov.info coverage-parts/remote-server.lcov
+
           echo "=== Running src/config/ ===" | tee -a coverage-output.txt
           bun test src/config/ --coverage --coverage-reporter=text --coverage-reporter=lcov 2>&1 | tee -a coverage-output.txt
           cp coverage/lcov.info coverage-parts/config.lcov
@@ -152,6 +156,10 @@ jobs:
           echo "=== Running src/plugins/ (excluding beads-bv, beads-rust, and linear) ===" | tee -a coverage-output.txt
           bun test src/plugins/agents/ src/plugins/trackers/builtin/beads.test.ts --coverage --coverage-reporter=text --coverage-reporter=lcov 2>&1 | tee -a coverage-output.txt || true
           cp coverage/lcov.info coverage-parts/plugins.lcov || true
+
+          echo "=== Running multi-scope tracker tests ===" | tee -a coverage-output.txt
+          bun test src/plugins/trackers/multi-scope.test.ts --coverage --coverage-reporter=text --coverage-reporter=lcov 2>&1 | tee -a coverage-output.txt
+          cp coverage/lcov.info coverage-parts/multi-scope.lcov
 
           # Linear tracker tests: client.test.ts and index.test.ts both use mock.module()
           # (client mocks @linear/sdk, index mocks ./client.js) so they must run in separate processes.
@@ -241,7 +249,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           # Upload all batch coverage files - Codecov will merge them correctly
-          files: ./coverage-parts/tests.lcov,./coverage-parts/tests-beads-rust-bv.lcov,./coverage-parts/tests-info.lcov,./coverage-parts/tests-run-remote-only.lcov,./coverage-parts/doctor.lcov,./coverage-parts/info.lcov,./coverage-parts/skills.lcov,./coverage-parts/run.lcov,./coverage-parts/config.lcov,./coverage-parts/engine.lcov,./coverage-parts/beads-bv.lcov,./coverage-parts/beads-rust.lcov,./coverage-parts/beads.lcov,./coverage-parts/plugins.lcov,./coverage-parts/jira.lcov,./coverage-parts/linear-body.lcov,./coverage-parts/linear-client.lcov,./coverage-parts/linear-index.lcov,./coverage-parts/session.lcov,./coverage-parts/sandbox.lcov,./coverage-parts/wizard.lcov,./coverage-parts/setup.lcov,./coverage-parts/skill-installer-spawn.lcov,./coverage-parts/migration-install.lcov,./coverage-parts/templates.lcov,./coverage-parts/tui.lcov,./coverage-parts/prd.lcov,./coverage-parts/chat.lcov,./coverage-parts/parallel.lcov
+          files: ./coverage-parts/tests.lcov,./coverage-parts/tests-beads-rust-bv.lcov,./coverage-parts/tests-info.lcov,./coverage-parts/tests-run-remote-only.lcov,./coverage-parts/doctor.lcov,./coverage-parts/info.lcov,./coverage-parts/skills.lcov,./coverage-parts/run.lcov,./coverage-parts/remote-server.lcov,./coverage-parts/config.lcov,./coverage-parts/engine.lcov,./coverage-parts/beads-bv.lcov,./coverage-parts/beads-rust.lcov,./coverage-parts/beads.lcov,./coverage-parts/plugins.lcov,./coverage-parts/multi-scope.lcov,./coverage-parts/jira.lcov,./coverage-parts/linear-body.lcov,./coverage-parts/linear-client.lcov,./coverage-parts/linear-index.lcov,./coverage-parts/session.lcov,./coverage-parts/sandbox.lcov,./coverage-parts/wizard.lcov,./coverage-parts/setup.lcov,./coverage-parts/skill-installer-spawn.lcov,./coverage-parts/migration-install.lcov,./coverage-parts/templates.lcov,./coverage-parts/tui.lcov,./coverage-parts/prd.lcov,./coverage-parts/chat.lcov,./coverage-parts/parallel.lcov
           fail_ci_if_error: false
           verbose: true
         env:

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ ralph-tui create-prd --output ./docs
 | `e` | Edit current remote (when viewing remote tab) |
 | `x` | Delete current remote (when viewing remote tab) |
 
+**Multi-epic sessions:** Repeated `--epic` and comma-separated `--epics` create one Ralph session across all selected hierarchy-tracker epics. Ralph uses one scheduler, one repo lock, one session branch, one merge queue, and task-scoped worktrees. The TUI scope filter (`g`/`G`) is only a local view filter over that session.
+
 **Dashboard (`d` key):** Toggle a status panel showing:
 - Current execution status and active task
 - Agent name and model (e.g., `claude-code`, `anthropic/claude-sonnet`)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ ralph-tui run --prd ./prd.json
 # Run with a Beads epic
 ralph-tui run --epic my-epic-id
 
+# Run one parallel session across multiple Beads epics
+ralph-tui run --parallel --epic ui-epic --epic backend-epic
+ralph-tui run --parallel --epics ui-epic,backend-epic
+
 # Override agent or model
 ralph-tui run --agent claude --model sonnet
 ralph-tui run --agent opencode --model anthropic/claude-3-5-sonnet
@@ -145,6 +149,8 @@ ralph-tui create-prd --output ./docs
 | `s` | Start execution |
 | `p` | Pause/Resume |
 | `d` | Toggle dashboard |
+| `g` | Cycle scope filter in multi-epic sessions |
+| `G` | Reset scope filter to All |
 | `T` | Toggle subagent tree panel (Shift+T) |
 | `t` | Cycle subagent detail level |
 | `o` | Cycle right panel views |

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,6 +28,7 @@ ignore:
   - "dist/**/*"
   # TUI components are React/blessed rendering code - hard to unit test meaningfully
   - "src/tui/**/*"
+  - "src/commands/*.tsx"
   - "src/commands/**/*.tsx"
 
 # Comment settings for PRs

--- a/src/commands/resume.tsx
+++ b/src/commands/resume.tsx
@@ -197,8 +197,10 @@ export function formatSessionEntry(entry: SessionRegistryEntry, index?: number):
                      entry.status === 'running' ? '▶' :
                      entry.status === 'interrupted' ? '⚠' : '•';
   const sandboxTag = entry.sandbox ? ' [sandbox]' : '';
-  const trackerInfo = entry.epicId ? `epic:${entry.epicId}` :
-                      entry.prdPath ? `prd:${entry.prdPath}` : entry.trackerPlugin;
+  const trackerInfo = entry.epicIds && entry.epicIds.length > 0
+    ? `epic:${entry.epicIds.join(',')}`
+    : entry.epicId ? `epic:${entry.epicId}`
+      : entry.prdPath ? `prd:${entry.prdPath}` : entry.trackerPlugin;
 
   return `${prefix}${statusIcon} ${shortId}  ${entry.status.padEnd(11)}  ${entry.agentPlugin.padEnd(10)}  ${trackerInfo}${sandboxTag}\n   ${entry.cwd}`;
 }
@@ -727,7 +729,11 @@ export async function executeResumeCommand(args: string[]): Promise<void> {
   if (shouldWarnAboutTrackerMismatch(engineState.totalTasks, sessionTotalTasks)) {
     console.warn('\nWarning: Session has task history but tracker returned no tasks.');
     console.warn('This may happen if:');
-    if (resumedState.trackerState.epicId) {
+    if (resumedState.trackerState.epicIds?.length) {
+      console.warn(
+        `  - The configured epic IDs "${resumedState.trackerState.epicIds.join(', ')}" no longer exist`
+      );
+    } else if (resumedState.trackerState.epicId) {
       console.warn(`  - The epic ID "${resumedState.trackerState.epicId}" no longer exists`);
     }
     if (resumedState.trackerState.prdPath) {

--- a/src/commands/resume.tsx
+++ b/src/commands/resume.tsx
@@ -43,7 +43,11 @@ import { registerBuiltinAgents } from '../plugins/agents/builtin/index.js';
 import { registerBuiltinTrackers } from '../plugins/trackers/builtin/index.js';
 import { getAgentRegistry } from '../plugins/agents/registry.js';
 import { getTrackerRegistry } from '../plugins/trackers/registry.js';
-import type { TrackerTask } from '../plugins/trackers/types.js';
+import {
+  MultiScopeTrackerPlugin,
+  createExecutionScopeFromTask,
+} from '../plugins/trackers/multi-scope.js';
+import type { ExecutionScope, TrackerPlugin, TrackerTask } from '../plugins/trackers/types.js';
 import { RunApp } from '../tui/components/RunApp.js';
 
 /**
@@ -64,6 +68,40 @@ export function shouldWarnAboutTrackerMismatch(
   sessionTotalTasks: number
 ): boolean {
   return engineTotalTasks === 0 && sessionTotalTasks > 0;
+}
+
+async function resolveExecutionScopes(
+  tracker: TrackerPlugin,
+  epicIds: string[],
+  persistedScopes?: ExecutionScope[]
+): Promise<ExecutionScope[]> {
+  if (epicIds.length === 0) {
+    return [];
+  }
+
+  const persistedScopeMap = new Map((persistedScopes ?? []).map((scope) => [scope.id, scope]));
+  let epics: TrackerTask[] = [];
+  try {
+    epics = await tracker.getEpics();
+  } catch {
+    epics = [];
+  }
+
+  return epicIds.map((epicId) => {
+    const persistedScope = persistedScopeMap.get(epicId);
+    if (persistedScope) {
+      return persistedScope;
+    }
+
+    const epic = epics.find((candidate) => candidate.id === epicId);
+    return epic
+      ? createExecutionScopeFromTask(epic)
+      : {
+          id: epicId,
+          title: epicId,
+          type: 'epic',
+        };
+  });
 }
 
 /**
@@ -313,7 +351,8 @@ async function runWithTui(
   initialState: PersistedSessionState,
   initialTasks: TrackerTask[],
   trackerType?: string,
-  currentModel?: string
+  currentModel?: string,
+  executionScopes: ExecutionScope[] = []
 ): Promise<PersistedSessionState> {
   let currentState = initialState;
 
@@ -410,6 +449,7 @@ async function runWithTui(
       }}
       onStart={handleStart}
       trackerType={trackerType}
+      executionScopes={executionScopes}
       initialSubagentPanelVisible={initialState.subagentPanelVisible ?? false}
       onSubagentPanelVisibilityChange={handleSubagentPanelVisibilityChange}
       currentModel={currentModel}
@@ -605,6 +645,7 @@ export async function executeResumeCommand(args: string[]): Promise<void> {
     agent: persistedState.agentPlugin,
     tracker: persistedState.trackerState.plugin,
     epicId: persistedState.trackerState.epicId,
+    epicIds: persistedState.trackerState.epicIds,
     prdPath: persistedState.trackerState.prdPath,
     iterations: persistedState.maxIterations,
     cwd,
@@ -652,9 +693,25 @@ export async function executeResumeCommand(args: string[]): Promise<void> {
 
   // Create and initialize engine
   const engine = new ExecutionEngine(config);
+  let executionScopes: ExecutionScope[] = [];
+  let trackerForResume: TrackerPlugin | undefined;
 
   try {
-    await engine.initialize();
+    if (config.epicIds && config.epicIds.length > 1) {
+      const trackerRegistry = getTrackerRegistry();
+      trackerForResume = await trackerRegistry.getInstance(config.tracker);
+      executionScopes = await resolveExecutionScopes(
+        trackerForResume,
+        config.epicIds,
+        resumedState.trackerState.executionScopes
+      );
+      await engine.initialize(undefined, {
+        tracker: new MultiScopeTrackerPlugin(trackerForResume, executionScopes),
+      });
+    } else {
+      executionScopes = resumedState.trackerState.executionScopes ?? [];
+      await engine.initialize();
+    }
   } catch (error) {
     console.error(
       'Failed to initialize engine:',
@@ -694,13 +751,21 @@ export async function executeResumeCommand(args: string[]): Promise<void> {
       let tasks: TrackerTask[] = [];
       try {
         const trackerRegistry = getTrackerRegistry();
-        const tracker = await trackerRegistry.getInstance(config.tracker);
+        const tracker = engine.getTracker() ?? trackerForResume ?? await trackerRegistry.getInstance(config.tracker);
         tasks = await tracker.getTasks({ status: ['open', 'in_progress', 'completed'] });
       } catch (error) {
         console.error('Warning: Failed to load tasks:', error);
       }
 
-      finalState = await runWithTui(engine, cwd, resumedState, tasks, config.tracker.plugin, config.model);
+      finalState = await runWithTui(
+        engine,
+        cwd,
+        resumedState,
+        tasks,
+        config.tracker.plugin,
+        config.model,
+        executionScopes
+      );
     } else {
       finalState = await runHeadless(engine, cwd, resumedState);
     }

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -22,8 +22,14 @@ import {
   type TaskRangeFilter,
   type ParallelConflictState,
 } from './run.js';
-import type { TrackerTask } from '../plugins/trackers/types.js';
-import type { FileConflict, ConflictResolutionResult, ParallelExecutorState, WorktreeInfo } from '../parallel/types.js';
+import type { ExecutionScope, TrackerTask } from '../plugins/trackers/types.js';
+import type {
+  FileConflict,
+  ConflictResolutionResult,
+  ParallelExecutorState,
+  WorktreeInfo,
+  WorkerResult,
+} from '../parallel/types.js';
 import type { PersistedSessionState } from '../session/persistence.js';
 
 /**
@@ -442,6 +448,7 @@ describe('parallel summary helpers', () => {
       currentGroupIndex: 0,
       totalGroups: 1,
       workers: [],
+      workerResults: [],
       mergeQueue: [],
       completedMerges: [],
       activeConflicts: [],
@@ -463,6 +470,33 @@ describe('parallel summary helpers', () => {
       active: false,
       dirty: true,
       createdAt: '2026-02-23T10:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  function createScopedTask(id: string, scope: ExecutionScope): TrackerTask {
+    return {
+      id,
+      title: id,
+      status: 'open',
+      priority: 2,
+      executionScope: scope,
+    } as TrackerTask & { executionScope: ExecutionScope };
+  }
+
+  function createWorkerResult(
+    task: TrackerTask,
+    overrides: Partial<WorkerResult> = {}
+  ): WorkerResult {
+    return {
+      workerId: 'worker-1',
+      task,
+      success: true,
+      iterationsRun: 1,
+      taskCompleted: true,
+      durationMs: 1000,
+      branchName: `ralph-parallel/${task.id}`,
+      commitCount: 1,
       ...overrides,
     };
   }
@@ -553,6 +587,83 @@ describe('parallel summary helpers', () => {
     expect(output).toContain('Preserved worktrees:    1');
     expect(output).toContain('ralph-parallel/task-1 (TASK-1)');
     expect(output).toContain('/tmp/worktrees/worker-1');
+  });
+
+  test('scope summaries include worker-phase failures before merge queue', () => {
+    const uiScope: ExecutionScope = { id: 'ui', title: 'UI', type: 'epic' };
+    const backendScope: ExecutionScope = { id: 'backend', title: 'Backend', type: 'epic' };
+    const uiTask = createScopedTask('ui-task', uiScope);
+    const backendTask = createScopedTask('backend-task', backendScope);
+
+    const summary = createParallelRunSummary({
+      sessionId: 'session-4',
+      mode: 'headless',
+      executorState: createMockExecutorState({
+        scopes: [uiScope, backendScope],
+        taskGraph: {
+          nodes: new Map([
+            ['ui-task', {
+              task: uiTask,
+              dependencies: [],
+              dependents: [],
+              depth: 0,
+              inCycle: false,
+            }],
+            ['backend-task', {
+              task: backendTask,
+              dependencies: [],
+              dependents: [],
+              depth: 0,
+              inCycle: false,
+            }],
+          ]),
+          groups: [],
+          cyclicTaskIds: [],
+          actionableTaskCount: 2,
+          maxParallelism: 2,
+          recommendParallel: true,
+        },
+        workerResults: [
+          createWorkerResult(uiTask, {
+            success: false,
+            taskCompleted: false,
+            error: 'worker failed',
+          }),
+          createWorkerResult(backendTask),
+        ],
+        mergeQueue: [
+          {
+            id: 'merge-1',
+            workerResult: createWorkerResult(backendTask),
+            status: 'completed',
+            backupTag: 'backup',
+            sourceBranch: 'ralph-parallel/backend-task',
+            commitMessage: 'complete backend-task',
+            queuedAt: '2026-02-23T10:00:00.000Z',
+          },
+        ],
+      }),
+      directMerge: false,
+      sessionBranch: 'ralph-session/session-4',
+      originalBranch: 'main',
+      returnToOriginalBranchError: null,
+      preservedRecoveryWorktrees: [],
+    });
+
+    expect(summary.scopeSummaries).toEqual([
+      {
+        scope: uiScope,
+        totalTasks: 1,
+        tasksCompleted: 0,
+        tasksFailed: 1,
+      },
+      {
+        scope: backendScope,
+        totalTasks: 1,
+        tasksCompleted: 1,
+        tasksFailed: 0,
+      },
+    ]);
   });
 });
 

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -19,10 +19,11 @@ import {
   buildSequentialSummaryFilePath,
   createSequentialRunSummary,
   formatSequentialRunSummary,
+  resolveExecutionScopes,
   type TaskRangeFilter,
   type ParallelConflictState,
 } from './run.js';
-import type { ExecutionScope, TrackerTask } from '../plugins/trackers/types.js';
+import type { ExecutionScope, TrackerPlugin, TrackerTask } from '../plugins/trackers/types.js';
 import type {
   FileConflict,
   ConflictResolutionResult,
@@ -42,6 +43,12 @@ function createTasks(count: number): TrackerTask[] {
     status: 'open' as const,
     priority: 2 as const,
   }));
+}
+
+function createTrackerWithEpics(getEpics: () => Promise<TrackerTask[]>): TrackerPlugin {
+  return {
+    getEpics,
+  } as TrackerPlugin;
 }
 
 describe('filterTasksByRange', () => {
@@ -192,6 +199,68 @@ describe('filterTasksByRange', () => {
 
       expect(result.message).toBe('Task range all: 5 of 5 tasks selected');
     });
+  });
+});
+
+describe('resolveExecutionScopes', () => {
+  test('resolves matching tracker epics and falls back per missing epic ID', async () => {
+    const tracker = createTrackerWithEpics(async () => [
+      {
+        id: 'ui-epic',
+        title: 'UI Epic',
+        status: 'open',
+        priority: 1,
+        description: 'Frontend work',
+        metadata: { owner: 'ui' },
+      },
+    ]);
+
+    const scopes = await resolveExecutionScopes(tracker, ['ui-epic', 'backend-epic']);
+
+    expect(scopes).toEqual([
+      {
+        id: 'ui-epic',
+        title: 'UI Epic',
+        type: 'epic',
+        description: 'Frontend work',
+        metadata: { owner: 'ui' },
+      },
+      {
+        id: 'backend-epic',
+        title: 'backend-epic',
+        type: 'epic',
+      },
+    ]);
+  });
+
+  test('logs getEpics failures before using synthetic scopes', async () => {
+    const originalError = console.error;
+    const calls: unknown[][] = [];
+    const error = new Error('tracker unavailable');
+    console.error = (...args: unknown[]) => {
+      calls.push(args);
+    };
+
+    try {
+      const tracker = createTrackerWithEpics(async () => {
+        throw error;
+      });
+
+      const scopes = await resolveExecutionScopes(tracker, ['ui-epic']);
+
+      expect(scopes).toEqual([
+        {
+          id: 'ui-epic',
+          title: 'ui-epic',
+          type: 'epic',
+        },
+      ]);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.[0]).toBe('Failed to resolve epics from tracker; using synthetic execution scopes:');
+      expect(calls[0]?.[1]).toBe(error);
+    } finally {
+      console.error = originalError;
+    }
   });
 });
 

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -190,6 +190,37 @@ describe('filterTasksByRange', () => {
 });
 
 describe('parseRunArgs', () => {
+  describe('--epic/--epics parsing', () => {
+    test('preserves single-epic compatibility', () => {
+      const result = parseRunArgs(['--epic', 'ui-epic']);
+
+      expect(result.epicId).toBe('ui-epic');
+      expect(result.epicIds).toEqual(['ui-epic']);
+    });
+
+    test('parses repeated --epic values in order', () => {
+      const result = parseRunArgs(['--parallel', '--epic', 'ui-epic', '--epic', 'backend-epic']);
+
+      expect(result.parallel).toBe(true);
+      expect(result.epicId).toBe('ui-epic');
+      expect(result.epicIds).toEqual(['ui-epic', 'backend-epic']);
+    });
+
+    test('parses comma-separated --epics values', () => {
+      const result = parseRunArgs(['--epics', 'ui-epic,backend-epic,docs-epic']);
+
+      expect(result.epicId).toBe('ui-epic');
+      expect(result.epicIds).toEqual(['ui-epic', 'backend-epic', 'docs-epic']);
+    });
+
+    test('deduplicates repeated epic IDs', () => {
+      const result = parseRunArgs(['--epic', 'ui-epic', '--epics', 'ui-epic,backend-epic']);
+
+      expect(result.epicId).toBe('ui-epic');
+      expect(result.epicIds).toEqual(['ui-epic', 'backend-epic']);
+    });
+  });
+
   describe('--task-range parsing', () => {
     test('parses full range "1-5"', () => {
       const result = parseRunArgs(['--task-range', '1-5']);

--- a/src/commands/run.tsx
+++ b/src/commands/run.tsx
@@ -52,6 +52,7 @@ import type {
   ParallelExecutorState,
   ParallelExecutorStatus,
   WorktreeInfo,
+  WorkerResult,
 } from '../parallel/types.js';
 import type { ParallelEvent } from '../parallel/events.js';
 import { registerBuiltinAgents } from '../plugins/agents/builtin/index.js';
@@ -502,6 +503,10 @@ function getTaskExecutionScope(task: TrackerTask): ExecutionScope | undefined {
   return undefined;
 }
 
+function isFailedWorkerResult(result: WorkerResult): boolean {
+  return !result.success || !result.taskCompleted;
+}
+
 function buildParallelScopeSummaries(
   executorState: ParallelExecutorState
 ): ParallelScopeSummary[] {
@@ -520,6 +525,18 @@ function buildParallelScopeSummaries(
 
   const completed = new Map<string, number>();
   const failed = new Map<string, number>();
+  const incrementFailed = (scopeId: string) => {
+    failed.set(scopeId, (failed.get(scopeId) ?? 0) + 1);
+  };
+
+  for (const result of executorState.workerResults ?? []) {
+    if (!isFailedWorkerResult(result)) continue;
+    const scope = getTaskExecutionScope(result.task);
+    if (!scope) continue;
+    scopes.set(scope.id, scope);
+    incrementFailed(scope.id);
+  }
+
   for (const operation of executorState.mergeQueue) {
     const scope = getTaskExecutionScope(operation.workerResult.task);
     if (!scope) continue;
@@ -528,7 +545,7 @@ function buildParallelScopeSummaries(
     if (operation.status === 'completed') {
       completed.set(scope.id, (completed.get(scope.id) ?? 0) + 1);
     } else if (operation.status === 'failed' || operation.status === 'rolled-back') {
-      failed.set(scope.id, (failed.get(scope.id) ?? 0) + 1);
+      incrementFailed(scope.id);
     }
   }
 
@@ -1620,8 +1637,10 @@ async function showEpicSelectionTui(
     });
 
     const root = createRoot(renderer);
+    let handleSigint = () => {};
 
     const cleanup = () => {
+      process.off('SIGINT', handleSigint);
       renderer.destroy();
     };
 
@@ -1636,7 +1655,7 @@ async function showEpicSelectionTui(
     };
 
     // Handle Ctrl+C during epic selection
-    const handleSigint = () => {
+    handleSigint = () => {
       cleanup();
       resolve(undefined);
     };

--- a/src/commands/run.tsx
+++ b/src/commands/run.tsx
@@ -1637,11 +1637,15 @@ async function showEpicSelectionTui(
     });
 
     const root = createRoot(renderer);
-    let handleSigint = () => {};
 
     const cleanup = () => {
       process.off('SIGINT', handleSigint);
       renderer.destroy();
+    };
+
+    const handleSigint = () => {
+      cleanup();
+      resolve(undefined);
     };
 
     const handleEpicSelected = (epics: TrackerTask[]) => {
@@ -1650,12 +1654,6 @@ async function showEpicSelectionTui(
     };
 
     const handleQuit = () => {
-      cleanup();
-      resolve(undefined);
-    };
-
-    // Handle Ctrl+C during epic selection
-    handleSigint = () => {
       cleanup();
       resolve(undefined);
     };
@@ -1672,7 +1670,7 @@ async function showEpicSelectionTui(
   });
 }
 
-async function resolveExecutionScopes(
+export async function resolveExecutionScopes(
   tracker: TrackerPlugin,
   epicIds: string[]
 ): Promise<ExecutionScope[]> {
@@ -1683,7 +1681,8 @@ async function resolveExecutionScopes(
   let epics: TrackerTask[] = [];
   try {
     epics = await tracker.getEpics();
-  } catch {
+  } catch (error) {
+    console.error('Failed to resolve epics from tracker; using synthetic execution scopes:', error);
     epics = [];
   }
 
@@ -3666,6 +3665,7 @@ export async function executeRunCommand(args: string[]): Promise<void> {
 
   let executionScopes: ExecutionScope[] = [];
   let trackerForRun: TrackerPlugin | undefined;
+  const trackerRegistry = getTrackerRegistry();
 
   // If using beads tracker without epic, show epic selection TUI
   const isBeadsTracker = config.tracker.plugin === 'beads' || config.tracker.plugin === 'beads-bv' || config.tracker.plugin === 'beads-rust';
@@ -3673,7 +3673,6 @@ export async function executeRunCommand(args: string[]): Promise<void> {
     console.log('No epic specified. Loading epic selection...');
 
     // Get tracker instance for epic selection
-    const trackerRegistry = getTrackerRegistry();
     const tracker = await trackerRegistry.getInstance(config.tracker);
     trackerForRun = tracker;
 
@@ -3699,12 +3698,6 @@ export async function executeRunCommand(args: string[]): Promise<void> {
 
     console.log(`Selected epic${selectedEpics.length > 1 ? 's' : ''}: ${config.epicIds.join(', ')}`);
     console.log('');
-  }
-
-  if (config.epicIds && config.epicIds.length > 0 && executionScopes.length === 0) {
-    const trackerRegistry = getTrackerRegistry();
-    trackerForRun = trackerForRun ?? await trackerRegistry.getInstance(config.tracker);
-    executionScopes = await resolveExecutionScopes(trackerForRun, config.epicIds);
   }
 
   // Detect and recover stale sessions EARLY (before any prompts)
@@ -3776,12 +3769,18 @@ export async function executeRunCommand(args: string[]): Promise<void> {
       executionScopes = session.executionScopes ?? executionScopes;
     }
   } else {
-    // Create new session (task count will be updated after tracker init)
-    // Note: Lock already acquired above, so createSession won't re-acquire
-
     // Clear progress file for fresh start with new epic
     await clearProgress(config.cwd);
+  }
 
+  trackerForRun = trackerForRun ?? await trackerRegistry.getInstance(config.tracker);
+  if (config.epicIds && config.epicIds.length > 0 && executionScopes.length === 0) {
+    executionScopes = await resolveExecutionScopes(trackerForRun, config.epicIds);
+  }
+
+  if (!session) {
+    // Create new session (task count will be updated after tracker init)
+    // Note: Lock already acquired above, so createSession won't re-acquire
     session = await createSession({
       sessionId: newSessionId,
       agentPlugin: config.agent.plugin,
@@ -3814,11 +3813,7 @@ export async function executeRunCommand(args: string[]): Promise<void> {
 
   let tasks: TrackerTask[] = [];
   let tracker: TrackerPlugin;
-  const trackerRegistry = getTrackerRegistry();
-  const baseTracker = trackerForRun ?? await trackerRegistry.getInstance(config.tracker);
-  if (config.epicIds && config.epicIds.length > 0 && executionScopes.length === 0) {
-    executionScopes = await resolveExecutionScopes(baseTracker, config.epicIds);
-  }
+  const baseTracker = trackerForRun;
   tracker = wrapTrackerForScopes(baseTracker, executionScopes);
 
   // Create and initialize engine

--- a/src/commands/run.tsx
+++ b/src/commands/run.tsx
@@ -58,9 +58,18 @@ import { registerBuiltinAgents } from '../plugins/agents/builtin/index.js';
 import { registerBuiltinTrackers } from '../plugins/trackers/builtin/index.js';
 import { getAgentRegistry } from '../plugins/agents/registry.js';
 import { getTrackerRegistry } from '../plugins/trackers/registry.js';
+import {
+  MultiScopeTrackerPlugin,
+  createExecutionScopeFromTask,
+} from '../plugins/trackers/multi-scope.js';
 import { RunApp } from '../tui/components/RunApp.js';
 import { EpicSelectionApp } from '../tui/components/EpicSelectionApp.js';
-import type { TrackerPlugin, TrackerTask } from '../plugins/trackers/types.js';
+import type {
+  ExecutionScope,
+  ScopedTrackerTask,
+  TrackerPlugin,
+  TrackerTask,
+} from '../plugins/trackers/types.js';
 import type { RalphConfig } from '../config/types.js';
 import { projectConfigExists, runSetupWizard, checkAndMigrate } from '../setup/index.js';
 import { createInterruptHandler } from '../interruption/index.js';
@@ -443,6 +452,14 @@ interface ParallelRunSummary {
   originalBranch: string | null;
   returnToOriginalBranchError: string | null;
   preservedRecoveryWorktrees: WorktreeInfo[];
+  scopeSummaries: ParallelScopeSummary[];
+}
+
+interface ParallelScopeSummary {
+  scope: ExecutionScope;
+  totalTasks: number;
+  tasksCompleted: number;
+  tasksFailed: number;
 }
 
 export function buildParallelSummaryFilePath(
@@ -457,6 +474,72 @@ export function buildParallelSummaryFilePath(
     PARALLEL_SUMMARY_DIR,
     `parallel-summary-${safeSessionId}-${safeTimestamp}.txt`
   );
+}
+
+function getTaskExecutionScope(task: TrackerTask): ExecutionScope | undefined {
+  const scopedTask = task as ScopedTrackerTask;
+  if (scopedTask.executionScope) {
+    return scopedTask.executionScope;
+  }
+
+  const metadataScope = task.metadata?.executionScope;
+  if (
+    metadataScope &&
+    typeof metadataScope === 'object' &&
+    'id' in metadataScope &&
+    typeof (metadataScope as { id?: unknown }).id === 'string'
+  ) {
+    const scopeRecord = metadataScope as Record<string, unknown>;
+    const id = scopeRecord.id as string;
+    return {
+      id,
+      title: typeof scopeRecord.title === 'string' ? scopeRecord.title : id,
+      type: scopeRecord.type === 'prd' || scopeRecord.type === 'tracker' ? scopeRecord.type : 'epic',
+      description: typeof scopeRecord.description === 'string' ? scopeRecord.description : undefined,
+    };
+  }
+
+  return undefined;
+}
+
+function buildParallelScopeSummaries(
+  executorState: ParallelExecutorState
+): ParallelScopeSummary[] {
+  const scopes = new Map<string, ExecutionScope>();
+  for (const scope of executorState.scopes ?? []) {
+    scopes.set(scope.id, scope);
+  }
+
+  const totals = new Map<string, number>();
+  for (const node of executorState.taskGraph?.nodes.values() ?? []) {
+    const scope = getTaskExecutionScope(node.task);
+    if (!scope) continue;
+    scopes.set(scope.id, scope);
+    totals.set(scope.id, (totals.get(scope.id) ?? 0) + 1);
+  }
+
+  const completed = new Map<string, number>();
+  const failed = new Map<string, number>();
+  for (const operation of executorState.mergeQueue) {
+    const scope = getTaskExecutionScope(operation.workerResult.task);
+    if (!scope) continue;
+    scopes.set(scope.id, scope);
+
+    if (operation.status === 'completed') {
+      completed.set(scope.id, (completed.get(scope.id) ?? 0) + 1);
+    } else if (operation.status === 'failed' || operation.status === 'rolled-back') {
+      failed.set(scope.id, (failed.get(scope.id) ?? 0) + 1);
+    }
+  }
+
+  return [...scopes.values()]
+    .filter((scope) => (totals.get(scope.id) ?? 0) > 0)
+    .map((scope) => ({
+      scope,
+      totalTasks: totals.get(scope.id) ?? 0,
+      tasksCompleted: completed.get(scope.id) ?? 0,
+      tasksFailed: failed.get(scope.id) ?? 0,
+    }));
 }
 
 export function createParallelRunSummary(params: {
@@ -513,6 +596,7 @@ export function createParallelRunSummary(params: {
     originalBranch,
     returnToOriginalBranchError,
     preservedRecoveryWorktrees: preservedRecoveryWorktrees.map((info) => ({ ...info })),
+    scopeSummaries: buildParallelScopeSummaries(executorState),
   };
 }
 
@@ -536,6 +620,17 @@ export function formatParallelRunSummary(summary: ParallelRunSummary): string {
   lines.push(
     `  Tasks:                  ${summary.tasksCompleted}/${summary.totalTasks} completed (${summary.tasksFailed} failed)`
   );
+  if (summary.scopeSummaries.length > 0) {
+    lines.push('  Scopes:');
+    for (const scopeSummary of summary.scopeSummaries) {
+      const failedText = scopeSummary.tasksFailed > 0
+        ? ` (${scopeSummary.tasksFailed} failed)`
+        : '';
+      lines.push(
+        `    - ${scopeSummary.scope.title}: ${scopeSummary.tasksCompleted}/${scopeSummary.totalTasks} completed${failedText}`
+      );
+    }
+  }
   lines.push(`  Merges completed:       ${summary.mergesCompleted}`);
   lines.push(`  Conflicts resolved:     ${summary.conflictsResolved}`);
   if (summary.directMerge) {
@@ -786,6 +881,15 @@ interface ExtendedRuntimeOptions extends RuntimeOptions {
   remoteOnly?: boolean;
 }
 
+function addEpicIdOption(options: ExtendedRuntimeOptions, epicId: string): void {
+  const trimmed = epicId.trim();
+  if (!trimmed) return;
+  const current = options.epicIds ?? (options.epicId ? [options.epicId] : []);
+  const nextEpicIds = current.includes(trimmed) ? current : [...current, trimmed];
+  options.epicIds = nextEpicIds;
+  options.epicId = nextEpicIds[0];
+}
+
 /**
  * Parse CLI arguments for the run command
  */
@@ -811,7 +915,16 @@ export function parseRunArgs(args: string[]): ExtendedRuntimeOptions {
     switch (arg) {
       case '--epic':
         if (nextArg && !nextArg.startsWith('-')) {
-          options.epicId = nextArg;
+          addEpicIdOption(options, nextArg);
+          i++;
+        }
+        break;
+
+      case '--epics':
+        if (nextArg && !nextArg.startsWith('-')) {
+          for (const epicId of nextArg.split(',')) {
+            addEpicIdOption(options, epicId);
+          }
           i++;
         }
         break;
@@ -1066,7 +1179,8 @@ ralph-tui run - Start Ralph execution
 Usage: ralph-tui run [options]
 
 Options:
-  --epic <id>         Epic/parent issue ID for beads or linear tracker
+  --epic <id>         Epic/parent issue ID for beads or linear tracker (repeatable)
+  --epics <ids>       Comma-separated epic/parent IDs for one multi-epic session
   --prd <path>        PRD file path (auto-switches to json tracker)
   --agent <name>      Override agent plugin (e.g., claude, opencode)
   --model <name>      Override model (e.g., opus, sonnet)
@@ -1120,6 +1234,8 @@ Log Output Format (--no-tui mode):
 Examples:
   ralph-tui run                              # Start with defaults
   ralph-tui run --epic ralph-tui-45r         # Run with specific epic
+  ralph-tui run --parallel --epic ui-epic --epic backend-epic
+  ralph-tui run --parallel --epics ui-epic,backend-epic
   ralph-tui run --prd ./prd.json             # Run with PRD file
   ralph-tui run --agent claude --model opus  # Override agent settings
   ralph-tui run --tracker beads-bv           # Use beads-bv tracker
@@ -1497,7 +1613,7 @@ async function promptResumeOrNew(cwd: string): Promise<'resume' | 'new' | 'abort
  */
 async function showEpicSelectionTui(
   tracker: TrackerPlugin
-): Promise<TrackerTask | undefined> {
+): Promise<TrackerTask[] | undefined> {
   return new Promise(async (resolve) => {
     const renderer = await createCliRenderer({
       exitOnCtrlC: false,
@@ -1509,9 +1625,9 @@ async function showEpicSelectionTui(
       renderer.destroy();
     };
 
-    const handleEpicSelected = (epic: TrackerTask) => {
+    const handleEpicSelected = (epics: TrackerTask[]) => {
       cleanup();
-      resolve(epic);
+      resolve(epics);
     };
 
     const handleQuit = () => {
@@ -1535,6 +1651,40 @@ async function showEpicSelectionTui(
       />
     );
   });
+}
+
+async function resolveExecutionScopes(
+  tracker: TrackerPlugin,
+  epicIds: string[]
+): Promise<ExecutionScope[]> {
+  if (epicIds.length === 0) {
+    return [];
+  }
+
+  let epics: TrackerTask[] = [];
+  try {
+    epics = await tracker.getEpics();
+  } catch {
+    epics = [];
+  }
+
+  return epicIds.map((epicId) => {
+    const epic = epics.find((candidate) => candidate.id === epicId);
+    return epic
+      ? createExecutionScopeFromTask(epic)
+      : {
+          id: epicId,
+          title: epicId,
+          type: 'epic',
+        };
+  });
+}
+
+function wrapTrackerForScopes(
+  tracker: TrackerPlugin,
+  scopes: ExecutionScope[]
+): TrackerPlugin {
+  return scopes.length > 1 ? new MultiScopeTrackerPlugin(tracker, scopes) : tracker;
 }
 
 /**
@@ -1561,6 +1711,8 @@ interface RunAppWrapperProps {
   agentCommand?: string;
   /** Current epic ID for highlighting */
   currentEpicId?: string;
+  /** Selected execution scopes for multi-epic sessions */
+  executionScopes?: ExecutionScope[];
   /** Initial subagent panel visibility (from persisted session) */
   initialSubagentPanelVisible?: boolean;
   /** Callback to update persisted session state */
@@ -1658,6 +1810,7 @@ function RunAppWrapper({
   agentPlugin,
   agentCommand,
   currentEpicId: initialEpicId,
+  executionScopes,
   initialSubagentPanelVisible = false,
   onUpdatePersistedState,
   currentModel,
@@ -1882,6 +2035,7 @@ function RunAppWrapper({
       agentPlugin={agentPlugin}
       agentCommand={agentCommand}
       currentEpicId={currentEpicId}
+      executionScopes={executionScopes}
       initialSubagentPanelVisible={initialSubagentPanelVisible}
       onSubagentPanelVisibilityChange={handleSubagentPanelVisibilityChange}
       currentModel={currentModel}
@@ -1957,7 +2111,8 @@ async function runWithTui(
   config: RalphConfig,
   initialTasks: TrackerTask[],
   storedConfig?: StoredConfig,
-  notificationOptions?: NotificationRunOptions
+  notificationOptions?: NotificationRunOptions,
+  executionScopes: ExecutionScope[] = []
 ): Promise<PersistedSessionState> {
   let currentState = persistedState;
   // Track when engine starts for duration calculation
@@ -2203,6 +2358,7 @@ async function runWithTui(
       agentPlugin={config.agent.plugin}
       agentCommand={config.agent.command}
       currentEpicId={config.epicId}
+      executionScopes={executionScopes}
       initialSubagentPanelVisible={persistedState.subagentPanelVisible ?? false}
       onUpdatePersistedState={handleUpdatePersistedState}
       currentModel={config.model}
@@ -2367,6 +2523,7 @@ async function runParallelWithTui(
   directMerge: boolean,
   storedConfig?: StoredConfig,
   tracker?: TrackerPlugin,
+  executionScopes: ExecutionScope[] = [],
 ): Promise<ParallelTuiRunResult> {
   let currentState = persistedState;
   let resolveQuitPromise: (() => void) | null = null;
@@ -2844,6 +3001,7 @@ async function runParallelWithTui(
         agentPlugin={config.agent.plugin}
         agentCommand={config.agent.command}
         currentEpicId={config.epicId}
+        executionScopes={executionScopes}
         currentModel={config.model}
         sandboxConfig={config.sandbox}
         resolvedSandboxMode={resolvedSandboxMode}
@@ -3487,6 +3645,9 @@ export async function executeRunCommand(args: string[]): Promise<void> {
     }
   }
 
+  let executionScopes: ExecutionScope[] = [];
+  let trackerForRun: TrackerPlugin | undefined;
+
   // If using beads tracker without epic, show epic selection TUI
   const isBeadsTracker = config.tracker.plugin === 'beads' || config.tracker.plugin === 'beads-bv' || config.tracker.plugin === 'beads-rust';
   if (isBeadsTracker && !config.epicId && config.showTui) {
@@ -3495,26 +3656,36 @@ export async function executeRunCommand(args: string[]): Promise<void> {
     // Get tracker instance for epic selection
     const trackerRegistry = getTrackerRegistry();
     const tracker = await trackerRegistry.getInstance(config.tracker);
+    trackerForRun = tracker;
 
     // Show epic selection TUI
-    const selectedEpic = await showEpicSelectionTui(tracker);
+    const selectedEpics = await showEpicSelectionTui(tracker);
 
-    if (!selectedEpic) {
+    if (!selectedEpics || selectedEpics.length === 0) {
       console.log('Epic selection cancelled.');
       process.exit(0);
     }
 
-    // Update config with selected epic
-    config.epicId = selectedEpic.id;
-    config.tracker.options.epicId = selectedEpic.id;
+    // Update config with selected epic(s)
+    config.epicIds = selectedEpics.map((epic) => epic.id);
+    config.epicId = config.epicIds[0];
+    config.tracker.options.epicId = config.epicId;
+    config.tracker.options.epicIds = config.epicIds;
+    executionScopes = selectedEpics.map(createExecutionScopeFromTask);
 
     // If the tracker has a setEpicId method, call it
     if (tracker.setEpicId) {
-      tracker.setEpicId(selectedEpic.id);
+      tracker.setEpicId(config.epicId);
     }
 
-    console.log(`Selected epic: ${selectedEpic.id} - ${selectedEpic.title}`);
+    console.log(`Selected epic${selectedEpics.length > 1 ? 's' : ''}: ${config.epicIds.join(', ')}`);
     console.log('');
+  }
+
+  if (config.epicIds && config.epicIds.length > 0 && executionScopes.length === 0) {
+    const trackerRegistry = getTrackerRegistry();
+    trackerForRun = trackerForRun ?? await trackerRegistry.getInstance(config.tracker);
+    executionScopes = await resolveExecutionScopes(trackerForRun, config.epicIds);
   }
 
   // Detect and recover stale sessions EARLY (before any prompts)
@@ -3578,6 +3749,13 @@ export async function executeRunCommand(args: string[]): Promise<void> {
       cleanupLockHandlers();
       process.exit(1);
     }
+    if (!config.epicIds && session.epicIds && session.epicIds.length > 0) {
+      config.epicIds = session.epicIds;
+      config.epicId = session.epicId ?? session.epicIds[0];
+      config.tracker.options.epicId = config.epicId;
+      config.tracker.options.epicIds = config.epicIds;
+      executionScopes = session.executionScopes ?? executionScopes;
+    }
   } else {
     // Create new session (task count will be updated after tracker init)
     // Note: Lock already acquired above, so createSession won't re-acquire
@@ -3590,6 +3768,8 @@ export async function executeRunCommand(args: string[]): Promise<void> {
       agentPlugin: config.agent.plugin,
       trackerPlugin: config.tracker.plugin,
       epicId: config.epicId,
+      epicIds: config.epicIds,
+      executionScopes,
       prdPath: config.prdPath,
       maxIterations: config.maxIterations,
       totalTasks: 0, // Will be updated
@@ -3605,7 +3785,7 @@ export async function executeRunCommand(args: string[]): Promise<void> {
   console.log(`Agent: ${config.agent.plugin}`);
   console.log(`Tracker: ${config.tracker.plugin}`);
   if (config.epicId) {
-    console.log(`Epic: ${config.epicId}`);
+    console.log(`Epic${config.epicIds && config.epicIds.length > 1 ? 's' : ''}: ${config.epicIds?.join(', ') ?? config.epicId}`);
   }
   if (config.prdPath) {
     console.log(`PRD: ${config.prdPath}`);
@@ -3613,16 +3793,19 @@ export async function executeRunCommand(args: string[]): Promise<void> {
   console.log(`Max iterations: ${config.maxIterations || 'unlimited'}`);
   console.log('');
 
-  // Create and initialize engine
-  const engine = new ExecutionEngine(config);
-
   let tasks: TrackerTask[] = [];
   let tracker: TrackerPlugin;
+  const trackerRegistry = getTrackerRegistry();
+  const baseTracker = trackerForRun ?? await trackerRegistry.getInstance(config.tracker);
+  if (config.epicIds && config.epicIds.length > 0 && executionScopes.length === 0) {
+    executionScopes = await resolveExecutionScopes(baseTracker, config.epicIds);
+  }
+  tracker = wrapTrackerForScopes(baseTracker, executionScopes);
+
+  // Create and initialize engine
+  const engine = new ExecutionEngine(config);
   try {
-    await engine.initialize();
-    // Get tasks for persisted state
-    const trackerRegistry = getTrackerRegistry();
-    tracker = await trackerRegistry.getInstance(config.tracker);
+    await engine.initialize(undefined, { tracker });
 
     // Detect and handle stale in_progress tasks from crashed sessions
     // This must happen before we fetch tasks, so they reflect any resets
@@ -3767,6 +3950,8 @@ export async function executeRunCommand(args: string[]): Promise<void> {
     model: config.model,
     trackerPlugin: config.tracker.plugin,
     epicId: config.epicId,
+    epicIds: config.epicIds,
+    executionScopes,
     prdPath: config.prdPath,
     maxIterations: config.maxIterations,
     tasks,
@@ -3786,6 +3971,7 @@ export async function executeRunCommand(args: string[]): Promise<void> {
     agentPlugin: config.agent.plugin,
     trackerPlugin: config.tracker.plugin,
     epicId: config.epicId,
+    epicIds: config.epicIds,
     prdPath: config.prdPath,
     sandbox: config.sandbox?.enabled,
   });
@@ -3908,6 +4094,7 @@ export async function executeRunCommand(args: string[]): Promise<void> {
         directMerge,
         sessionBranchName: targetBranch,
         filteredTaskIds,
+        scopes: executionScopes,
       });
 
       // Wire up AI conflict resolution if enabled (default: true)
@@ -3946,7 +4133,14 @@ export async function executeRunCommand(args: string[]): Promise<void> {
       if (config.showTui) {
         // Parallel TUI mode — visualize workers, merges, and conflicts
         const parallelTuiResult = await runParallelWithTui(
-          parallelExecutor, persistedState, config, tasks, directMerge, storedConfig, tracker
+          parallelExecutor,
+          persistedState,
+          config,
+          tasks,
+          directMerge,
+          storedConfig,
+          tracker,
+          executionScopes
         );
         persistedState = parallelTuiResult.state;
         parallelSummaryForGuidance = parallelTuiResult.summary;
@@ -4204,7 +4398,15 @@ export async function executeRunCommand(args: string[]): Promise<void> {
       // Sequential TUI mode (existing path)
       // Pass tasks for initial TUI display in "ready" state
       // Also pass storedConfig for settings view
-      persistedState = await runWithTui(engine, persistedState, config, tasks, storedConfig, notificationRunOptions);
+      persistedState = await runWithTui(
+        engine,
+        persistedState,
+        config,
+        tasks,
+        storedConfig,
+        notificationRunOptions,
+        executionScopes
+      );
     } else {
       // Sequential headless mode (existing path)
       persistedState = await runHeadless(engine, persistedState, config, {

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -1008,6 +1008,30 @@ default = true
     expect(config).not.toBeNull();
     expect(config!.agent.command).toBe('my-custom-claude');
   });
+
+  test('normalizes multiple runtime epic IDs into config and tracker options', async () => {
+    const projectConfigDir = join(tempDir, '.ralph-tui');
+    await mkdir(projectConfigDir, { recursive: true });
+    await writeFile(
+      join(projectConfigDir, 'config.toml'),
+      `
+agent = "claude"
+tracker = "beads-rust"
+`,
+      'utf-8'
+    );
+
+    const config = await buildConfig({
+      cwd: tempDir,
+      epicIds: ['ui-epic', 'backend-epic'],
+    });
+
+    expect(config).not.toBeNull();
+    expect(config!.epicId).toBe('ui-epic');
+    expect(config!.epicIds).toEqual(['ui-epic', 'backend-epic']);
+    expect(config!.tracker.options?.epicId).toBe('ui-epic');
+    expect(config!.tracker.options?.epicIds).toEqual(['ui-epic', 'backend-epic']);
+  });
 });
 
 describe('buildConfig - envPassthrough shorthand', () => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -646,11 +646,19 @@ export async function buildConfig(
     }
   }
 
+  const epicIds = options.epicIds && options.epicIds.length > 0
+    ? options.epicIds
+    : options.epicId
+      ? [options.epicId]
+      : undefined;
+  const primaryEpicId = epicIds?.[0];
+
   // Apply epic/prd options to tracker
-  if (options.epicId) {
+  if (primaryEpicId) {
     trackerConfig.options = {
       ...trackerConfig.options,
-      epicId: options.epicId,
+      epicId: primaryEpicId,
+      epicIds,
     };
   }
   if (options.prdPath) {
@@ -697,7 +705,8 @@ export async function buildConfig(
       options.progressFile ??
       storedConfig.progressFile ??
       DEFAULT_CONFIG.progressFile,
-    epicId: options.epicId,
+    epicId: primaryEpicId,
+    epicIds,
     prdPath: options.prdPath,
     model: options.model ?? storedConfig.model,
     showTui: !options.headless,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -179,6 +179,9 @@ export interface RuntimeOptions {
   /** Epic ID for beads-based trackers */
   epicId?: string;
 
+  /** Epic IDs for multi-epic hierarchy tracker runs */
+  epicIds?: string[];
+
   /** PRD file path for json tracker */
   prdPath?: string;
 
@@ -384,6 +387,9 @@ export interface RalphConfig {
 
   /** Epic ID (for beads trackers) */
   epicId?: string;
+
+  /** Epic IDs for multi-epic hierarchy tracker runs */
+  epicIds?: string[];
 
   /** PRD path (for json tracker) */
   prdPath?: string;

--- a/src/engine/index.test.ts
+++ b/src/engine/index.test.ts
@@ -8,6 +8,8 @@
  */
 
 import { describe, test, expect } from 'bun:test';
+import { AgentRegistry } from '../plugins/agents/registry.js';
+import type { AgentPlugin } from '../plugins/agents/types.js';
 import type { TrackerPlugin, TrackerTask, TaskFilter } from '../plugins/trackers/types.js';
 import type { RalphConfig } from '../config/types.js';
 import { ExecutionEngine } from './index.js';
@@ -78,7 +80,97 @@ function createMockConfig(): RalphConfig {
   };
 }
 
+function createMockAgent(): AgentPlugin {
+  return {
+    meta: {
+      id: 'engine-test-agent',
+      name: 'Engine Test Agent',
+      description: 'Agent used by ExecutionEngine tests',
+      version: '1.0.0',
+      defaultCommand: 'engine-test-agent',
+      supportsStreaming: false,
+      supportsInterrupt: false,
+      supportsFileContext: false,
+      supportsSubagentTracing: false,
+    },
+    initialize: async () => undefined,
+    isReady: async () => true,
+    detect: async () => ({ available: true, version: '1.0.0' }),
+    getSandboxRequirements: () => ({
+      authPaths: [],
+      binaryPaths: [],
+      runtimePaths: [],
+      requiresNetwork: false,
+    }),
+    execute: () => ({
+      executionId: 'engine-test-execution',
+      promise: Promise.resolve({
+        executionId: 'engine-test-execution',
+        status: 'completed',
+        stdout: '',
+        stderr: '',
+        durationMs: 0,
+        interrupted: false,
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+      }),
+      interrupt: () => undefined,
+      isRunning: () => false,
+    }),
+    interrupt: () => false,
+    interruptAll: () => undefined,
+    getCurrentExecution: () => undefined,
+    getSetupQuestions: () => [],
+    validateSetup: async () => null,
+    validateModel: () => null,
+    listModels: () => [],
+    preflight: async () => ({ success: true }),
+    dispose: async () => undefined,
+  };
+}
+
 describe('ExecutionEngine', () => {
+  describe('initialize', () => {
+    test('uses an injected tracker in normal mode', async () => {
+      const registry = AgentRegistry.getInstance();
+      if (!registry.hasPlugin('engine-test-agent')) {
+        registry.registerBuiltin(createMockAgent);
+      }
+
+      const config = createMockConfig();
+      config.agent = { name: 'engine-test-agent', plugin: 'engine-test-agent', options: {} };
+      config.tracker = { name: 'unused', plugin: 'missing-tracker', options: {} };
+
+      let syncCalls = 0;
+      const getTasksFilters: TaskFilter[] = [];
+      const injectedTracker = {
+        ...createMockTracker([createMockTask({ id: 'task-1' })]),
+        sync: async () => {
+          syncCalls++;
+          return {
+            success: true,
+            message: 'Synced',
+            syncedAt: new Date().toISOString(),
+          };
+        },
+        getTasks: async (filter?: TaskFilter) => {
+          if (filter) {
+            getTasksFilters.push(filter);
+          }
+          return [createMockTask({ id: 'task-1' })];
+        },
+      } as TrackerPlugin;
+
+      const engine = new ExecutionEngine(config);
+
+      await engine.initialize(undefined, { tracker: injectedTracker });
+
+      expect(syncCalls).toBe(1);
+      expect(getTasksFilters).toEqual([{ status: ['open', 'in_progress'] }]);
+      expect(engine.getState().totalTasks).toBe(1);
+    });
+  });
+
   describe('generatePromptPreview', () => {
     test('returns prompt for open tasks', async () => {
       const openTask = createMockTask({ id: 'task-open', status: 'open', title: 'Open Task' });

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -227,6 +227,14 @@ export interface WorkerModeOptions {
 }
 
 /**
+ * Options for initializing the engine in the normal session path.
+ */
+export interface EngineInitializeOptions {
+  /** Pre-initialized tracker plugin to use instead of resolving from registry */
+  tracker?: TrackerPlugin;
+}
+
+/**
  * Execution engine for the agent loop
  */
 export class ExecutionEngine {
@@ -306,7 +314,7 @@ export class ExecutionEngine {
    *   When provided, the engine uses the injected tracker and works only on
    *   the forced task, skipping tracker initialization and sync.
    */
-  async initialize(workerMode?: WorkerModeOptions): Promise<void> {
+  async initialize(workerMode?: WorkerModeOptions, options?: EngineInitializeOptions): Promise<void> {
     // Get agent instance
     const agentRegistry = getAgentRegistry();
     this.agent = await agentRegistry.getInstance(this.config.agent);
@@ -352,8 +360,12 @@ export class ExecutionEngine {
       this.state.totalTasks = 1;
     } else {
       // Normal mode: initialize tracker from config
-      const trackerRegistry = getTrackerRegistry();
-      this.tracker = await trackerRegistry.getInstance(this.config.tracker);
+      if (options?.tracker) {
+        this.tracker = options.tracker;
+      } else {
+        const trackerRegistry = getTrackerRegistry();
+        this.tracker = await trackerRegistry.getInstance(this.config.tracker);
+      }
 
       // Sync tracker
       await this.tracker.sync();

--- a/src/parallel/events.ts
+++ b/src/parallel/events.ts
@@ -5,7 +5,7 @@
  */
 
 import type { EngineEventBase } from '../engine/types.js';
-import type { TrackerTask } from '../plugins/trackers/types.js';
+import type { ExecutionScope, TrackerTask } from '../plugins/trackers/types.js';
 import type {
   WorkerResult,
   MergeResult,
@@ -192,6 +192,7 @@ export interface ParallelStartedEvent extends EngineEventBase {
   totalGroups: number;
   totalTasks: number;
   maxWorkers: number;
+  scopes?: ExecutionScope[];
 }
 
 /**

--- a/src/parallel/index.ts
+++ b/src/parallel/index.ts
@@ -444,6 +444,7 @@ export class ParallelExecutor {
       currentGroupIndex: this.currentGroupIndex,
       totalGroups: this.taskGraph?.groups.length ?? 0,
       workers: this.activeWorkers.map((w) => w.getDisplayState()),
+      workerResults: [...this.completedResults],
       mergeQueue: [...this.mergeEngine.getQueue()],
       completedMerges: [],
       activeConflicts: [],

--- a/src/parallel/index.ts
+++ b/src/parallel/index.ts
@@ -331,6 +331,7 @@ export class ParallelExecutor {
         totalGroups: this.taskGraph.groups.length,
         totalTasks: this.taskGraph.actionableTaskCount,
         maxWorkers: this.config.maxWorkers,
+        scopes: this.config.scopes,
       });
 
       // Execute groups in topological order
@@ -452,6 +453,7 @@ export class ParallelExecutor {
       elapsedMs: this.startedAt
         ? Date.now() - new Date(this.startedAt).getTime()
         : 0,
+      scopes: this.config.scopes,
     };
   }
 
@@ -726,9 +728,14 @@ export class ParallelExecutor {
 
       // Acquire worktree - use the sanitized branch name returned by acquire()
       // since acquire() sanitizes task IDs into valid git branch names
+      const executionScope = (task as { executionScope?: { id: string } }).executionScope;
       const worktreeInfo = await this.worktreeManager.acquire(
         workerId,
-        task.id
+        task.id,
+        {
+          sessionId: this.sessionId,
+          scopeId: executionScope?.id,
+        }
       );
       branchNames.push(worktreeInfo.branch);
 

--- a/src/parallel/parallel-executor.test.ts
+++ b/src/parallel/parallel-executor.test.ts
@@ -333,6 +333,7 @@ describe('ParallelExecutor class', () => {
       expect(state.currentGroupIndex).toBe(0);
       expect(state.totalGroups).toBe(0);
       expect(state.workers).toEqual([]);
+      expect(state.workerResults).toEqual([]);
       expect(state.mergeQueue).toEqual([]);
       expect(state.completedMerges).toEqual([]);
       expect(state.activeConflicts).toEqual([]);

--- a/src/parallel/parallel-executor.test.ts
+++ b/src/parallel/parallel-executor.test.ts
@@ -9,7 +9,7 @@
 import { describe, test, expect } from 'bun:test';
 import { analyzeTaskGraph, shouldRunParallel } from './task-graph.js';
 import { ParallelExecutor } from './index.js';
-import type { TrackerTask, TrackerPlugin } from '../plugins/trackers/types.js';
+import type { ExecutionScope, TrackerTask, TrackerPlugin } from '../plugins/trackers/types.js';
 import type { RalphConfig } from '../config/types.js';
 import type { ParallelEvent } from './events.js';
 import type { AiResolverCallback } from './conflict-resolver.js';
@@ -340,6 +340,18 @@ describe('ParallelExecutor class', () => {
       expect(state.totalTasks).toBe(0);
       expect(state.startedAt).toBeNull();
       expect(state.elapsedMs).toBe(0);
+    });
+
+    test('includes configured execution scopes', () => {
+      const scopes: ExecutionScope[] = [
+        { id: 'ui', title: 'UI', type: 'epic' },
+        { id: 'backend', title: 'Backend', type: 'epic' },
+      ];
+      const executor = new ParallelExecutor(createMockConfig(), createMockTracker(), {
+        scopes,
+      });
+
+      expect(executor.getState().scopes).toEqual(scopes);
     });
   });
 

--- a/src/parallel/types.ts
+++ b/src/parallel/types.ts
@@ -385,6 +385,9 @@ export interface ParallelExecutorState {
   /** Active workers and their display states */
   workers: WorkerDisplayState[];
 
+  /** Results from workers that have completed during this execution */
+  workerResults?: WorkerResult[];
+
   /** Merge queue state */
   mergeQueue: MergeOperation[];
 

--- a/src/parallel/types.ts
+++ b/src/parallel/types.ts
@@ -4,7 +4,11 @@
  * task graph analysis, and parallel session persistence types.
  */
 
-import type { TrackerTask, TaskPriority } from '../plugins/trackers/types.js';
+import type {
+  ExecutionScope,
+  TrackerTask,
+  TaskPriority,
+} from '../plugins/trackers/types.js';
 
 // ─── Worker Types ──────────────────────────────────────────────────────────────
 
@@ -336,6 +340,9 @@ export interface ParallelExecutorConfig {
    * Used for --task-range filtering.
    */
   filteredTaskIds?: string[];
+
+  /** Selected execution scopes for multi-epic runs */
+  scopes?: ExecutionScope[];
 }
 
 /**
@@ -398,6 +405,9 @@ export interface ParallelExecutorState {
 
   /** Elapsed time in milliseconds */
   elapsedMs: number;
+
+  /** Selected execution scopes for this run */
+  scopes?: ExecutionScope[];
 }
 
 // ─── Session Persistence Types ─────────────────────────────────────────────────

--- a/src/parallel/worktree-manager.test.ts
+++ b/src/parallel/worktree-manager.test.ts
@@ -152,6 +152,15 @@ describe('WorktreeManager', () => {
       expect(worktreeList).toContain(info.path);
     });
 
+    test('includes session and scope slugs in branch names when provided', async () => {
+      const info = await manager.acquire('w1', 'task/001', {
+        sessionId: 'session/abc',
+        scopeId: 'UI Epic',
+      });
+
+      expect(info.branch).toBe('ralph-parallel/session-abc/UI-Epic/task-001');
+    });
+
     test('creates the worktree base directory', async () => {
       const worktreeBaseDir = path.join(repoDir, '.ralph-tui/worktrees');
       expect(fs.existsSync(worktreeBaseDir)).toBe(false);

--- a/src/parallel/worktree-manager.ts
+++ b/src/parallel/worktree-manager.ts
@@ -54,6 +54,10 @@ function sanitizeBranchName(taskId: string): string {
   return sanitized;
 }
 
+function sanitizeBranchSegment(value: string): string {
+  return sanitizeBranchName(value).replace(/\/+/g, '-') || 'segment';
+}
+
 /** Default minimum free disk space (500 MB) before creating a worktree */
 const DEFAULT_MIN_FREE_DISK_SPACE = 500 * 1024 * 1024;
 
@@ -115,7 +119,11 @@ export class WorktreeManager {
    * @returns Information about the created worktree
    * @throws If worktree creation fails or disk space is insufficient
    */
-  async acquire(workerId: string, taskId: string): Promise<WorktreeInfo> {
+  async acquire(
+    workerId: string,
+    taskId: string,
+    branchParts?: { sessionId?: string; scopeId?: string }
+  ): Promise<WorktreeInfo> {
     const activeWorktreeCount = this.getActiveWorktreeCount();
     if (activeWorktreeCount >= this.config.maxWorktrees) {
       throw new Error(
@@ -128,8 +136,14 @@ export class WorktreeManager {
 
     const worktreeId = `worker-${workerId}`;
     // Sanitize task ID to create a valid git branch name
-    const sanitizedTaskId = sanitizeBranchName(taskId);
-    const branchName = `ralph-parallel/${sanitizedTaskId}`;
+    const sanitizedTaskId = branchParts ? sanitizeBranchSegment(taskId) : sanitizeBranchName(taskId);
+    const branchSegments = [
+      'ralph-parallel',
+      branchParts?.sessionId ? sanitizeBranchSegment(branchParts.sessionId) : undefined,
+      branchParts?.scopeId ? sanitizeBranchSegment(branchParts.scopeId) : undefined,
+      sanitizedTaskId,
+    ].filter((segment): segment is string => Boolean(segment));
+    const branchName = branchSegments.join('/');
     // worktreeDir is now an absolute path (sibling of project), so just join
     const worktreePath = path.join(this.config.worktreeDir, worktreeId);
 

--- a/src/plugins/trackers/builtin/beads-rust/README.md
+++ b/src/plugins/trackers/builtin/beads-rust/README.md
@@ -34,6 +34,10 @@ ralph-tui run --tracker beads-rust
 
 # Work on tasks within a specific epic
 ralph-tui run --tracker beads-rust --epic ralph-tui-123
+
+# Run one parallel session across multiple epics
+ralph-tui run --tracker beads-rust --parallel --epic ui-epic --epic backend-epic
+ralph-tui run --tracker beads-rust --parallel --epics ui-epic,backend-epic
 ```
 
 ### Creating Tasks for ralph-tui
@@ -81,17 +85,22 @@ Or via CLI flags:
 ralph-tui run --tracker beads-rust --epic ralph-tui-123
 ```
 
+For multi-epic parallel sessions, use repeated `--epic` flags or comma-separated `--epics`. Ralph keeps one global scheduler and merge queue, annotates tasks with their source epic, and stores the full selected epic set for resume.
+
 ## Task Selection
 
 The plugin uses `br ready` to find unblocked tasks:
 
 1. **With `--epic`**: Only tasks that are children of the specified epic
-2. **Without `--epic`**: Any unblocked task in the project
+2. **With repeated `--epic` or `--epics`**: Children from all selected epics are combined into one scoped run
+3. **Without `--epic`**: Any unblocked task in the project
 
 Tasks are selected based on:
 - Dependency status (only unblocked tasks)
 - Priority (P0 > P1 > P2 > P3 > P4)
 - Parent-child relationships
+
+Cross-epic dependencies are respected when both tasks are in the selected epic set. Dependencies outside the selected set must already be completed or cancelled; otherwise, the dependent task is blocked for that run.
 
 ## PRD Context Injection
 

--- a/src/plugins/trackers/index.ts
+++ b/src/plugins/trackers/index.ts
@@ -9,6 +9,8 @@ export type {
   TaskPriority,
   TrackerTaskStatus,
   TrackerTask,
+  ExecutionScope,
+  ScopedTrackerTask,
   TaskCompletionResult,
   SyncResult,
   SetupQuestion,
@@ -21,6 +23,9 @@ export type {
 
 // Base class for creating plugins
 export { BaseTrackerPlugin } from './base.js';
+
+// Tracker wrappers
+export { MultiScopeTrackerPlugin, createExecutionScopeFromTask } from './multi-scope.js';
 
 // Plugin registry
 export { TrackerRegistry, getTrackerRegistry } from './registry.js';

--- a/src/plugins/trackers/multi-scope.test.ts
+++ b/src/plugins/trackers/multi-scope.test.ts
@@ -54,6 +54,7 @@ class MockTracker extends BaseTrackerPlugin {
 
   completedTaskIds: string[] = [];
   statusUpdates: Array<{ id: string; status: TrackerTaskStatus }> = [];
+  initializeConfigs: Record<string, unknown>[] = [];
   syncCount = 0;
   disposeCount = 0;
 
@@ -66,8 +67,9 @@ class MockTracker extends BaseTrackerPlugin {
     super();
   }
 
-  override async initialize(): Promise<void> {
-    await super.initialize({});
+  override async initialize(config: Record<string, unknown>): Promise<void> {
+    this.initializeConfigs.push(config);
+    await super.initialize(config);
   }
 
   override async getTasks(filter?: TaskFilter): Promise<TrackerTask[]> {
@@ -120,6 +122,17 @@ class MockTracker extends BaseTrackerPlugin {
 }
 
 describe('MultiScopeTrackerPlugin', () => {
+  test('initializes the wrapped tracker with the provided config', async () => {
+    const delegate = new MockTracker([]);
+    const tracker = new MultiScopeTrackerPlugin(delegate, scopes);
+    const config = { labels: ['frontend'] };
+
+    await tracker.initialize(config);
+
+    expect(delegate.initializeConfigs).toEqual([config]);
+    expect(await tracker.isReady()).toBe(true);
+  });
+
   test('creates execution scopes from tracker parent tasks and returns defensive scope copies', () => {
     const epicTask = task('epic-1', '', {
       title: 'Feature Epic',
@@ -169,6 +182,32 @@ describe('MultiScopeTrackerPlugin', () => {
     } finally {
       console.warn = originalWarn;
     }
+  });
+
+  test('fetches scoped task lists concurrently while preserving scope order', async () => {
+    const startedScopes: string[] = [];
+    const releaseFetches: Array<() => void> = [];
+    const scopedTasks = [
+      task('ui-task', 'ui-epic'),
+      task('backend-task', 'backend-epic'),
+    ];
+    const delegate = new MockTracker(scopedTasks);
+    delegate.getTasks = async (filter?: TaskFilter) => {
+      startedScopes.push(String(filter?.parentId));
+      await new Promise<void>((resolve) => releaseFetches.push(resolve));
+      return scopedTasks.filter((candidate) => candidate.parentId === filter?.parentId);
+    };
+    const tracker = new MultiScopeTrackerPlugin(delegate, scopes);
+
+    const taskPromise = tracker.getTasks();
+    await Promise.resolve();
+
+    expect(startedScopes).toEqual(['ui-epic', 'backend-epic']);
+
+    for (const release of releaseFetches) release();
+    const tasks = await taskPromise;
+
+    expect(tasks.map((candidate) => candidate.id)).toEqual(['ui-task', 'backend-task']);
   });
 
   test('getNextTask picks lowest priority, then stable scope order, then task id', async () => {

--- a/src/plugins/trackers/multi-scope.test.ts
+++ b/src/plugins/trackers/multi-scope.test.ts
@@ -1,0 +1,217 @@
+/**
+ * ABOUTME: Tests for combining multiple tracker scopes into one Ralph execution view.
+ * Covers task annotation, dedupe, scheduling order, external dependency blocking, and writes.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { analyzeTaskGraph } from '../../parallel/task-graph.js';
+import { BaseTrackerPlugin } from './base.js';
+import { MultiScopeTrackerPlugin } from './multi-scope.js';
+import type {
+  ExecutionScope,
+  SetupQuestion,
+  SyncResult,
+  TaskCompletionResult,
+  TaskFilter,
+  TrackerPluginMeta,
+  TrackerTask,
+  TrackerTaskStatus,
+} from './types.js';
+
+const scopes: ExecutionScope[] = [
+  { id: 'ui-epic', title: 'UI', type: 'epic' },
+  { id: 'backend-epic', title: 'Backend', type: 'epic' },
+];
+
+function task(
+  id: string,
+  parentId: string,
+  overrides: Partial<TrackerTask> = {}
+): TrackerTask {
+  return {
+    id,
+    parentId,
+    title: id,
+    status: 'open',
+    priority: 2,
+    ...overrides,
+  };
+}
+
+class MockTracker extends BaseTrackerPlugin {
+  readonly meta: TrackerPluginMeta = {
+    id: 'mock',
+    name: 'Mock',
+    description: 'Mock tracker',
+    version: '1.0.0',
+    supportsBidirectionalSync: true,
+    supportsHierarchy: true,
+    supportsDependencies: true,
+  };
+
+  completedTaskIds: string[] = [];
+  statusUpdates: Array<{ id: string; status: TrackerTaskStatus }> = [];
+  syncCount = 0;
+  disposeCount = 0;
+
+  constructor(
+    private readonly tasks: TrackerTask[],
+    private readonly epics: TrackerTask[] = scopes.map((scope) =>
+      task(scope.id, '', { title: scope.title, type: 'epic' })
+    )
+  ) {
+    super();
+  }
+
+  override async initialize(): Promise<void> {
+    await super.initialize({});
+  }
+
+  override async getTasks(filter?: TaskFilter): Promise<TrackerTask[]> {
+    return this.filterTasks(this.tasks, filter);
+  }
+
+  override async getTask(id: string): Promise<TrackerTask | undefined> {
+    return [...this.tasks, ...this.epics].find((candidate) => candidate.id === id);
+  }
+
+  override async completeTask(id: string): Promise<TaskCompletionResult> {
+    this.completedTaskIds.push(id);
+    return { success: true, message: 'completed' };
+  }
+
+  override async updateTaskStatus(
+    id: string,
+    status: TrackerTaskStatus
+  ): Promise<TrackerTask | undefined> {
+    this.statusUpdates.push({ id, status });
+    const existing = this.tasks.find((candidate) => candidate.id === id);
+    return existing ? { ...existing, status } : undefined;
+  }
+
+  override async sync(): Promise<SyncResult> {
+    this.syncCount += 1;
+    return { success: true, message: 'synced', syncedAt: '2026-05-13T00:00:00.000Z' };
+  }
+
+  override async isTaskReady(id: string): Promise<boolean> {
+    const candidate = await this.getTask(id);
+    return Boolean(candidate);
+  }
+
+  override async getEpics(): Promise<TrackerTask[]> {
+    return this.epics;
+  }
+
+  override getSetupQuestions(): SetupQuestion[] {
+    return [];
+  }
+
+  override async validateSetup(): Promise<string | null> {
+    return null;
+  }
+
+  override async dispose(): Promise<void> {
+    this.disposeCount += 1;
+  }
+}
+
+describe('MultiScopeTrackerPlugin', () => {
+  test('combines scoped tasks, annotates them, and deduplicates duplicate IDs', async () => {
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (message?: unknown) => warnings.push(String(message));
+    try {
+      const delegate = new MockTracker([
+        task('shared-task', 'ui-epic'),
+        task('ui-task', 'ui-epic'),
+        task('shared-task', 'backend-epic'),
+        task('backend-task', 'backend-epic'),
+      ]);
+      const tracker = new MultiScopeTrackerPlugin(delegate, scopes);
+
+      const tasks = await tracker.getTasks({ status: ['open', 'in_progress'] });
+
+      expect(tasks.map((candidate) => candidate.id)).toEqual([
+        'shared-task',
+        'ui-task',
+        'backend-task',
+      ]);
+      expect(tasks[0].executionScope?.id).toBe('ui-epic');
+      expect(tasks[2].executionScope?.id).toBe('backend-epic');
+      expect(warnings).toHaveLength(1);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test('getNextTask picks lowest priority, then stable scope order, then task id', async () => {
+    const delegate = new MockTracker([
+      task('z-ui', 'ui-epic', { priority: 1 }),
+      task('a-backend', 'backend-epic', { priority: 1 }),
+      task('critical-backend', 'backend-epic', { priority: 0 }),
+    ]);
+    const tracker = new MultiScopeTrackerPlugin(delegate, scopes);
+
+    expect((await tracker.getNextTask())?.id).toBe('critical-backend');
+
+    const equalPriorityDelegate = new MockTracker([
+      task('z-ui', 'ui-epic', { priority: 1 }),
+      task('a-backend', 'backend-epic', { priority: 1 }),
+    ]);
+    const equalPriorityTracker = new MultiScopeTrackerPlugin(equalPriorityDelegate, scopes);
+
+    expect((await equalPriorityTracker.getNextTask())?.id).toBe('z-ui');
+  });
+
+  test('preserves cross-epic dependencies for one global task graph', async () => {
+    const delegate = new MockTracker([
+      task('ui-foundation', 'ui-epic'),
+      task('backend-after-ui', 'backend-epic', { dependsOn: ['ui-foundation'] }),
+    ]);
+    const tracker = new MultiScopeTrackerPlugin(delegate, scopes);
+
+    const analysis = analyzeTaskGraph(await tracker.getTasks({ status: ['open', 'in_progress'] }));
+
+    expect(analysis.groups).toHaveLength(2);
+    expect(analysis.groups[0].tasks.map((candidate) => candidate.id)).toEqual(['ui-foundation']);
+    expect(analysis.groups[1].tasks.map((candidate) => candidate.id)).toEqual(['backend-after-ui']);
+  });
+
+  test('excludes tasks with unresolved external dependencies from scheduling', async () => {
+    const delegate = new MockTracker([
+      task('blocked-by-external', 'ui-epic', { dependsOn: ['external-task'] }),
+      task('ready-backend', 'backend-epic'),
+    ]);
+    const tracker = new MultiScopeTrackerPlugin(delegate, scopes);
+
+    const schedulable = await tracker.getTasks({ status: ['open', 'in_progress'] });
+    expect(schedulable.map((candidate) => candidate.id)).toEqual(['ready-backend']);
+    expect(await tracker.getNextTask()).toMatchObject({ id: 'ready-backend' });
+
+    const displayTasks = await tracker.getTasks({ status: ['open', 'in_progress', 'completed'] });
+    const blocked = displayTasks.find((candidate) => candidate.id === 'blocked-by-external');
+    expect(blocked?.status).toBe('blocked');
+    expect(blocked?.metadata?.externalDependencyBlocked).toBe(true);
+    expect(tracker.getExternalBlockedTaskIds()).toEqual(['blocked-by-external']);
+  });
+
+  test('delegates writes, sync, dispose, and completion checks', async () => {
+    const delegate = new MockTracker([
+      task('done-ui', 'ui-epic', { status: 'completed' }),
+      task('done-backend', 'backend-epic', { status: 'completed' }),
+    ]);
+    const tracker = new MultiScopeTrackerPlugin(delegate, scopes);
+
+    await tracker.completeTask('done-ui', 'done');
+    await tracker.updateTaskStatus('done-backend', 'open');
+    await tracker.sync();
+    expect(await tracker.isComplete()).toBe(true);
+    await tracker.dispose();
+
+    expect(delegate.completedTaskIds).toEqual(['done-ui']);
+    expect(delegate.statusUpdates).toEqual([{ id: 'done-backend', status: 'open' }]);
+    expect(delegate.syncCount).toBe(1);
+    expect(delegate.disposeCount).toBe(1);
+  });
+});

--- a/src/plugins/trackers/multi-scope.test.ts
+++ b/src/plugins/trackers/multi-scope.test.ts
@@ -6,7 +6,10 @@
 import { describe, expect, test } from 'bun:test';
 import { analyzeTaskGraph } from '../../parallel/task-graph.js';
 import { BaseTrackerPlugin } from './base.js';
-import { MultiScopeTrackerPlugin } from './multi-scope.js';
+import {
+  MultiScopeTrackerPlugin,
+  createExecutionScopeFromTask,
+} from './multi-scope.js';
 import type {
   ExecutionScope,
   SetupQuestion,
@@ -117,6 +120,29 @@ class MockTracker extends BaseTrackerPlugin {
 }
 
 describe('MultiScopeTrackerPlugin', () => {
+  test('creates execution scopes from tracker parent tasks and returns defensive scope copies', () => {
+    const epicTask = task('epic-1', '', {
+      title: 'Feature Epic',
+      type: 'epic',
+      description: 'Build the feature',
+      metadata: { owner: 'team-a' },
+    });
+
+    expect(createExecutionScopeFromTask(epicTask)).toEqual({
+      id: 'epic-1',
+      title: 'Feature Epic',
+      type: 'epic',
+      description: 'Build the feature',
+      metadata: { owner: 'team-a' },
+    });
+
+    const tracker = new MultiScopeTrackerPlugin(new MockTracker([]), scopes);
+    const returnedScopes = tracker.getScopes();
+    returnedScopes[0].title = 'Changed';
+
+    expect(tracker.getScopes()[0].title).toBe('UI');
+  });
+
   test('combines scoped tasks, annotates them, and deduplicates duplicate IDs', async () => {
     const originalWarn = console.warn;
     const warnings: string[] = [];

--- a/src/plugins/trackers/multi-scope.ts
+++ b/src/plugins/trackers/multi-scope.ts
@@ -81,7 +81,8 @@ export class MultiScopeTrackerPlugin extends BaseTrackerPlugin {
     return [...this.externalBlockedIds];
   }
 
-  override async initialize(_config: Record<string, unknown>): Promise<void> {
+  override async initialize(config: Record<string, unknown>): Promise<void> {
+    await this.delegate.initialize(config);
     this.ready = await this.delegate.isReady();
   }
 
@@ -92,9 +93,13 @@ export class MultiScopeTrackerPlugin extends BaseTrackerPlugin {
   override async getTasks(filter?: TaskFilter): Promise<ScopedTrackerTask[]> {
     const combined: ScopedTrackerTask[] = [];
     const seenTaskIds = new Set<string>();
+    const scopedTaskLists = await Promise.all(
+      this.scopes.map((scope) => this.delegate.getTasks(mergeFilterForScope(filter, scope)))
+    );
 
-    for (const scope of this.scopes) {
-      const scopedTasks = await this.delegate.getTasks(mergeFilterForScope(filter, scope));
+    for (let index = 0; index < this.scopes.length; index++) {
+      const scope = this.scopes[index]!;
+      const scopedTasks = scopedTaskLists[index]!;
       for (const task of scopedTasks) {
         if (seenTaskIds.has(task.id)) {
           if (!this.warnedDuplicateIds.has(task.id)) {

--- a/src/plugins/trackers/multi-scope.ts
+++ b/src/plugins/trackers/multi-scope.ts
@@ -1,0 +1,298 @@
+/**
+ * ABOUTME: Tracker wrapper for running one Ralph session across multiple execution scopes.
+ * Combines tasks from selected epics while keeping all writes delegated to the underlying tracker.
+ */
+
+import { BaseTrackerPlugin } from './base.js';
+import type {
+  ExecutionScope,
+  ScopedTrackerTask,
+  SetupQuestion,
+  SyncResult,
+  TaskCompletionResult,
+  TaskFilter,
+  TrackerPlugin,
+  TrackerPluginMeta,
+  TrackerTask,
+  TrackerTaskStatus,
+} from './types.js';
+
+/**
+ * Convert a tracker task representing an epic/parent into an execution scope.
+ */
+export function createExecutionScopeFromTask(task: TrackerTask): ExecutionScope {
+  return {
+    id: task.id,
+    title: task.title,
+    type: task.type === 'prd' ? 'prd' : 'epic',
+    description: task.description,
+    metadata: task.metadata,
+  };
+}
+
+function isTerminalStatus(status: string | undefined): boolean {
+  return status === 'completed' || status === 'cancelled';
+}
+
+function mergeFilterForScope(filter: TaskFilter | undefined, scope: ExecutionScope): TaskFilter {
+  return {
+    ...filter,
+    parentId: scope.id,
+  };
+}
+
+/**
+ * Wraps a tracker so multiple parent epics behave like one tracker scope.
+ */
+export class MultiScopeTrackerPlugin extends BaseTrackerPlugin {
+  readonly meta: TrackerPluginMeta;
+
+  private readonly delegate: TrackerPlugin;
+  private readonly scopes: ExecutionScope[];
+  private readonly scopeIndexById: Map<string, number>;
+  private warnedDuplicateIds = new Set<string>();
+  private externalBlockedIds = new Set<string>();
+
+  constructor(delegate: TrackerPlugin, scopes: ExecutionScope[]) {
+    super();
+    this.delegate = delegate;
+    this.scopes = scopes;
+    this.scopeIndexById = new Map(scopes.map((scope, index) => [scope.id, index]));
+    this.meta = {
+      ...delegate.meta,
+      id: `${delegate.meta.id}-multi-scope`,
+      name: `${delegate.meta.name} (Multi-Epic)`,
+      description: `Multi-epic wrapper for ${delegate.meta.name}`,
+    };
+    this.ready = true;
+  }
+
+  /**
+   * Return the selected execution scopes.
+   */
+  getScopes(): ExecutionScope[] {
+    return this.scopes.map((scope) => ({ ...scope }));
+  }
+
+  /**
+   * Return task IDs blocked by unresolved dependencies outside selected scopes.
+   */
+  getExternalBlockedTaskIds(): string[] {
+    return [...this.externalBlockedIds];
+  }
+
+  override async initialize(_config: Record<string, unknown>): Promise<void> {
+    this.ready = await this.delegate.isReady();
+  }
+
+  override async isReady(): Promise<boolean> {
+    return this.delegate.isReady();
+  }
+
+  override async getTasks(filter?: TaskFilter): Promise<ScopedTrackerTask[]> {
+    const combined: ScopedTrackerTask[] = [];
+    const seenTaskIds = new Set<string>();
+
+    for (const scope of this.scopes) {
+      const scopedTasks = await this.delegate.getTasks(mergeFilterForScope(filter, scope));
+      for (const task of scopedTasks) {
+        if (seenTaskIds.has(task.id)) {
+          if (!this.warnedDuplicateIds.has(task.id)) {
+            this.warnedDuplicateIds.add(task.id);
+            console.warn(
+              `Warning: task ${task.id} appears in multiple selected epics; using first occurrence.`
+            );
+          }
+          continue;
+        }
+        seenTaskIds.add(task.id);
+        combined.push({
+          ...task,
+          executionScope: scope,
+          metadata: {
+            ...task.metadata,
+            executionScope: scope,
+          },
+        });
+      }
+    }
+
+    const resolved = await this.applyExternalDependencyStatus(combined);
+    const filtered = this.filterTasks(resolved, filter) as ScopedTrackerTask[];
+
+    if (!filter?.status) {
+      return filtered;
+    }
+
+    const requestedStatuses = Array.isArray(filter.status) ? filter.status : [filter.status];
+    if (!requestedStatuses.includes('completed')) {
+      return filtered;
+    }
+
+    const filteredIds = new Set(filtered.map((task) => task.id));
+    return [
+      ...filtered,
+      ...resolved.filter((task) =>
+        task.metadata?.externalDependencyBlocked === true && !filteredIds.has(task.id)
+      ),
+    ];
+  }
+
+  override async getTask(id: string): Promise<ScopedTrackerTask | undefined> {
+    for (const scope of this.scopes) {
+      const tasks = await this.delegate.getTasks({ parentId: scope.id });
+      const match = tasks.find((task) => task.id === id);
+      if (match) {
+        return {
+          ...match,
+          executionScope: scope,
+          metadata: {
+            ...match.metadata,
+            executionScope: scope,
+          },
+        };
+      }
+    }
+
+    const task = await this.delegate.getTask(id);
+    return task ? { ...task } : undefined;
+  }
+
+  override async getNextTask(filter?: TaskFilter): Promise<ScopedTrackerTask | undefined> {
+    const tasks = await this.getTasks({
+      ...filter,
+      status: ['open', 'in_progress'],
+      ready: true,
+    });
+
+    if (tasks.length === 0) {
+      return undefined;
+    }
+
+    return [...tasks].sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return a.priority - b.priority;
+      }
+      const aScope = this.scopeIndexById.get(a.executionScope?.id ?? '') ?? Number.MAX_SAFE_INTEGER;
+      const bScope = this.scopeIndexById.get(b.executionScope?.id ?? '') ?? Number.MAX_SAFE_INTEGER;
+      if (aScope !== bScope) {
+        return aScope - bScope;
+      }
+      return a.id.localeCompare(b.id);
+    })[0];
+  }
+
+  override async completeTask(
+    id: string,
+    reason?: string
+  ): Promise<TaskCompletionResult> {
+    return this.delegate.completeTask(id, reason);
+  }
+
+  override async updateTaskStatus(
+    id: string,
+    status: TrackerTaskStatus
+  ): Promise<TrackerTask | undefined> {
+    return this.delegate.updateTaskStatus(id, status);
+  }
+
+  override async isComplete(filter?: TaskFilter): Promise<boolean> {
+    const tasks = await this.getTasks(filter);
+    return tasks.length > 0 && tasks.every((task) => isTerminalStatus(task.status));
+  }
+
+  override async sync(): Promise<SyncResult> {
+    return this.delegate.sync();
+  }
+
+  override async isTaskReady(id: string): Promise<boolean> {
+    const task = await this.getTask(id);
+    if (!task) {
+      return false;
+    }
+    const tasks = await this.getTasks();
+    return !this.externalBlockedIds.has(id) && this.checkTaskReady(task, tasks);
+  }
+
+  override async getEpics(): Promise<TrackerTask[]> {
+    return this.delegate.getEpics();
+  }
+
+  override getSetupQuestions(): SetupQuestion[] {
+    return this.delegate.getSetupQuestions();
+  }
+
+  override async validateSetup(answers: Record<string, unknown>): Promise<string | null> {
+    return this.delegate.validateSetup(answers);
+  }
+
+  override async dispose(): Promise<void> {
+    await this.delegate.dispose();
+    this.ready = false;
+  }
+
+  override getTemplate(): string {
+    return this.delegate.getTemplate();
+  }
+
+  async getPrdContext(): Promise<{
+    name: string;
+    description?: string;
+    content: string;
+    completedCount: number;
+    totalCount: number;
+  } | null> {
+    return this.delegate.getPrdContext?.() ?? null;
+  }
+
+  getStateFiles(): string[] {
+    return this.delegate.getStateFiles?.() ?? [];
+  }
+
+  getConfiguredLabels(): string[] {
+    const delegateWithLabels = this.delegate as { getConfiguredLabels?: () => string[] };
+    return delegateWithLabels.getConfiguredLabels?.() ?? [];
+  }
+
+  private async applyExternalDependencyStatus(
+    tasks: ScopedTrackerTask[]
+  ): Promise<ScopedTrackerTask[]> {
+    const selectedTaskIds = new Set(tasks.map((task) => task.id));
+    const externalStatusCache = new Map<string, string | undefined>();
+    const externalBlockedIds = new Set<string>();
+
+    for (const task of tasks) {
+      for (const depId of task.dependsOn ?? []) {
+        if (selectedTaskIds.has(depId)) {
+          continue;
+        }
+
+        if (!externalStatusCache.has(depId)) {
+          const depTask = await this.delegate.getTask(depId);
+          externalStatusCache.set(depId, depTask?.status);
+        }
+
+        if (!isTerminalStatus(externalStatusCache.get(depId))) {
+          externalBlockedIds.add(task.id);
+          break;
+        }
+      }
+    }
+
+    this.externalBlockedIds = externalBlockedIds;
+    return tasks.map((task) => {
+      if (!externalBlockedIds.has(task.id)) {
+        return task;
+      }
+      return {
+        ...task,
+        status: 'blocked',
+        metadata: {
+          ...task.metadata,
+          externalDependencyBlocked: true,
+          originalStatus: task.status,
+        },
+      };
+    });
+  }
+}

--- a/src/plugins/trackers/types.ts
+++ b/src/plugins/trackers/types.ts
@@ -71,6 +71,35 @@ export interface TrackerTask {
 }
 
 /**
+ * Execution scope selected for a run.
+ * A scope is usually a tracker epic/parent issue, or a PRD when using file-backed tasks.
+ */
+export interface ExecutionScope {
+  /** Stable scope identifier from the tracker */
+  id: string;
+
+  /** Human-readable scope title */
+  title: string;
+
+  /** Scope kind */
+  type: 'epic' | 'prd' | 'tracker';
+
+  /** Optional scope description */
+  description?: string;
+
+  /** Tracker-specific scope metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Tracker task annotated with the execution scope it belongs to.
+ */
+export interface ScopedTrackerTask extends TrackerTask {
+  /** Scope that produced this task */
+  executionScope?: ExecutionScope;
+}
+
+/**
  * Result of completing a task
  */
 export interface TaskCompletionResult {

--- a/src/remote/client.ts
+++ b/src/remote/client.ts
@@ -815,6 +815,7 @@ export class RemoteClient {
   async startOrchestration(options: {
     prdPath?: string;
     epicId?: string;
+    epicIds?: string[];
     maxWorkers?: number;
     maxIterations?: number;
     directMerge?: boolean;

--- a/src/remote/server.test.ts
+++ b/src/remote/server.test.ts
@@ -217,6 +217,19 @@ describe('RemoteServer', () => {
             elapsedMs: 200,
           },
         ],
+        workerResults: [
+          {
+            workerId: 'worker-4',
+            task: uiTask,
+            success: false,
+            iterationsRun: 1,
+            taskCompleted: false,
+            durationMs: 150,
+            error: 'worker failed',
+            branchName: 'ralph-parallel/session/ui/ui-task',
+            commitCount: 0,
+          },
+        ],
         mergeQueue: [
           {
             id: 'merge-1',
@@ -245,7 +258,7 @@ describe('RemoteServer', () => {
           totalTasks: 1,
           activeTasks: 1,
           completedTasks: 0,
-          failedTasks: 0,
+          failedTasks: 1,
         },
         {
           scopeId: 'backend',
@@ -263,6 +276,7 @@ describe('RemoteServer', () => {
         scopes: [scope],
         taskGraph: null,
         workers: [],
+        workerResults: [],
         mergeQueue: [],
       } as Partial<ParallelExecutorState> as ParallelExecutorState;
 

--- a/src/remote/server.test.ts
+++ b/src/remote/server.test.ts
@@ -4,9 +4,18 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { RemoteServer } from './server.js';
+import {
+  RemoteServer,
+  buildRemoteScopeCounts,
+  resolveExecutionScopes,
+} from './server.js';
 import type { RalphConfig } from '../config/types.js';
-import type { TrackerPlugin } from '../plugins/trackers/types.js';
+import type {
+  ExecutionScope,
+  TrackerPlugin,
+  TrackerTask,
+} from '../plugins/trackers/types.js';
+import type { ParallelExecutorState } from '../parallel/types.js';
 
 /** Create a minimal mock config for testing */
 function createMockConfig(): RalphConfig {
@@ -59,6 +68,20 @@ function createMockTracker(): TrackerPlugin {
   };
 }
 
+function createScopedTask(
+  id: string,
+  scope: ExecutionScope,
+  status: TrackerTask['status'] = 'open'
+): TrackerTask {
+  return {
+    id,
+    title: id,
+    status,
+    priority: 2,
+    executionScope: scope,
+  } as TrackerTask & { executionScope: ExecutionScope };
+}
+
 describe('RemoteServer', () => {
   describe('constructor', () => {
     test('creates instance with minimal options', () => {
@@ -108,6 +131,142 @@ describe('RemoteServer', () => {
       const server = new RemoteServer({ port: 7890, hasToken: false });
 
       expect(server.actualPort).toBeNull();
+    });
+  });
+
+  describe('multi-epic orchestration helpers', () => {
+    test('resolves requested epic IDs to execution scopes in requested order', async () => {
+      const tracker = {
+        ...createMockTracker(),
+        getEpics: async () => [
+          {
+            id: 'backend',
+            title: 'Backend Epic',
+            type: 'epic',
+            status: 'open',
+            priority: 2,
+          },
+          {
+            id: 'ui',
+            title: 'UI Epic',
+            type: 'epic',
+            status: 'open',
+            priority: 2,
+          },
+        ],
+      } as TrackerPlugin;
+
+      const scopes = await resolveExecutionScopes(tracker, ['ui', 'missing', 'backend']);
+
+      expect(scopes).toEqual([
+        expect.objectContaining({ id: 'ui', title: 'UI Epic', type: 'epic' }),
+        expect.objectContaining({ id: 'missing', title: 'missing', type: 'epic' }),
+        expect.objectContaining({ id: 'backend', title: 'Backend Epic', type: 'epic' }),
+      ]);
+    });
+
+    test('builds per-scope counts from graph, workers, and merge queue', () => {
+      const ui: ExecutionScope = { id: 'ui', title: 'UI', type: 'epic' };
+      const backend: ExecutionScope = { id: 'backend', title: 'Backend', type: 'epic' };
+      const uiTask = createScopedTask('ui-task', ui);
+      const backendTask = createScopedTask('backend-task', backend);
+      const failedTask = createScopedTask('backend-failed', backend);
+
+      const state = {
+        scopes: [ui, backend],
+        taskGraph: {
+          nodes: new Map([
+            ['ui-task', {
+              task: uiTask,
+              dependencies: [],
+              dependents: [],
+              depth: 0,
+              inCycle: false,
+            }],
+            ['backend-task', {
+              task: backendTask,
+              dependencies: [],
+              dependents: [],
+              depth: 0,
+              inCycle: false,
+            }],
+          ]),
+          groups: [],
+          cyclicTaskIds: [],
+          actionableTaskCount: 2,
+          maxParallelism: 2,
+          recommendParallel: true,
+        },
+        workers: [
+          {
+            id: 'worker-1',
+            status: 'running',
+            task: uiTask,
+            currentIteration: 1,
+            maxIterations: 5,
+            lastOutput: '',
+            elapsedMs: 100,
+          },
+          {
+            id: 'worker-2',
+            status: 'failed',
+            task: failedTask,
+            currentIteration: 2,
+            maxIterations: 5,
+            lastOutput: '',
+            elapsedMs: 200,
+          },
+        ],
+        mergeQueue: [
+          {
+            id: 'merge-1',
+            workerResult: {
+              workerId: 'worker-3',
+              task: backendTask,
+              success: true,
+              iterationsRun: 1,
+              taskCompleted: true,
+              durationMs: 300,
+              branchName: 'ralph-parallel/session/backend/backend-task',
+              commitCount: 1,
+            },
+            status: 'completed',
+            backupTag: 'backup',
+            sourceBranch: 'ralph-parallel/session/backend/backend-task',
+            commitMessage: 'complete backend-task',
+            queuedAt: new Date().toISOString(),
+          },
+        ],
+      } as Partial<ParallelExecutorState> as ParallelExecutorState;
+
+      expect(buildRemoteScopeCounts(state)).toEqual([
+        {
+          scopeId: 'ui',
+          totalTasks: 1,
+          activeTasks: 1,
+          completedTasks: 0,
+          failedTasks: 0,
+        },
+        {
+          scopeId: 'backend',
+          totalTasks: 1,
+          activeTasks: 0,
+          completedTasks: 1,
+          failedTasks: 1,
+        },
+      ]);
+    });
+
+    test('omits per-scope counts for single-scope state', () => {
+      const scope: ExecutionScope = { id: 'ui', title: 'UI', type: 'epic' };
+      const state = {
+        scopes: [scope],
+        taskGraph: null,
+        workers: [],
+        mergeQueue: [],
+      } as Partial<ParallelExecutorState> as ParallelExecutorState;
+
+      expect(buildRemoteScopeCounts(state)).toBeUndefined();
     });
   });
 });

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -72,7 +72,7 @@ import type { RalphConfig } from '../config/types.js';
 import { summarizeTokenUsageFromOutput } from '../plugins/agents/usage.js';
 import { ParallelExecutor, analyzeTaskGraph, shouldRunParallel } from '../parallel/index.js';
 import type { ParallelEvent } from '../parallel/events.js';
-import type { ParallelExecutorState } from '../parallel/types.js';
+import type { ParallelExecutorState, WorkerResult } from '../parallel/types.js';
 
 export async function resolveExecutionScopes(
   tracker: TrackerPlugin,
@@ -133,6 +133,10 @@ function createRemoteScopeCount(scopeId: string): RemoteScopeCount {
   };
 }
 
+function isFailedWorkerResult(result: WorkerResult): boolean {
+  return !result.success || !result.taskCompleted;
+}
+
 export function buildRemoteScopeCounts(
   executorState: ParallelExecutorState
 ): RemoteScopeCount[] | undefined {
@@ -162,6 +166,15 @@ export function buildRemoteScopeCounts(
     } else if (worker.status === 'failed' || worker.status === 'cancelled') {
       count.failedTasks += 1;
     }
+    counts.set(scope.id, count);
+  }
+
+  for (const result of executorState.workerResults ?? []) {
+    if (!isFailedWorkerResult(result)) continue;
+    const scope = getTaskExecutionScope(result.task);
+    if (!scope) continue;
+    const count = counts.get(scope.id) ?? createRemoteScopeCount(scope.id);
+    count.failedTasks += 1;
     counts.set(scope.id, count);
   }
 

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -74,7 +74,7 @@ import { ParallelExecutor, analyzeTaskGraph, shouldRunParallel } from '../parall
 import type { ParallelEvent } from '../parallel/events.js';
 import type { ParallelExecutorState } from '../parallel/types.js';
 
-async function resolveExecutionScopes(
+export async function resolveExecutionScopes(
   tracker: TrackerPlugin,
   epicIds: string[]
 ): Promise<ExecutionScope[]> {
@@ -133,7 +133,7 @@ function createRemoteScopeCount(scopeId: string): RemoteScopeCount {
   };
 }
 
-function buildRemoteScopeCounts(
+export function buildRemoteScopeCounts(
   executorState: ParallelExecutorState
 ): RemoteScopeCount[] | undefined {
   if (!executorState.scopes || executorState.scopes.length <= 1) {

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -50,6 +50,7 @@ import type {
   OrchestrateStateResponseMessage,
   ParallelEventMessage,
   RemoteOrchestrationState,
+  RemoteScopeCount,
 } from './types.js';
 import {
   validateServerToken,
@@ -62,11 +63,126 @@ import {
 } from './token.js';
 import { createAuditLogger, type AuditLogger } from './audit.js';
 import type { ExecutionEngine, EngineEvent } from '../engine/index.js';
-import type { TrackerPlugin } from '../plugins/trackers/types.js';
+import type { ExecutionScope, TrackerPlugin, TrackerTask } from '../plugins/trackers/types.js';
+import {
+  MultiScopeTrackerPlugin,
+  createExecutionScopeFromTask,
+} from '../plugins/trackers/multi-scope.js';
 import type { RalphConfig } from '../config/types.js';
 import { summarizeTokenUsageFromOutput } from '../plugins/agents/usage.js';
 import { ParallelExecutor, analyzeTaskGraph, shouldRunParallel } from '../parallel/index.js';
 import type { ParallelEvent } from '../parallel/events.js';
+import type { ParallelExecutorState } from '../parallel/types.js';
+
+async function resolveExecutionScopes(
+  tracker: TrackerPlugin,
+  epicIds: string[]
+): Promise<ExecutionScope[]> {
+  if (epicIds.length === 0) return [];
+  let epics: TrackerTask[] = [];
+  try {
+    epics = await tracker.getEpics();
+  } catch {
+    epics = [];
+  }
+  return epicIds.map((epicId) => {
+    const epic = epics.find((candidate) => candidate.id === epicId);
+    return epic ? createExecutionScopeFromTask(epic) : {
+      id: epicId,
+      title: epicId,
+      type: 'epic',
+    };
+  });
+}
+
+function getTaskExecutionScope(task: TrackerTask): ExecutionScope | undefined {
+  const scopedTask = task as TrackerTask & { executionScope?: ExecutionScope };
+  if (scopedTask.executionScope) {
+    return scopedTask.executionScope;
+  }
+
+  const metadataScope = task.metadata?.executionScope;
+  if (!metadataScope || typeof metadataScope !== 'object') {
+    return undefined;
+  }
+
+  const scopeRecord = metadataScope as Record<string, unknown>;
+  const id = scopeRecord.id;
+  if (typeof id !== 'string') {
+    return undefined;
+  }
+
+  return {
+    id,
+    title: typeof scopeRecord.title === 'string' ? scopeRecord.title : id,
+    type: scopeRecord.type === 'prd' || scopeRecord.type === 'tracker' ? scopeRecord.type : 'epic',
+    description: typeof scopeRecord.description === 'string' ? scopeRecord.description : undefined,
+    metadata: scopeRecord.metadata && typeof scopeRecord.metadata === 'object'
+      ? scopeRecord.metadata as Record<string, unknown>
+      : undefined,
+  };
+}
+
+function createRemoteScopeCount(scopeId: string): RemoteScopeCount {
+  return {
+    scopeId,
+    totalTasks: 0,
+    activeTasks: 0,
+    completedTasks: 0,
+    failedTasks: 0,
+  };
+}
+
+function buildRemoteScopeCounts(
+  executorState: ParallelExecutorState
+): RemoteScopeCount[] | undefined {
+  if (!executorState.scopes || executorState.scopes.length <= 1) {
+    return undefined;
+  }
+
+  const counts = new Map<string, RemoteScopeCount>();
+  for (const scope of executorState.scopes) {
+    counts.set(scope.id, createRemoteScopeCount(scope.id));
+  }
+
+  for (const node of executorState.taskGraph?.nodes.values() ?? []) {
+    const scope = getTaskExecutionScope(node.task);
+    if (!scope) continue;
+    const count = counts.get(scope.id) ?? createRemoteScopeCount(scope.id);
+    count.totalTasks += 1;
+    counts.set(scope.id, count);
+  }
+
+  for (const worker of executorState.workers) {
+    const scope = getTaskExecutionScope(worker.task);
+    if (!scope) continue;
+    const count = counts.get(scope.id) ?? createRemoteScopeCount(scope.id);
+    if (worker.status === 'running') {
+      count.activeTasks += 1;
+    } else if (worker.status === 'failed' || worker.status === 'cancelled') {
+      count.failedTasks += 1;
+    }
+    counts.set(scope.id, count);
+  }
+
+  for (const operation of executorState.mergeQueue) {
+    const scope = getTaskExecutionScope(operation.workerResult.task);
+    if (!scope) continue;
+    const count = counts.get(scope.id) ?? createRemoteScopeCount(scope.id);
+    if (operation.status === 'completed') {
+      count.completedTasks += 1;
+    } else if (
+      operation.status === 'failed' ||
+      operation.status === 'conflicted' ||
+      operation.status === 'rolled-back'
+    ) {
+      count.failedTasks += 1;
+    }
+    counts.set(scope.id, count);
+  }
+
+  return [...counts.values()];
+}
 
 /**
  * WebSocket data attached to each connection
@@ -1363,8 +1479,18 @@ export class RemoteServer {
         return;
       }
 
+      const requestedEpicIds = message.epicIds && message.epicIds.length > 0
+        ? message.epicIds
+        : message.epicId
+          ? [message.epicId]
+          : this.options.baseConfig.epicIds ?? [];
+      const scopes = await resolveExecutionScopes(this.options.tracker, requestedEpicIds);
+      const orchestrationTracker = scopes.length > 1
+        ? new MultiScopeTrackerPlugin(this.options.tracker, scopes)
+        : this.options.tracker;
+
       // Fetch tasks from tracker
-      let tasks = await this.options.tracker.getTasks({ status: ['open', 'in_progress'] });
+      let tasks = await orchestrationTracker.getTasks({ status: ['open', 'in_progress'] });
 
       // Apply filteredTaskIds filter if specified in baseConfig (non-empty array)
       if (filteredTaskIds && filteredTaskIds.length > 0) {
@@ -1416,13 +1542,18 @@ export class RemoteServer {
       // Create ParallelExecutor with validated options
       // Pass filteredTaskIds so executor only schedules those tasks
       const executor = new ParallelExecutor(
-        this.options.baseConfig,
-        this.options.tracker,
+        {
+          ...this.options.baseConfig,
+          epicId: requestedEpicIds[0] ?? this.options.baseConfig.epicId,
+          epicIds: requestedEpicIds.length > 0 ? requestedEpicIds : this.options.baseConfig.epicIds,
+        },
+        orchestrationTracker,
         {
           maxWorkers,
           directMerge: message.directMerge ?? false,
           maxIterationsPerWorker: message.maxIterations ?? this.options.baseConfig.maxIterations,
           filteredTaskIds: filteredTaskIds?.length ? filteredTaskIds : undefined,
+          scopes,
         }
       );
 
@@ -1622,6 +1753,8 @@ export class RemoteServer {
       elapsedMs: executorState.elapsedMs,
       sessionBranch: this.orchestrationSession.executor.getSessionBranch() ?? undefined,
       originalBranch: this.orchestrationSession.executor.getOriginalBranch() ?? undefined,
+      scopes: executorState.scopes,
+      scopeCounts: buildRemoteScopeCounts(executorState),
     };
 
     const response = createMessage<OrchestrateStateResponseMessage>('orchestrate:state_response', {

--- a/src/remote/types.ts
+++ b/src/remote/types.ts
@@ -583,10 +583,27 @@ export interface IterationOutputResponseMessage extends WSMessage {
 // ============================================================================
 
 import type { ParallelEvent } from '../parallel/events.js';
+import type { ExecutionScope } from '../plugins/trackers/types.js';
 import type {
   WorkerDisplayState,
   MergeOperation,
 } from '../parallel/types.js';
+
+/**
+ * Per-scope orchestration counts for remote multi-epic state.
+ */
+export interface RemoteScopeCount {
+  /** Execution scope ID */
+  scopeId: string;
+  /** Total actionable tasks in this scope */
+  totalTasks: number;
+  /** Currently running tasks in this scope */
+  activeTasks: number;
+  /** Successfully merged tasks in this scope */
+  completedTasks: number;
+  /** Failed, conflicted, or cancelled tasks in this scope */
+  failedTasks: number;
+}
 
 /**
  * Request to start parallel orchestration on remote.
@@ -597,6 +614,8 @@ export interface OrchestrateStartMessage extends WSMessage {
   prdPath?: string;
   /** Epic ID (for beads/beads-rust tracker) */
   epicId?: string;
+  /** Epic IDs for multi-epic orchestration */
+  epicIds?: string[];
   /** Maximum workers (default: 3) */
   maxWorkers?: number;
   /** Maximum iterations per worker */
@@ -684,6 +703,10 @@ export interface RemoteOrchestrationState {
   sessionBranch?: string;
   /** Original branch name (if not using directMerge) */
   originalBranch?: string;
+  /** Selected execution scopes for multi-epic orchestration */
+  scopes?: ExecutionScope[];
+  /** Per-scope task counts for multi-epic orchestration */
+  scopeCounts?: RemoteScopeCount[];
 }
 
 /**

--- a/src/session/index.test.ts
+++ b/src/session/index.test.ts
@@ -1,0 +1,56 @@
+/**
+ * ABOUTME: Tests for session metadata creation.
+ * Covers multi-epic session fields written to session metadata.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ExecutionScope } from '../plugins/trackers/types.js';
+import { checkSession, createSession } from './index.js';
+
+let tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'ralph-session-index-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(async () => {
+  for (const tempDir of tempDirs) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe('createSession', () => {
+  test('persists multi-epic IDs and execution scopes', async () => {
+    const cwd = await createTempDir();
+    const executionScopes: ExecutionScope[] = [
+      { id: 'ui-epic', title: 'UI', type: 'epic' },
+      { id: 'backend-epic', title: 'Backend', type: 'epic' },
+    ];
+
+    const session = await createSession({
+      cwd,
+      sessionId: 'session-123',
+      agentPlugin: 'claude',
+      trackerPlugin: 'beads-rust',
+      epicId: 'ui-epic',
+      epicIds: ['ui-epic', 'backend-epic'],
+      executionScopes,
+      maxIterations: 5,
+      totalTasks: 2,
+      lockAlreadyAcquired: true,
+    });
+
+    expect(session.epicIds).toEqual(['ui-epic', 'backend-epic']);
+    expect(session.executionScopes).toEqual(executionScopes);
+
+    const checked = await checkSession(cwd);
+    expect(checked.session?.epicIds).toEqual(['ui-epic', 'backend-epic']);
+    expect(checked.session?.executionScopes).toEqual(executionScopes);
+  });
+});

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -258,6 +258,8 @@ export async function createSession(
     agentPlugin: options.agentPlugin,
     trackerPlugin: options.trackerPlugin,
     epicId: options.epicId,
+    epicIds: options.epicIds,
+    executionScopes: options.executionScopes,
     prdPath: options.prdPath,
     currentIteration: 0,
     maxIterations: options.maxIterations,

--- a/src/session/persistence.test.ts
+++ b/src/session/persistence.test.ts
@@ -1,0 +1,76 @@
+/**
+ * ABOUTME: Tests for persisted session state serialization and summaries.
+ * Covers multi-epic session metadata so resume can restore selected scopes.
+ */
+
+import { describe, expect, test, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ExecutionScope, TrackerTask } from '../plugins/trackers/types.js';
+import {
+  createPersistedSession,
+  getSessionSummary,
+  loadPersistedSession,
+  savePersistedSession,
+} from './persistence.js';
+
+let tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'ralph-session-persistence-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(async () => {
+  for (const tempDir of tempDirs) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+function task(id: string): TrackerTask {
+  return {
+    id,
+    title: id,
+    status: 'open',
+    priority: 2,
+  };
+}
+
+describe('session persistence multi-epic metadata', () => {
+  test('creates, saves, loads, and summarizes epicIds and execution scopes', async () => {
+    const cwd = await createTempDir();
+    const executionScopes: ExecutionScope[] = [
+      { id: 'ui-epic', title: 'UI', type: 'epic' },
+      { id: 'backend-epic', title: 'Backend', type: 'epic' },
+    ];
+
+    const state = createPersistedSession({
+      sessionId: 'session-123',
+      agentPlugin: 'claude',
+      trackerPlugin: 'beads-rust',
+      epicId: 'ui-epic',
+      epicIds: ['ui-epic', 'backend-epic'],
+      executionScopes,
+      maxIterations: 5,
+      tasks: [task('ui-task'), task('backend-task')],
+      cwd,
+    });
+
+    expect(state.trackerState.epicIds).toEqual(['ui-epic', 'backend-epic']);
+    expect(state.trackerState.executionScopes).toEqual(executionScopes);
+
+    await savePersistedSession(state);
+    const loaded = await loadPersistedSession(cwd);
+
+    expect(loaded?.trackerState.epicIds).toEqual(['ui-epic', 'backend-epic']);
+    expect(loaded?.trackerState.executionScopes).toEqual(executionScopes);
+
+    const summary = getSessionSummary(loaded!);
+    expect(summary.epicId).toBe('ui-epic');
+    expect(summary.epicIds).toEqual(['ui-epic', 'backend-epic']);
+    expect(summary.executionScopes).toEqual(executionScopes);
+  });
+});

--- a/src/session/persistence.test.ts
+++ b/src/session/persistence.test.ts
@@ -64,11 +64,15 @@ describe('session persistence multi-epic metadata', () => {
 
     await savePersistedSession(state);
     const loaded = await loadPersistedSession(cwd);
+    expect(loaded).not.toBeNull();
+    if (!loaded) {
+      throw new Error('Expected persisted session to load');
+    }
 
-    expect(loaded?.trackerState.epicIds).toEqual(['ui-epic', 'backend-epic']);
-    expect(loaded?.trackerState.executionScopes).toEqual(executionScopes);
+    expect(loaded.trackerState.epicIds).toEqual(['ui-epic', 'backend-epic']);
+    expect(loaded.trackerState.executionScopes).toEqual(executionScopes);
 
-    const summary = getSessionSummary(loaded!);
+    const summary = getSessionSummary(loaded);
     expect(summary.epicId).toBe('ui-epic');
     expect(summary.epicIds).toEqual(['ui-epic', 'backend-epic']);
     expect(summary.executionScopes).toEqual(executionScopes);

--- a/src/session/persistence.ts
+++ b/src/session/persistence.ts
@@ -11,7 +11,11 @@ import {
   access,
   constants,
 } from 'node:fs/promises';
-import type { TrackerTask, TrackerTaskStatus } from '../plugins/trackers/types.js';
+import type {
+  ExecutionScope,
+  TrackerTask,
+  TrackerTaskStatus,
+} from '../plugins/trackers/types.js';
 import type { IterationResult } from '../engine/types.js';
 import type { SessionStatus } from './types.js';
 import { writeJsonAtomic } from './atomic-write.js';
@@ -43,6 +47,10 @@ export interface TrackerStateSnapshot {
   plugin: string;
   /** Epic ID if using beads */
   epicId?: string;
+  /** Epic IDs if using a multi-epic hierarchy tracker run */
+  epicIds?: string[];
+  /** Selected execution scopes */
+  executionScopes?: ExecutionScope[];
   /** PRD path if using json tracker */
   prdPath?: string;
   /** Total tasks at session start */
@@ -301,6 +309,8 @@ export function createPersistedSession(options: {
   model?: string;
   trackerPlugin: string;
   epicId?: string;
+  epicIds?: string[];
+  executionScopes?: ExecutionScope[];
   prdPath?: string;
   maxIterations: number;
   tasks: TrackerTask[];
@@ -323,6 +333,8 @@ export function createPersistedSession(options: {
     trackerState: {
       plugin: options.trackerPlugin,
       epicId: options.epicId,
+      epicIds: options.epicIds,
+      executionScopes: options.executionScopes,
       prdPath: options.prdPath,
       totalTasks: options.tasks.length,
       tasks: options.tasks.map((task) => ({
@@ -640,6 +652,8 @@ export function getSessionSummary(state: PersistedSessionState): {
   agentPlugin: string;
   trackerPlugin: string;
   epicId?: string;
+  epicIds?: string[];
+  executionScopes?: ExecutionScope[];
   prdPath?: string;
 } {
   // Defensive: handle missing trackerState (corrupted/old session files)
@@ -663,6 +677,8 @@ export function getSessionSummary(state: PersistedSessionState): {
     agentPlugin: state.agentPlugin,
     trackerPlugin: trackerState.plugin ?? 'unknown',
     epicId: trackerState.epicId,
+    epicIds: trackerState.epicIds,
+    executionScopes: trackerState.executionScopes,
     prdPath: trackerState.prdPath,
   };
 }

--- a/src/session/registry.test.ts
+++ b/src/session/registry.test.ts
@@ -52,6 +52,8 @@ describe('Session Registry', () => {
         agentPlugin: 'claude',
         trackerPlugin: 'json',
         prdPath: '/tmp/test-project/prd.json',
+        epicId: 'ui-epic',
+        epicIds: ['ui-epic', 'backend-epic'],
       };
 
       await registerSession(entry);
@@ -61,6 +63,8 @@ describe('Session Registry', () => {
       expect(retrieved?.sessionId).toBe(sessionId);
       expect(retrieved?.cwd).toBe('/tmp/test-project');
       expect(retrieved?.status).toBe('running');
+      expect(retrieved?.epicId).toBe('ui-epic');
+      expect(retrieved?.epicIds).toEqual(['ui-epic', 'backend-epic']);
     });
 
     test('updates existing session on re-register', async () => {

--- a/src/session/registry.ts
+++ b/src/session/registry.ts
@@ -75,6 +75,9 @@ export interface SessionRegistryEntry {
   /** Epic ID (for beads tracker) */
   epicId?: string;
 
+  /** Epic IDs for multi-epic runs */
+  epicIds?: string[];
+
   /** PRD path (for json tracker) */
   prdPath?: string;
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -3,6 +3,8 @@
  * Defines session state, lock files, and related structures.
  */
 
+import type { ExecutionScope } from '../plugins/trackers/types.js';
+
 /**
  * Session status
  */
@@ -61,6 +63,12 @@ export interface SessionMetadata {
   /** Epic ID (if using beads) */
   epicId?: string;
 
+  /** Epic IDs for multi-epic runs */
+  epicIds?: string[];
+
+  /** Selected execution scopes for multi-epic runs */
+  executionScopes?: ExecutionScope[];
+
   /** PRD path (if using json tracker) */
   prdPath?: string;
 
@@ -115,6 +123,12 @@ export interface CreateSessionOptions {
 
   /** Epic ID (if using beads) */
   epicId?: string;
+
+  /** Epic IDs for multi-epic runs */
+  epicIds?: string[];
+
+  /** Selected execution scopes for multi-epic runs */
+  executionScopes?: ExecutionScope[];
 
   /** PRD path (if using json tracker) */
   prdPath?: string;

--- a/src/tui/components/EpicSelectionApp.tsx
+++ b/src/tui/components/EpicSelectionApp.tsx
@@ -17,7 +17,7 @@ export interface EpicSelectionAppProps {
   /** Tracker plugin instance */
   tracker: TrackerPlugin;
   /** Callback when user selects an epic and wants to start a run */
-  onEpicSelected: (epic: TrackerTask) => void;
+  onEpicSelected: (epics: TrackerTask[]) => void;
   /** Callback when user quits without selecting */
   onQuit: () => void;
 }
@@ -33,6 +33,7 @@ export function EpicSelectionApp({
 }: EpicSelectionAppProps): ReactNode {
   const [epics, setEpics] = useState<TrackerTask[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedEpicIds, setSelectedEpicIds] = useState<Set<string>>(() => new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | undefined>();
 
@@ -65,8 +66,10 @@ export function EpicSelectionApp({
 
   // Handle keyboard navigation
   const handleKeyboard = useCallback(
-    (key: { name: string }) => {
-      switch (key.name) {
+    (key: { name: string; sequence?: string }) => {
+      const keyName = key.sequence === ' ' ? 'space' : key.name;
+
+      switch (keyName) {
         case 'q':
         case 'escape':
           onQuit();
@@ -82,17 +85,40 @@ export function EpicSelectionApp({
           setSelectedIndex((prev) => Math.min(epics.length - 1, prev + 1));
           break;
 
+        case 'space':
+          if (epics.length > 0 && epics[selectedIndex]) {
+            const epic = epics[selectedIndex];
+            setSelectedEpicIds((prev) => {
+              const next = new Set(prev);
+              if (next.has(epic.id)) {
+                next.delete(epic.id);
+              } else {
+                next.add(epic.id);
+              }
+              return next;
+            });
+          }
+          break;
+
+        case 'a':
+          setSelectedEpicIds((prev) =>
+            prev.size === epics.length
+              ? new Set()
+              : new Set(epics.map((epic) => epic.id))
+          );
+          break;
+
         case 'return':
         case 'enter':
         case 'r':
-          // Start run on selected epic
           if (epics.length > 0 && epics[selectedIndex]) {
-            onEpicSelected(epics[selectedIndex]);
+            const selected = epics.filter((epic) => selectedEpicIds.has(epic.id));
+            onEpicSelected(selected.length > 0 ? selected : [epics[selectedIndex]]);
           }
           break;
       }
     },
-    [epics, selectedIndex, onEpicSelected, onQuit]
+    [epics, selectedIndex, selectedEpicIds, onEpicSelected, onQuit]
   );
 
   useKeyboard(handleKeyboard);
@@ -101,6 +127,7 @@ export function EpicSelectionApp({
     <EpicSelectionView
       epics={epics}
       selectedIndex={selectedIndex}
+      selectedEpicIds={selectedEpicIds}
       trackerName={tracker.meta.name}
       loading={loading}
       error={error}

--- a/src/tui/components/EpicSelectionView.tsx
+++ b/src/tui/components/EpicSelectionView.tsx
@@ -16,6 +16,8 @@ export interface EpicSelectionViewProps {
   epics: TrackerTask[];
   /** Currently selected epic index */
   selectedIndex: number;
+  /** IDs toggled for multi-select */
+  selectedEpicIds?: Set<string>;
   /** Name of the tracker being used */
   trackerName: string;
   /** Whether we're loading epics */
@@ -73,6 +75,7 @@ function getEpicStatusColor(epic: TrackerTask): string {
 export function EpicSelectionView({
   epics,
   selectedIndex,
+  selectedEpicIds = new Set(),
   trackerName,
   loading = false,
   error,
@@ -175,6 +178,9 @@ export function EpicSelectionView({
         <box style={{ flexDirection: 'row', gap: 2 }}>
           <text fg={colors.accent.primary}>Select Epic</text>
           <text fg={colors.fg.muted}>({epics.length} available)</text>
+          {selectedEpicIds.size > 0 && (
+            <text fg={colors.fg.muted}>{selectedEpicIds.size} selected</text>
+          )}
         </box>
         <text fg={colors.fg.muted}>[{trackerName}]</text>
       </box>
@@ -192,6 +198,7 @@ export function EpicSelectionView({
         <scrollbox style={{ flexGrow: 1 }}>
           {epics.map((epic, index) => {
             const isSelected = index === selectedIndex;
+            const isToggled = selectedEpicIds.has(epic.id);
             const statusColor = getEpicStatusColor(epic);
             const meta = epic.metadata as Record<string, unknown> | undefined;
             const storyCount = (meta?.storyCount as number | undefined) ?? 0;
@@ -217,6 +224,10 @@ export function EpicSelectionView({
                 {/* Selection indicator */}
                 <text fg={isSelected ? colors.accent.primary : 'transparent'}>
                   {isSelected ? '▸ ' : '  '}
+                </text>
+
+                <text fg={isToggled ? colors.accent.primary : colors.fg.dim}>
+                  {isToggled ? '■ ' : '□ '}
                 </text>
 
                 {/* Status indicator */}
@@ -258,6 +269,12 @@ export function EpicSelectionView({
       >
         <text fg={colors.fg.muted}>
           <span fg={colors.accent.primary}>Enter/r</span> Start Run
+        </text>
+        <text fg={colors.fg.muted}>
+          <span fg={colors.accent.primary}>Space</span> Toggle
+        </text>
+        <text fg={colors.fg.muted}>
+          <span fg={colors.accent.primary}>a</span> All
         </text>
         <text fg={colors.fg.muted}>
           <span fg={colors.accent.primary}>↑↓/jk</span> Navigate

--- a/src/tui/components/LeftPanel.tsx
+++ b/src/tui/components/LeftPanel.tsx
@@ -40,6 +40,13 @@ function formatTaskUsageIndicator(task: TaskItem): string {
   return `c${contextDisplay} t${formatTokenCount(totalTokens)}`;
 }
 
+function formatScopePrefix(task: TaskItem): string {
+  const label = task.executionScope?.title || task.executionScope?.id;
+  if (!label) return '';
+  const compact = label.length > 10 ? `${label.slice(0, 9)}…` : label;
+  return `[${compact}]`;
+}
+
 /**
  * Single task item row
  * Shows: [indent][status indicator] [task ID] [task title (truncated)]
@@ -51,6 +58,7 @@ function TaskRow({
   isSelected,
   maxWidth,
   indentLevel = 0,
+  showScopePrefix = false,
 }: {
   task: TaskItem;
   isSelected: boolean;
@@ -58,6 +66,8 @@ function TaskRow({
   maxWidth: number;
   /** Indentation level (0 = epic/root, 1 = child of epic) */
   indentLevel?: number;
+  /** Whether to show a compact execution scope prefix before the task ID */
+  showScopePrefix?: boolean;
 }): ReactNode {
   const statusColor = getTaskStatusColor(task.status);
   const statusIndicator = getTaskStatusIndicator(task.status);
@@ -70,11 +80,16 @@ function TaskRow({
   // Calculate available width:
   // maxWidth - indent - indicator(1) - space(1) - id - space(1)
   const idDisplay = task.id;
+  const scopePrefix = showScopePrefix ? formatScopePrefix(task) : '';
+  const scopePrefixWidth = scopePrefix ? scopePrefix.length + 1 : 0;
   const indentWidth = indentLevel * 2;
   const usageIndicator = formatTaskUsageIndicator(task);
   const hasUsageIndicator = usageIndicator.length > 0;
   const usageIndicatorWidth = hasUsageIndicator ? usageIndicator.length + 1 : 0;
-  const availableForTitle = Math.max(0, maxWidth - indentWidth - 3 - idDisplay.length);
+  const availableForTitle = Math.max(
+    0,
+    maxWidth - indentWidth - 3 - idDisplay.length - scopePrefixWidth
+  );
   const minimalTitlePlusIndicator = 5 + usageIndicator.length + 1;
   const shouldShowUsageIndicator =
     hasUsageIndicator && availableForTitle > minimalTitlePlusIndicator;
@@ -104,6 +119,7 @@ function TaskRow({
       <text>
         <span fg={colors.fg.dim}>{indent}</span>
         <span fg={statusColor}>{statusIndicator}</span>
+        {scopePrefix && <span fg={colors.accent.tertiary}> {scopePrefix}</span>}
         <span fg={idColor}> {idDisplay}</span>
         <span fg={titleColor}> {truncatedTitle}</span>
         {shouldShowUsageIndicator && <span fg={colors.fg.dim}> {usageIndicator}</span>}
@@ -151,6 +167,7 @@ export const LeftPanel = memo(function LeftPanel({
   isViewingRemote = false,
   remoteConnectionStatus,
   remoteAlias,
+  showScopePrefixes = false,
 }: LeftPanelProps & {
   width?: number;
   isFocused?: boolean;
@@ -160,6 +177,8 @@ export const LeftPanel = memo(function LeftPanel({
   remoteConnectionStatus?: ConnectionStatus;
   /** Alias of the remote being viewed */
   remoteAlias?: string;
+  /** Show compact execution scope labels on task rows */
+  showScopePrefixes?: boolean;
 }): ReactNode {
   // Calculate max width for task row content (panel width minus padding and border)
   const maxRowWidth = Math.max(20, width - 4);
@@ -214,6 +233,7 @@ export const LeftPanel = memo(function LeftPanel({
               isSelected={index === selectedIndex}
               maxWidth={maxRowWidth}
               indentLevel={indentMap.get(task.id) ?? 0}
+              showScopePrefix={showScopePrefixes}
             />
           ))
         )}

--- a/src/tui/components/MergeProgressView.tsx
+++ b/src/tui/components/MergeProgressView.tsx
@@ -9,6 +9,7 @@ import { memo } from 'react';
 import { createTextAttributes } from '@opentui/core';
 import { colors, statusIndicators, formatElapsedTime } from '../theme.js';
 import type { MergeOperation } from '../../parallel/types.js';
+import type { ScopedTrackerTask } from '../../plugins/trackers/types.js';
 
 const boldAttr = createTextAttributes({ bold: true });
 
@@ -58,6 +59,13 @@ function getMergeElapsed(op: MergeOperation): string {
   return formatElapsedTime(seconds);
 }
 
+function getScopeLabel(operation: MergeOperation): string {
+  const scope = (operation.workerResult.task as ScopedTrackerTask).executionScope;
+  if (!scope) return '';
+  const label = scope.title || scope.id;
+  return label.length > 14 ? `${label.slice(0, 13)}…` : label;
+}
+
 /**
  * Single merge operation row.
  */
@@ -72,12 +80,14 @@ function MergeOperationRow({
   const elapsed = getMergeElapsed(operation);
   const taskId = operation.workerResult.task.id;
   const taskTitle = operation.workerResult.task.title;
+  const scopeLabel = getScopeLabel(operation);
+  const scopedTaskId = scopeLabel ? `[${scopeLabel}] ${taskId}` : taskId;
 
   // Build the line: indicator taskId → main  label  elapsed
   const prefix = `${indicator} `;
   const arrow = ' → main  ';
   const suffix = elapsed ? `  ${elapsed}` : '';
-  const fixedLen = prefix.length + taskId.length + arrow.length + label.length + suffix.length;
+  const fixedLen = prefix.length + scopedTaskId.length + arrow.length + label.length + suffix.length;
   const titleSpace = maxWidth - fixedLen - 2;
   const title = titleSpace > 3
     ? (taskTitle.length > titleSpace ? taskTitle.slice(0, titleSpace - 1) + '…' : taskTitle)
@@ -87,6 +97,7 @@ function MergeOperationRow({
     <box style={{ flexDirection: 'column' }}>
       <text>
         <span fg={color}>{indicator} </span>
+        {scopeLabel && <span fg={colors.accent.tertiary}>[{scopeLabel}] </span>}
         <span fg={colors.fg.secondary}>{taskId}</span>
         <span fg={colors.fg.dim}>{arrow}</span>
         <span fg={color}>{label}</span>

--- a/src/tui/components/ParallelProgressView.tsx
+++ b/src/tui/components/ParallelProgressView.tsx
@@ -9,6 +9,7 @@ import { memo } from 'react';
 import { createTextAttributes } from '@opentui/core';
 import { colors, statusIndicators, formatElapsedTime } from '../theme.js';
 import type { WorkerDisplayState, MergeOperation } from '../../parallel/types.js';
+import type { ExecutionScope, ScopedTrackerTask, TrackerTask } from '../../plugins/trackers/types.js';
 
 const boldAttr = createTextAttributes({ bold: true });
 
@@ -73,6 +74,17 @@ function getMergeStatusDisplay(status: MergeOperation['status']): {
   }
 }
 
+function getExecutionScope(task: TrackerTask): ExecutionScope | undefined {
+  return (task as ScopedTrackerTask).executionScope;
+}
+
+function formatScopeLabel(task: TrackerTask): string {
+  const scope = getExecutionScope(task);
+  if (!scope) return '';
+  const label = scope.title || scope.id;
+  return label.length > 14 ? `${label.slice(0, 13)}…` : label;
+}
+
 /**
  * Single worker row showing status, progress, and task title.
  */
@@ -90,10 +102,12 @@ function WorkerRow({
   const { indicator, color: statusColor } = getWorkerStatusDisplay(worker.status);
   const progress = `[${worker.currentIteration}/${worker.maxIterations}]`;
   const elapsed = worker.elapsedMs > 0 ? formatElapsedTime(Math.floor(worker.elapsedMs / 1000)) : '';
+  const scopeLabel = formatScopeLabel(worker.task);
+  const scopePrefix = scopeLabel ? `[${scopeLabel}] ` : '';
 
-  const prefix = `${indicator} W${index + 1} ${progress} `;
+  const prefix = `${indicator} W${index + 1} ${progress} ${scopePrefix}`;
   const suffix = elapsed ? ` ${elapsed}` : '';
-  const titleWidth = maxWidth - prefix.length - suffix.length;
+  const titleWidth = Math.max(1, maxWidth - prefix.length - suffix.length);
   const title = worker.task.title.length > titleWidth
     ? worker.task.title.slice(0, titleWidth - 1) + '…'
     : worker.task.title;
@@ -105,6 +119,7 @@ function WorkerRow({
       <span fg={statusColor}>{indicator}</span>
       <span fg={colors.fg.muted}> W{index + 1} </span>
       <span fg={colors.fg.dim}>{progress} </span>
+      {scopePrefix && <span fg={colors.accent.tertiary}>{scopePrefix}</span>}
       <span fg={titleColor}>{title}</span>
       {suffix && <span fg={colors.fg.dim}>{suffix}</span>}
     </text>
@@ -123,8 +138,10 @@ function MergeRow({
 }): ReactNode {
   const { indicator, color: mergeColor, label } = getMergeStatusDisplay(operation.status);
   const taskId = operation.workerResult.task.id;
+  const scopeLabel = formatScopeLabel(operation.workerResult.task);
+  const scopedTaskId = scopeLabel ? `[${scopeLabel}] ${taskId}` : taskId;
 
-  const line = `${indicator} ${taskId} → main  ${label}`;
+  const line = `${indicator} ${scopedTaskId} → main  ${label}`;
 
   return (
     <text fg={mergeColor}>{line.slice(0, maxWidth)}</text>

--- a/src/tui/components/RunApp.tsx
+++ b/src/tui/components/RunApp.tsx
@@ -37,6 +37,7 @@ import { WorkerDetailView } from './WorkerDetailView.js';
 import { MergeProgressView } from './MergeProgressView.js';
 import { ConflictResolutionPanel } from './ConflictResolutionPanel.js';
 import { TabBar } from './TabBar.js';
+import { ScopeFilterBar, type ScopeFilterCount } from './ScopeFilterBar.js';
 import { RemoteConfigView } from './RemoteConfigView.js';
 import type { RemoteConfigData } from './RemoteConfigView.js';
 import { RemoteManagementOverlay } from './RemoteManagementOverlay.js';
@@ -52,7 +53,7 @@ import type {
   ActiveAgentState,
   RateLimitState,
 } from '../../engine/index.js';
-import type { TrackerTask } from '../../plugins/trackers/types.js';
+import type { ExecutionScope, ScopedTrackerTask, TrackerTask } from '../../plugins/trackers/types.js';
 import type { StoredConfig, SubagentDetailLevel, SandboxConfig, SandboxMode } from '../../config/types.js';
 import type { TrackerPluginMeta } from '../../plugins/trackers/types.js';
 import { getIterationLogsByTask } from '../../logs/index.js';
@@ -134,6 +135,8 @@ export interface RunAppProps {
   agentCommand?: string;
   /** Current epic ID for highlighting in the loader */
   currentEpicId?: string;
+  /** Selected execution scopes for multi-epic sessions */
+  executionScopes?: ExecutionScope[];
   /** Initial subagent panel visibility state (from persisted session) */
   initialSubagentPanelVisible?: boolean;
   /** Callback when subagent panel visibility changes (to persist state) */
@@ -259,6 +262,7 @@ function trackerStatusToTaskStatus(trackerStatus: string): TaskStatus {
  * Convert a TrackerTask to a TaskItem for display in the TUI.
  */
 function trackerTaskToTaskItem(task: TrackerTask): TaskItem {
+  const scopedTask = task as ScopedTrackerTask;
   return {
     id: task.id,
     title: task.title,
@@ -273,6 +277,7 @@ function trackerTaskToTaskItem(task: TrackerTask): TaskItem {
     createdAt: task.createdAt,
     updatedAt: task.updatedAt,
     parentId: task.parentId,
+    executionScope: scopedTask.executionScope,
     metadata: task.metadata,
   };
 }
@@ -490,6 +495,40 @@ function areUsageSummariesEqual(
   );
 }
 
+function createEmptyScopeCount(scopeId?: string): ScopeFilterCount {
+  return {
+    scopeId,
+    total: 0,
+    active: 0,
+    done: 0,
+    completedLocally: 0,
+    blocked: 0,
+    closed: 0,
+  };
+}
+
+function addTaskToScopeCount(count: ScopeFilterCount, task: TaskItem): ScopeFilterCount {
+  const next = { ...count, total: count.total + 1 };
+  switch (task.status) {
+    case 'active':
+      next.active += 1;
+      break;
+    case 'done':
+      next.done += 1;
+      break;
+    case 'completedLocally':
+      next.completedLocally += 1;
+      break;
+    case 'blocked':
+      next.blocked += 1;
+      break;
+    case 'closed':
+      next.closed += 1;
+      break;
+  }
+  return next;
+}
+
 /**
  * Main RunApp component for execution view
  */
@@ -514,6 +553,7 @@ export function RunApp({
   agentPlugin,
   agentCommand,
   currentEpicId,
+  executionScopes = [],
   initialSubagentPanelVisible = false,
   onSubagentPanelVisibilityChange,
   currentModel,
@@ -660,6 +700,8 @@ export function RunApp({
   const [conflictSelectedIndex, setConflictSelectedIndex] = useState(0);
   // Show/hide closed tasks filter (default: show closed tasks)
   const [showClosedTasks, setShowClosedTasks] = useState(true);
+  // Local multi-epic filter; remote instance tabs remain independent.
+  const [scopeFilterId, setScopeFilterId] = useState<string>('all');
   // Track prior summary-line count so auto-open only happens on empty -> non-empty transition.
   const prevParallelSummaryLinesCountRef = useRef(0);
   // Cache for historical iteration output loaded from disk (taskId -> { output, timing, agent, model })
@@ -1335,24 +1377,7 @@ export function RunApp({
     return countRunning(tree);
   }, [subagentTree, remoteSubagentTree, isViewingRemote]);
 
-  // Filter and sort tasks for display
-  // Sort order: active → actionable → blocked → done → closed
-  // This is computed early so keyboard handlers can use displayedTasks.length
-  // Use remoteTasks when viewing a remote instance
-  const displayedTasks = useMemo(() => {
-    // Status priority for sorting (lower = higher priority)
-    const statusPriority: Record<TaskStatus, number> = {
-      active: 0,
-      actionable: 1,
-      pending: 2, // Treat pending same as actionable (shouldn't happen often)
-      blocked: 3,
-      error: 4, // Failed tasks show after blocked
-      completedLocally: 5, // Completed but not merged (e.g., no commits)
-      done: 6,
-      closed: 7,
-    };
-
-    // Use remote tasks when viewing remote, local tasks otherwise
+  const runtimeSourceTasks = useMemo(() => {
     let sourceTasks = isViewingRemote ? remoteTasks : tasks;
 
     // Parallel mode: overlay worker statuses onto tasks in a single render cycle.
@@ -1414,23 +1439,103 @@ export function RunApp({
       };
     });
 
-    const filtered = showClosedTasks ? sourceTasks : sourceTasks.filter((t) => t.status !== 'closed');
-    return [...filtered].sort((a, b) => {
-      const priorityA = statusPriority[a.status] ?? 10;
-      const priorityB = statusPriority[b.status] ?? 10;
-      return priorityA - priorityB;
-    });
+    return sourceTasks;
   }, [
     tasks,
     remoteTasks,
     isViewingRemote,
-    showClosedTasks,
     isParallelMode,
     parallelWorkers,
     parallelCompletedLocallyTaskIds,
     parallelMergedTaskIds,
     taskUsageMap,
     remoteTaskUsageMap,
+  ]);
+
+  const activeExecutionScopes = useMemo(() => {
+    const scopeMap = new Map<string, ExecutionScope>();
+    const preferredScopes = isViewingRemote ? [] : executionScopes;
+
+    for (const scope of preferredScopes) {
+      scopeMap.set(scope.id, scope);
+    }
+
+    for (const task of runtimeSourceTasks) {
+      if (task.executionScope && !scopeMap.has(task.executionScope.id)) {
+        scopeMap.set(task.executionScope.id, task.executionScope);
+      }
+    }
+
+    return [...scopeMap.values()];
+  }, [executionScopes, isViewingRemote, runtimeSourceTasks]);
+
+  const scopeFilterEnabled = activeExecutionScopes.length > 1;
+
+  useEffect(() => {
+    if (!scopeFilterEnabled) {
+      if (scopeFilterId !== 'all') {
+        setScopeFilterId('all');
+      }
+      return;
+    }
+
+    if (
+      scopeFilterId !== 'all' &&
+      !activeExecutionScopes.some((scope) => scope.id === scopeFilterId)
+    ) {
+      setScopeFilterId('all');
+    }
+  }, [activeExecutionScopes, scopeFilterEnabled, scopeFilterId]);
+
+  const { scopeCounts, allScopeCount } = useMemo(() => {
+    const nextCounts = new Map<string, ScopeFilterCount>();
+    let nextAllCount = createEmptyScopeCount();
+
+    for (const task of runtimeSourceTasks) {
+      nextAllCount = addTaskToScopeCount(nextAllCount, task);
+      const scopeId = task.executionScope?.id;
+      if (!scopeId) continue;
+
+      const existing = nextCounts.get(scopeId) ?? createEmptyScopeCount(scopeId);
+      nextCounts.set(scopeId, addTaskToScopeCount(existing, task));
+    }
+
+    return { scopeCounts: nextCounts, allScopeCount: nextAllCount };
+  }, [runtimeSourceTasks]);
+
+  // Filter and sort tasks for display.
+  // Sort order: active → actionable → blocked → done → closed.
+  // This is computed early so keyboard handlers can use displayedTasks.length.
+  const displayedTasks = useMemo(() => {
+    const statusPriority: Record<TaskStatus, number> = {
+      active: 0,
+      actionable: 1,
+      pending: 2,
+      blocked: 3,
+      error: 4,
+      completedLocally: 5,
+      done: 6,
+      closed: 7,
+    };
+
+    let filtered = showClosedTasks
+      ? runtimeSourceTasks
+      : runtimeSourceTasks.filter((t) => t.status !== 'closed');
+
+    if (scopeFilterEnabled && scopeFilterId !== 'all') {
+      filtered = filtered.filter((task) => task.executionScope?.id === scopeFilterId);
+    }
+
+    return [...filtered].sort((a, b) => {
+      const priorityA = statusPriority[a.status] ?? 10;
+      const priorityB = statusPriority[b.status] ?? 10;
+      return priorityA - priorityB;
+    });
+  }, [
+    runtimeSourceTasks,
+    showClosedTasks,
+    scopeFilterEnabled,
+    scopeFilterId,
   ]);
 
   // Derive parallel execution status from worker states.
@@ -1473,6 +1578,10 @@ export function RunApp({
 
   // Clamp selectedIndex when displayedTasks shrinks (e.g., when hiding closed tasks)
   useEffect(() => {
+    if (displayedTasks.length === 0 && selectedIndex !== 0) {
+      setSelectedIndex(0);
+      return;
+    }
     if (displayedTasks.length > 0 && selectedIndex >= displayedTasks.length) {
       setSelectedIndex(displayedTasks.length - 1);
     }
@@ -2364,6 +2473,21 @@ export function RunApp({
           setShowClosedTasks((prev) => !prev);
           break;
 
+        case 'g':
+        case 'G':
+          if (scopeFilterEnabled) {
+            if (key.sequence === 'G') {
+              setScopeFilterId('all');
+            } else {
+              setScopeFilterId((prev) => {
+                const scopeIds = ['all', ...activeExecutionScopes.map((scope) => scope.id)];
+                const currentIndex = scopeIds.indexOf(prev);
+                return scopeIds[(currentIndex + 1) % scopeIds.length] ?? 'all';
+              });
+            }
+          }
+          break;
+
         case '?':
           // Show help overlay
           setShowHelp(true);
@@ -2749,7 +2873,7 @@ export function RunApp({
           break;
       }
     },
-    [displayedTasks, selectedIndex, status, engine, onQuit, viewMode, iterations, iterationSelectedIndex, iterationHistoryLength, onIterationDrillDown, showInterruptDialog, onInterruptConfirm, onInterruptCancel, showHelp, showSettings, showAgentModelPicker, showQuitDialog, showKillDialog, showParallelSummaryOverlay, showEpicLoader, showRemoteManagement, onStart, storedConfig, onSaveSettings, onLoadEpics, subagentDetailLevel, onSubagentPanelVisibilityChange, currentIteration, maxIterations, renderer, detailsViewMode, subagentPanelVisible, focusedPane, navigateSubagentTree, instanceTabs, selectedTabIndex, onSelectTab, isViewingRemote, displayStatus, instanceManager, isParallelMode, parallelWorkers, parallelConflicts, showConflictPanel, onParallelKill, onParallelPause, onParallelResume, onParallelStart, parallelDerivedStatus, onRefreshTasks]
+    [displayedTasks, selectedIndex, status, engine, onQuit, viewMode, iterations, iterationSelectedIndex, iterationHistoryLength, onIterationDrillDown, showInterruptDialog, onInterruptConfirm, onInterruptCancel, showHelp, showSettings, showAgentModelPicker, showQuitDialog, showKillDialog, showParallelSummaryOverlay, showEpicLoader, showRemoteManagement, onStart, storedConfig, onSaveSettings, onLoadEpics, subagentDetailLevel, onSubagentPanelVisibilityChange, currentIteration, maxIterations, renderer, detailsViewMode, subagentPanelVisible, focusedPane, navigateSubagentTree, instanceTabs, selectedTabIndex, onSelectTab, isViewingRemote, displayStatus, instanceManager, isParallelMode, parallelWorkers, parallelConflicts, showConflictPanel, onParallelKill, onParallelPause, onParallelResume, onParallelStart, parallelDerivedStatus, onRefreshTasks, scopeFilterEnabled, activeExecutionScopes]
   );
 
   useKeyboard(handleKeyboard);
@@ -2761,9 +2885,11 @@ export function RunApp({
   const shouldShowTabBar = !!instanceTabs && !(instanceTabs.length === 1 && instanceTabs[0]?.isLocal);
   const dashboardHeight = showDashboard ? layout.progressDashboard.height : 0;
   const tabBarHeight = shouldShowTabBar ? layout.tabBar.height : 0;
+  const scopeFilterBarHeight = scopeFilterEnabled ? 1 : 0;
   const contentHeight = Math.max(
     1,
-    height - layout.header.height - layout.footer.height - dashboardHeight - tabBarHeight
+    height - layout.header.height - layout.footer.height - dashboardHeight - tabBarHeight -
+      scopeFilterBarHeight
   );
   const isCompact = width < 80;
   const availableWidth = Math.max(0, width - 4);
@@ -3534,6 +3660,15 @@ export function RunApp({
         />
       )}
 
+      {scopeFilterEnabled && (
+        <ScopeFilterBar
+          scopes={activeExecutionScopes}
+          selectedScopeId={scopeFilterId}
+          counts={scopeCounts}
+          allCount={allScopeCount}
+        />
+      )}
+
       {/* Main content area */}
       <box
         style={{
@@ -3594,6 +3729,7 @@ export function RunApp({
               isViewingRemote={isViewingRemote}
               remoteConnectionStatus={instanceTabs?.[selectedTabIndex]?.status}
               remoteAlias={instanceTabs?.[selectedTabIndex]?.alias}
+              showScopePrefixes={scopeFilterEnabled && scopeFilterId === 'all'}
             />
             <RightPanel
               selectedTask={selectedTask}

--- a/src/tui/components/ScopeFilterBar.tsx
+++ b/src/tui/components/ScopeFilterBar.tsx
@@ -1,0 +1,118 @@
+/**
+ * ABOUTME: Scope filter bar for multi-epic Ralph sessions.
+ * Shows the aggregate All view and per-scope task counts for local filtering.
+ */
+
+import type { ReactNode } from 'react';
+import { colors } from '../theme.js';
+import type { ExecutionScope } from '../../plugins/trackers/types.js';
+
+export interface ScopeFilterCount {
+  scopeId?: string;
+  total: number;
+  active: number;
+  done: number;
+  completedLocally: number;
+  blocked: number;
+  closed: number;
+}
+
+export interface ScopeFilterBarProps {
+  scopes: ExecutionScope[];
+  selectedScopeId: string;
+  counts: Map<string, ScopeFilterCount>;
+  allCount: ScopeFilterCount;
+}
+
+function truncateLabel(label: string, maxWidth: number): string {
+  if (label.length <= maxWidth) return label;
+  if (maxWidth <= 1) return label.slice(0, maxWidth);
+  return `${label.slice(0, maxWidth - 1)}…`;
+}
+
+function formatCount(count: ScopeFilterCount): string {
+  const completed = count.done + count.closed + count.completedLocally;
+  const extras: string[] = [];
+  if (count.active > 0) extras.push(`a${count.active}`);
+  if (count.blocked > 0) extras.push(`b${count.blocked}`);
+  const suffix = extras.length > 0 ? ` ${extras.join(' ')}` : '';
+  return `${completed}/${count.total}${suffix}`;
+}
+
+function ScopePill({
+  label,
+  selected,
+  count,
+}: {
+  label: string;
+  selected: boolean;
+  count: ScopeFilterCount;
+}): ReactNode {
+  const fg = selected ? colors.fg.primary : colors.fg.secondary;
+  const bg = selected ? colors.bg.tertiary : colors.bg.secondary;
+  const safeLabel = truncateLabel(label, 18);
+
+  return (
+    <box
+      style={{
+        flexDirection: 'row',
+        paddingLeft: 1,
+        paddingRight: 1,
+        backgroundColor: bg,
+      }}
+    >
+      <text>
+        <span fg={fg}>{safeLabel}</span>
+        <span fg={colors.fg.dim}> {formatCount(count)}</span>
+      </text>
+    </box>
+  );
+}
+
+export function ScopeFilterBar({
+  scopes,
+  selectedScopeId,
+  counts,
+  allCount,
+}: ScopeFilterBarProps): ReactNode {
+  if (scopes.length <= 1) {
+    return null;
+  }
+
+  return (
+    <box
+      style={{
+        width: '100%',
+        height: 1,
+        flexDirection: 'row',
+        backgroundColor: colors.bg.secondary,
+      }}
+    >
+      <ScopePill
+        label="All"
+        selected={selectedScopeId === 'all'}
+        count={allCount}
+      />
+      {scopes.map((scope) => (
+        <ScopePill
+          key={scope.id}
+          label={scope.title || scope.id}
+          selected={selectedScopeId === scope.id}
+          count={counts.get(scope.id) ?? {
+            scopeId: scope.id,
+            total: 0,
+            active: 0,
+            done: 0,
+            completedLocally: 0,
+            blocked: 0,
+            closed: 0,
+          }}
+        />
+      ))}
+      <box style={{ flexGrow: 1 }} />
+      <box style={{ paddingRight: 1 }}>
+        <text fg={colors.fg.dim}>g next  G all</text>
+      </box>
+    </box>
+  );
+}

--- a/src/tui/components/WorkerDetailView.tsx
+++ b/src/tui/components/WorkerDetailView.tsx
@@ -9,6 +9,7 @@ import { memo } from 'react';
 import { createTextAttributes } from '@opentui/core';
 import { colors, statusIndicators, formatElapsedTime } from '../theme.js';
 import type { WorkerDisplayState } from '../../parallel/types.js';
+import type { ScopedTrackerTask } from '../../plugins/trackers/types.js';
 
 const boldAttr = createTextAttributes({ bold: true });
 
@@ -56,6 +57,7 @@ export const WorkerDetailView = memo(function WorkerDetailView({
   const elapsed = worker.elapsedMs > 0
     ? formatElapsedTime(Math.floor(worker.elapsedMs / 1000))
     : '0s';
+  const executionScope = (worker.task as ScopedTrackerTask).executionScope;
 
   // Reserve lines for header info (title, task, progress/git, worktree path, separator)
   // With worktreePath: title(1) + task(1) + progress(1) + worktree(1) + separator(1) = 5
@@ -78,6 +80,11 @@ export const WorkerDetailView = memo(function WorkerDetailView({
       {/* Task info */}
       <text>
         <span fg={colors.fg.muted}>Task: </span>
+        {executionScope && (
+          <>
+            <span fg={colors.accent.tertiary}>[{executionScope.title || executionScope.id}] </span>
+          </>
+        )}
         <span fg={colors.fg.secondary}>{worker.task.id}</span>
         <span fg={colors.fg.dim}> — </span>
         <span fg={colors.fg.primary}>{worker.task.title}</span>

--- a/src/tui/components/index.ts
+++ b/src/tui/components/index.ts
@@ -10,6 +10,7 @@ export type { RunAppProps } from './RunApp.js';
 export { Header } from './Header.js';
 export { Footer } from './Footer.js';
 export { LeftPanel } from './LeftPanel.js';
+export { ScopeFilterBar } from './ScopeFilterBar.js';
 export { RightPanel } from './RightPanel.js';
 export { IterationHistoryView } from './IterationHistoryView.js';
 export type { IterationHistoryViewProps } from './IterationHistoryView.js';

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -190,6 +190,8 @@ export const fullKeyboardShortcuts = [
   { key: 'l', description: 'Load / switch epic', category: 'Execution' },
   { key: 'd', description: 'Toggle progress dashboard', category: 'Views' },
   { key: 'h', description: 'Toggle show/hide closed tasks', category: 'Views' },
+  { key: 'g', description: 'Cycle scope filter', category: 'Views' },
+  { key: 'G', description: 'Reset scope filter to all', category: 'Views' },
   { key: 'v', description: 'Toggle iterations / tasks view', category: 'Views' },
   { key: 'o', description: 'Cycle views (details/output/prompt)', category: 'Views' },
   { key: 'O', description: 'Jump to prompt preview', category: 'Views' },

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -5,7 +5,7 @@
 
 import type { TaskStatus, RalphStatus } from './theme.js';
 import type { IterationResult, SubagentTreeNode, ActiveAgentState, RateLimitState } from '../engine/types.js';
-import type { TaskPriority } from '../plugins/trackers/types.js';
+import type { ExecutionScope, TaskPriority } from '../plugins/trackers/types.js';
 import type { SubagentDetailLevel, SandboxConfig, SandboxMode } from '../config/types.js';
 import type { FormattedSegment } from '../plugins/agents/output-formatting.js';
 import type { TokenUsageSummary } from '../plugins/agents/usage.js';
@@ -66,6 +66,8 @@ export interface TaskItem {
   updatedAt?: string;
   /** Parent task/epic ID for hierarchical display */
   parentId?: string;
+  /** Execution scope this task belongs to during multi-epic runs */
+  executionScope?: ExecutionScope;
   /** Tracker-specific metadata (varies by plugin) */
   metadata?: Record<string, unknown>;
   /** Task-level token/context usage indicators */

--- a/tests/remote/remote.test.ts
+++ b/tests/remote/remote.test.ts
@@ -28,6 +28,8 @@ import type {
   CheckConfigResponseMessage,
   PushConfigMessage,
   PushConfigResponseMessage,
+  OrchestrateStartMessage,
+  OrchestrateStartResponseMessage,
   RemoteEngineState,
 } from '../../src/remote/types.js';
 import type { ExecutionEngine } from '../../src/engine/index.js';
@@ -294,6 +296,55 @@ describe('RemoteClient', () => {
 
       // Verify client is still connected after pong
       expect(client.status).toBe('connected');
+    });
+  });
+
+  describe('Orchestration', () => {
+    test('sends multiple epic IDs in start payload', async () => {
+      const { RemoteClient } = await import('../../src/remote/client.js');
+
+      const client = new RemoteClient('localhost', 7890, 'test-token', () => {});
+      const connectPromise = client.connect();
+      mockWebSocket.onopen?.();
+
+      const authCall = (mockWebSocket.send as ReturnType<typeof mock>).mock.calls[0];
+      const authMessage = JSON.parse(authCall[0] as string) as AuthMessage;
+      const authResponse: AuthResponseMessage = {
+        type: 'auth_response',
+        id: authMessage.id,
+        timestamp: new Date().toISOString(),
+        success: true,
+      };
+      mockWebSocket.onmessage?.({ data: JSON.stringify(authResponse) });
+      await connectPromise;
+
+      const startPromise = client.startOrchestration({
+        epicIds: ['ui-epic', 'backend-epic'],
+        maxWorkers: 2,
+      });
+      const startCall = (mockWebSocket.send as ReturnType<typeof mock>).mock.calls[1];
+      const startMessage = JSON.parse(startCall[0] as string) as OrchestrateStartMessage;
+
+      expect(startMessage.type).toBe('orchestrate:start');
+      expect(startMessage.epicIds).toEqual(['ui-epic', 'backend-epic']);
+      expect(startMessage.maxWorkers).toBe(2);
+
+      const startResponse: OrchestrateStartResponseMessage = {
+        type: 'orchestrate:start_response',
+        id: startMessage.id,
+        timestamp: new Date().toISOString(),
+        success: true,
+        orchestrationId: 'orch-test',
+        totalTasks: 2,
+        totalGroups: 1,
+        maxParallelism: 2,
+      };
+      mockWebSocket.onmessage?.({ data: JSON.stringify(startResponse) });
+
+      await expect(startPromise).resolves.toMatchObject({
+        success: true,
+        orchestrationId: 'orch-test',
+      });
     });
   });
 

--- a/website/content/docs/cli/overview.mdx
+++ b/website/content/docs/cli/overview.mdx
@@ -58,7 +58,7 @@ The commands are typically used in this order:
   </Step>
 
   <Step title="Execute">
-    Start execution with `ralph-tui run`. Ralph will work through your tasks autonomously.
+    Start execution with `ralph-tui run`. Ralph will work through your tasks autonomously. For hierarchy trackers, use repeated `--epic` flags or `--epics` to run one parallel session across multiple epics.
   </Step>
 
   <Step title="Monitor & Resume">

--- a/website/content/docs/cli/remote.mdx
+++ b/website/content/docs/cli/remote.mdx
@@ -243,6 +243,8 @@ When starting orchestration, you can specify:
 
 | Option | Type | Description |
 |--------|------|-------------|
+| `epicId` | string | Single epic ID for hierarchy trackers |
+| `epicIds` | string[] | Multiple epic IDs for one multi-epic orchestration session |
 | `maxWorkers` | number | Maximum concurrent workers (default: 3) |
 | `directMerge` | boolean | Merge to current branch vs session branch |
 | `maxIterations` | number | Max iterations per worker |
@@ -280,6 +282,18 @@ if (result.success) {
 }
 ```
 
+### Example: Multi-Epic Remote Start
+
+```typescript
+const result = await client.startOrchestration({
+  epicIds: ['ui-epic', 'backend-epic'],
+  maxWorkers: 4,
+  directMerge: false,
+});
+```
+
+The remote server still runs one active orchestration session. Multiple `epicIds` create one scoped tracker wrapper on the server, one global worker pool, and one merge queue.
+
 ### State Response
 
 The `orchestrate:get_state` command returns:
@@ -287,20 +301,29 @@ The `orchestrate:get_state` command returns:
 ```typescript
 {
   orchestrationId: string;
-  status: 'running' | 'paused' | 'completed' | 'failed';
-  startedAt: string;        // ISO 8601 timestamp
+  status: 'idle' | 'running' | 'paused' | 'completed' | 'failed';
+  currentGroupIndex: number;
+  totalGroups: number;
   totalTasks: number;
-  completedTasks: number;
-  failedTasks: number;
-  workerStates: {
-    [workerId: string]: {
-      status: 'idle' | 'running' | 'completed' | 'failed';
-      currentTaskId?: string;
-      completedTaskIds: string[];
-    };
-  };
+  totalTasksCompleted: number;
+  startedAt: string | null;
+  elapsedMs: number;
+  sessionBranch?: string;
+  originalBranch?: string;
+  workers: WorkerDisplayState[];
+  mergeQueue: MergeOperation[];
+  scopes?: ExecutionScope[];
+  scopeCounts?: {
+    scopeId: string;
+    totalTasks: number;
+    activeTasks: number;
+    completedTasks: number;
+    failedTasks: number;
+  }[];
 }
 ```
+
+`scopes` and `scopeCounts` are present for multi-epic remote orchestration so remote clients can render All/per-epic views without starting separate remote sessions.
 
 <Callout type="info">
   Remote orchestration respects the `--task-range` filter if configured on the server. Only filtered tasks will be distributed to workers.

--- a/website/content/docs/cli/resume.mdx
+++ b/website/content/docs/cli/resume.mdx
@@ -73,6 +73,9 @@ Resumable sessions:
 
 2. ⚠ e5f6g7h8  interrupted  codex       epic:EPIC-123
    /home/user/another-project
+
+3. ⏸ j9k0l1m2  paused       claude      epics:UI,Backend
+   /home/user/multi-epic-project
 ```
 
 ### Resume by Session ID
@@ -118,6 +121,7 @@ When you resume a session, Ralph restores:
 - **Task statuses** - Completed tasks remain completed
 - **Progress file** - Cross-iteration context is preserved
 - **Configuration** - Uses the same config as the original run
+- **Epic selection** - Multi-epic sessions restore the same `epicIds` and execution scopes
 
 ## Handling Stale Tasks
 
@@ -128,6 +132,12 @@ If Ralph was interrupted while a task was "in_progress", resume automatically:
 3. Re-selects the next task based on priority
 
 This ensures no tasks are permanently stuck due to crashes.
+
+## Multi-Epic Resume
+
+When a multi-epic hierarchy tracker session is resumed, Ralph reconstructs the same scoped tracker wrapper from the saved `epicIds` and execution scopes. The resumed session continues to use one scheduler, one session branch, and one merge queue across the original selected epic set.
+
+Existing sessions that only have a single `epicId` continue to load as single-epic sessions.
 
 ## Session States
 

--- a/website/content/docs/cli/run.mdx
+++ b/website/content/docs/cli/run.mdx
@@ -22,7 +22,8 @@ Running `ralph-tui` without any command also starts the TUI interface, allowing 
 | Option | Description |
 |--------|-------------|
 | `--prd <path>` | PRD file path (auto-switches to json tracker) |
-| `--epic <id>` | Epic ID for beads tracker |
+| `--epic <id>` | Epic ID for hierarchy trackers. May be repeated for multi-epic runs. |
+| `--epics <ids>` | Comma-separated epic IDs for hierarchy trackers. |
 
 ### Agent & Model Options
 
@@ -124,6 +125,32 @@ ralph-tui run --epic my-feature-epic
 ralph-tui run --epic my-feature-epic --tracker beads-bv
 ```
 
+### Multi-Epic Parallel Runs
+
+Hierarchy trackers such as Beads, Beads-Rust, and Beads-BV can run one parallel session across multiple selected epics:
+
+```bash
+# Repeat --epic
+ralph-tui run --parallel --epic ui-epic --epic backend-epic
+
+# Or use comma-separated IDs
+ralph-tui run --parallel --epics ui-epic,backend-epic
+```
+
+Multi-epic mode is one orchestration session, not several local runners. Ralph uses one scheduler, one repo lock, one session branch, and one sequential merge queue. Each task still gets its own worker branch and worktree.
+
+<Callout type="info">
+For compatibility, the first selected epic is still exposed as `epicId`; the full selected set is stored as `epicIds`.
+</Callout>
+
+If you launch a hierarchy tracker without `--epic` and the TUI is enabled, the epic picker supports multi-select:
+
+| Key | Action |
+|-----|--------|
+| `Space` | Toggle highlighted epic |
+| `a` | Toggle all visible epics |
+| `Enter` | Accept selected epics, or the highlighted epic if none are selected |
+
 ### Agent & Model Override
 
 ```bash
@@ -180,6 +207,7 @@ Ralph automatically saves state to `.ralph-tui/session.json`:
 - Task statuses
 - Iteration history
 - Active task IDs (for crash recovery)
+- Selected epic IDs and execution scopes for multi-epic runs
 
 If interrupted, use [`ralph-tui resume`](/docs/cli/resume) to continue.
 

--- a/website/content/docs/configuration/config-file.mdx
+++ b/website/content/docs/configuration/config-file.mdx
@@ -96,6 +96,8 @@ subagentTracingDetail = "minimal"
 # These options are passed to the selected tracker plugin
 # Example for beads-bv tracker:
 # epicId = "beads-001"
+# For multi-epic runs, prefer runtime flags:
+# ralph-tui run --parallel --epic ui-epic --epic backend-epic
 
 # ─────────────────────────────────────────────
 # Error Handling

--- a/website/content/docs/configuration/options.mdx
+++ b/website/content/docs/configuration/options.mdx
@@ -227,6 +227,10 @@ For basic Beads integration:
 |--------|------|-------------|
 | `epicId` | string | Epic ID to filter tasks |
 
+<Callout type="info">
+Multi-epic selection is a runtime option. Use repeated `--epic` flags or `--epics` on `ralph-tui run`; Ralph stores the selected set as `epicIds` in session state for resume.
+</Callout>
+
 ## Error Handling
 
 Controls how Ralph responds to task failures.
@@ -493,6 +497,8 @@ directMerge = false
 | `--parallel` | Force parallel with default workers |
 | `--parallel N` | Force parallel with N workers |
 | `--direct-merge` | Merge directly to current branch |
+| `--epic <id>` | Select an epic. May be repeated for hierarchy trackers. |
+| `--epics <ids>` | Select comma-separated epic IDs for hierarchy trackers. |
 
 See the [Parallel Execution guide](/docs/parallel/overview) for detailed documentation.
 
@@ -587,7 +593,8 @@ These flags override config file settings. Use with any execution command.
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
 | `--tracker <name>` | `-t` | string | Tracker to use |
-| `--epic <id>` | `-e` | string | Epic ID (beads trackers) |
+| `--epic <id>` | `-e` | string | Epic ID (hierarchy trackers). May be repeated. |
+| `--epics <ids>` | | string | Comma-separated epic IDs (hierarchy trackers) |
 | `--prd <path>` | `-p` | string | PRD file path (json tracker) |
 
 ### Error Handling Options

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -121,6 +121,10 @@ tracker = "beads-bv"     # Shorthand: use this tracker plugin
 epicId = "beads-001"
 ```
 
+<Callout type="info">
+For multi-epic runs, select epics at runtime with repeated `--epic` flags or `--epics`. The config file keeps a default single tracker setup; the session stores the selected multi-epic scope for resume.
+</Callout>
+
 ### Error Handling
 
 Control how Ralph responds to failures:

--- a/website/content/docs/getting-started/quick-start.mdx
+++ b/website/content/docs/getting-started/quick-start.mdx
@@ -86,6 +86,9 @@ If you use [Beads](https://github.com/steveyegge/beads) for issue tracking, you 
 ```bash
 # Run with a beads epic
 ralph-tui run --epic my-project-epic
+
+# Run one parallel session across multiple epics
+ralph-tui run --parallel --epic frontend-epic --epic backend-epic
 ```
 
 Beads provides additional features like:
@@ -93,6 +96,7 @@ Beads provides additional features like:
 - Task dependencies
 - Hierarchy (epics containing stories)
 - Labels and priorities
+- Multi-epic parallel sessions for larger features
 
 ## Alternative: Using Skills Directly in Your Agent
 

--- a/website/content/docs/getting-started/quick-start.mdx
+++ b/website/content/docs/getting-started/quick-start.mdx
@@ -150,11 +150,15 @@ While Ralph is running, use these keyboard shortcuts:
 | `o` | Cycle right panel views (details → output → prompt) |
 | `O` | Jump directly to prompt preview |
 | `d` | Toggle progress dashboard |
+| `g` | Cycle to the next epic/scope filter |
+| `G` | Return to all epics/scopes |
 | `a` | Open agent/model picker |
 | `h` | Toggle show/hide closed tasks |
 | `r` | Refresh task list from tracker |
 | `T` | Toggle subagent tree panel |
 | `t` | Cycle subagent detail level (minimal → moderate → detailed) |
+
+For multi-epic parallel sessions, `g` and `G` filter the TUI by epic/scope without changing the running orchestration.
 
 ### File Browser
 

--- a/website/content/docs/parallel/configuration.mdx
+++ b/website/content/docs/parallel/configuration.mdx
@@ -49,6 +49,10 @@ ralph-tui run --parallel
 
 # Force parallel with specific worker count
 ralph-tui run --parallel 4
+
+# Force one parallel session across multiple epics
+ralph-tui run --parallel --epic ui-epic --epic backend-epic
+ralph-tui run --parallel --epics ui-epic,backend-epic
 ```
 
 ### Flag Reference
@@ -59,9 +63,15 @@ ralph-tui run --parallel 4
 | `--parallel` | Force parallel execution with default worker count |
 | `--parallel N` | Force parallel execution with N workers |
 | `--direct-merge` | Merge directly to current branch instead of creating a session branch |
+| `--epic <id>` | Select an epic. Can be repeated for multi-epic hierarchy tracker runs. |
+| `--epics <ids>` | Select comma-separated epics for hierarchy tracker runs. |
 
 <Callout type="info">
   When both `--serial` and `--parallel` are specified, `--serial` takes precedence.
+</Callout>
+
+<Callout type="tip">
+Multi-epic selection is currently a runtime option, not a config-file setting. Use repeated `--epic` or `--epics` so each session records the exact selected epic set.
 </Callout>
 
 ## Precedence
@@ -125,6 +135,18 @@ mode = "never"    # Disable auto-detection
 # Override config to run parallel when you choose
 ralph-tui run --parallel 3
 ```
+
+### Multi-Epic Hierarchy Tracker Run
+
+For Beads-style hierarchy trackers, select more than one epic at runtime:
+
+```bash
+ralph-tui run --tracker beads-rust --parallel 4 \
+  --epic ui-epic \
+  --epic backend-epic
+```
+
+Ralph preserves the first ID as `epicId` for compatibility and stores the full selected set as `epicIds` in session state. Worker count remains global across all selected epics.
 
 ## Smart Parallelism Heuristics
 

--- a/website/content/docs/parallel/configuration.mdx
+++ b/website/content/docs/parallel/configuration.mdx
@@ -63,7 +63,7 @@ ralph-tui run --parallel --epics ui-epic,backend-epic
 | `--parallel` | Force parallel execution with default worker count |
 | `--parallel N` | Force parallel execution with N workers |
 | `--direct-merge` | Merge directly to current branch instead of creating a session branch |
-| `--epic <id>` | Select an epic. Can be repeated for multi-epic hierarchy tracker runs. |
+| `--epic <id>` | Select an epic. This option can be repeated for multi-epic hierarchy tracker runs. |
 | `--epics <ids>` | Select comma-separated epics for hierarchy tracker runs. |
 
 <Callout type="info">

--- a/website/content/docs/parallel/git-worktrees.mdx
+++ b/website/content/docs/parallel/git-worktrees.mdx
@@ -21,11 +21,11 @@ This means worktrees are fast to create (no file copying beyond checkout) and di
 
 <Steps>
   <Step title="Create">
-    When a parallel group starts, ralph creates worktrees at `.ralph-tui/worktrees/worker-N/` with a dedicated branch `ralph-parallel/{taskId}` branched from the current HEAD.
+    When a parallel group starts, Ralph creates worker-scoped worktrees under the configured worktree directory with a dedicated branch branched from the current HEAD.
 
     ```bash
     # What ralph runs internally:
-    git worktree add .ralph-tui/worktrees/worker-1 -b ralph-parallel/task-123
+    git worktree add <worktree-dir>/worker-1 -b ralph-parallel/session-abc/ui-epic/task-123
     ```
   </Step>
 
@@ -42,11 +42,27 @@ This means worktrees are fast to create (no file copying beyond checkout) and di
 
     ```bash
     # What ralph runs internally:
-    git worktree remove --force .ralph-tui/worktrees/worker-1
-    git branch -D ralph-parallel/task-123
+    git worktree remove --force <worktree-dir>/worker-1
+    git branch -D ralph-parallel/session-abc/ui-epic/task-123
     ```
   </Step>
 </Steps>
+
+## Branch Names
+
+Worker branches include enough context to identify the session, selected epic scope, and task:
+
+```text
+ralph-parallel/<session-slug>/<scope-slug>/<task-slug>
+```
+
+For single-scope or legacy contexts where no scope is available, Ralph falls back to:
+
+```text
+ralph-parallel/<session-slug>/<task-slug>
+```
+
+Worktree paths remain worker-scoped (`worker-1`, `worker-2`, and so on). The scope is in the branch name, not the directory name, so workers can be reused predictably within the configured worktree directory.
 
 ## Directory Layout
 

--- a/website/content/docs/parallel/how-it-works.mdx
+++ b/website/content/docs/parallel/how-it-works.mdx
@@ -24,11 +24,11 @@ ParallelExecutor
 
 <Steps>
   <Step title="Task Graph Analysis">
-    Ralph fetches all tasks from your tracker and builds a dependency graph using the `dependsOn` and `blocks` fields. Tasks are sorted topologically (Kahn's algorithm) and grouped by depth level — tasks at the same depth with no mutual dependencies form a **parallel group**.
+    Ralph fetches all tasks from your tracker and builds a dependency graph using the `dependsOn` and `blocks` fields. In multi-epic mode, the tracker is wrapped so tasks from every selected epic are fetched and annotated with their execution scope before graph analysis. Tasks are sorted topologically (Kahn's algorithm) and grouped by depth level — tasks at the same depth with no mutual dependencies form a **parallel group**.
   </Step>
 
   <Step title="Worktree Creation">
-    For each task in the current group, the WorktreeManager creates a git worktree at `.ralph-tui/worktrees/worker-N/` with a dedicated branch `ralph-parallel/{taskId}`. Each worktree is a full working copy of your repository branched from the current HEAD.
+    For each task in the current group, the WorktreeManager creates a worker-scoped git worktree with a dedicated task branch. Multi-epic task branches include session and scope context: `ralph-parallel/{session}/{scope}/{task}`. Each worktree is a full working copy of your repository branched from the current HEAD.
   </Step>
 
   <Step title="Parallel Execution">
@@ -63,6 +63,17 @@ The tracker plugin runs **only in the main process**. Workers signal task status
 - Concurrent writes to the beads database
 - Race conditions in JSON file updates
 - Inconsistent task state across workers
+
+## Multi-Scope Tracker Wrapper
+
+When multiple epics are selected, Ralph wraps the configured tracker with a multi-scope tracker:
+
+- `getTasks()` fetches children for each selected epic and annotates each task with its execution scope
+- Duplicate task IDs are deduplicated, keeping the first selected scope
+- `getNextTask()` selects the best ready task across all selected scopes by priority, scope order, and task ID
+- `completeTask()`, `updateTaskStatus()`, `sync()`, and `dispose()` delegate to the underlying tracker
+
+Dependencies inside the selected epic set are preserved in the global graph. Dependencies outside the selected set are resolved through the underlying tracker; if the external dependency cannot be found or is not completed/cancelled, the dependent task is marked blocked for this run and excluded from scheduling.
 
 ## Failure Handling
 

--- a/website/content/docs/parallel/merge-and-conflicts.mdx
+++ b/website/content/docs/parallel/merge-and-conflicts.mdx
@@ -34,7 +34,7 @@ Each completed worker enters a merge queue, processed in priority order (P0 task
     If fast-forward fails (HEAD has moved), fall back to a regular merge:
 
     ```
-    git merge --no-edit ralph-parallel/{taskId}
+    git merge --no-edit ralph-parallel/{session}/{scope}/{taskId}
     ```
 
     This creates a merge commit: `feat({taskId}): {taskTitle}`.

--- a/website/content/docs/parallel/overview.mdx
+++ b/website/content/docs/parallel/overview.mdx
@@ -32,6 +32,9 @@ ralph-tui run
 # Force parallel execution with 4 workers
 ralph-tui run --parallel 4
 
+# Run one parallel session across multiple epics
+ralph-tui run --parallel --epic ui-epic --epic backend-epic
+
 # Force sequential execution (disable parallel)
 ralph-tui run --serial
 ```
@@ -47,6 +50,29 @@ The auto-detection heuristic checks three conditions:
 3. **Less than 50% cyclic dependencies** (heavily coupled tasks don't parallelize well)
 
 If all conditions are met, parallel mode activates. Otherwise, ralph-tui stays in sequential execution.
+
+## Multi-Epic Sessions
+
+Parallel execution can span multiple hierarchy-tracker epics in one Ralph session:
+
+```bash
+ralph-tui run --parallel --epic ui-epic --epic backend-epic
+ralph-tui run --parallel --epics ui-epic,backend-epic
+```
+
+This is a single global orchestration session:
+
+- One task graph is built across all selected epics
+- One worker pool schedules tasks globally
+- One repo lock and one session branch protect the main checkout
+- One merge queue merges completed worker branches sequentially
+- TUI "epic tabs" are local filters over the same session, not separate runners
+
+Tasks keep their source scope as metadata. When viewing all scopes in the TUI, task rows and worker/merge details include a compact scope label.
+
+<Callout type="warning">
+External dependencies outside the selected epic set block their dependent task for that run unless the external task is already completed or cancelled. Ralph excludes those tasks from parallel scheduling and shows them as blocked.
+</Callout>
 
 ## What Happens
 

--- a/website/content/docs/parallel/task-dependencies.mdx
+++ b/website/content/docs/parallel/task-dependencies.mdx
@@ -60,6 +60,22 @@ This produces three parallel groups:
 
 With `maxWorkers: 3`, groups 0 and 1 run 2 workers each. Group 2 also runs 2 workers.
 
+## Cross-Epic Dependencies
+
+In multi-epic sessions, Ralph builds one dependency graph across all selected epics. If a task in `backend-epic` depends on a task in `ui-epic`, that edge is preserved and the backend task waits until the UI task finishes.
+
+```bash
+ralph-tui run --parallel --epic ui-epic --epic backend-epic
+```
+
+Dependencies that point outside the selected epic set are treated conservatively:
+
+- If the external dependency exists and is completed or cancelled, the dependent task can run
+- If the external dependency is unresolved or cannot be found, the dependent task is marked blocked for this run
+- External-blocked tasks are excluded from parallel scheduling and counted as blocked in the TUI
+
+This prevents Ralph from running a task whose prerequisite is outside the current orchestration session.
+
 ## Structuring Tasks for Parallelism
 
 To maximize parallel execution:

--- a/website/content/docs/parallel/troubleshooting.mdx
+++ b/website/content/docs/parallel/troubleshooting.mdx
@@ -27,8 +27,8 @@ git worktree remove --force .ralph-tui/worktrees/worker-2
 git worktree prune
 
 # Remove leftover branches
-git branch -D ralph-parallel/task-123
-git branch -D ralph-parallel/task-456
+git branch -D ralph-parallel/session-abc/ui-epic/task-123
+git branch -D ralph-parallel/session-abc/backend-epic/task-456
 ```
 
 <Callout type="tip">

--- a/website/content/docs/parallel/tui-guide.mdx
+++ b/website/content/docs/parallel/tui-guide.mdx
@@ -7,6 +7,23 @@ description: Visual guide to the parallel execution TUI — worker progress, det
 
 When parallel execution is active, ralph-tui adds new views and keyboard shortcuts for monitoring workers, merges, and conflicts.
 
+## Scope Filter Bar
+
+In multi-epic sessions, the TUI shows a scope filter bar above the main content:
+
+```text
+[All 3/17] [UI 1/6] [Backend 2/8] [Docs 0/3]
+```
+
+The filter is local to the TUI. It does not start or stop separate runners; all scopes are still part of the same global scheduler and merge queue.
+
+| Key | Action |
+|-----|--------|
+| `g` | Cycle to the next scope filter |
+| `G` | Return to `All` |
+
+When the filter is `All`, task rows show a compact scope prefix. Worker detail and merge progress views also show the task's scope beside the task ID.
+
 ## Workers View
 
 Press `w` to toggle the parallel workers view. This shows all active workers with their status, progress, and task titles:
@@ -123,6 +140,8 @@ All parallel-specific keyboard shortcuts:
 |-----|---------|--------|
 | `w` | Any view | Toggle parallel workers view |
 | `m` | Any view | Toggle merge progress view |
+| `g` | Any view with multiple scopes | Cycle scope filter |
+| `G` | Any view with multiple scopes | Reset scope filter to All |
 | `↑`/`↓` | Workers view | Select worker |
 | `Enter` | Workers view | Drill into worker detail |
 | `Esc` | Detail/merge view | Return to previous view |

--- a/website/content/docs/plugins/overview.mdx
+++ b/website/content/docs/plugins/overview.mdx
@@ -121,9 +121,10 @@ The execution engine orchestrates plugins:
 
     ```bash
     ralph-tui run --tracker beads --epic my-epic
+    ralph-tui run --tracker beads --parallel --epic ui-epic --epic backend-epic
     ```
 
-    Issues sync across team members via git.
+    Issues sync across team members via git. Hierarchy trackers can also run one parallel session across multiple selected epics.
   </TabsContent>
   <TabsContent value="large">
     Use **Beads-BV tracker** for intelligent task selection:

--- a/website/content/docs/plugins/trackers/beads-bv.mdx
+++ b/website/content/docs/plugins/trackers/beads-bv.mdx
@@ -94,6 +94,12 @@ bd init
 ralph-tui run --tracker beads-bv --epic beads-xyz
 ```
 
+```bash
+# One parallel session across multiple epics
+ralph-tui run --tracker beads-bv --parallel --epic beads-ui --epic beads-backend
+ralph-tui run --tracker beads-bv --parallel --epics beads-ui,beads-backend
+```
+
 ### Config File
 
 ```toml
@@ -118,6 +124,20 @@ Same as the base Beads tracker:
 
 <Callout type="info">
 See the [Beads Tracker docs](/docs/plugins/trackers/beads#label-filtering-optional) for details on label filtering.
+</Callout>
+
+## Multi-Epic Parallel Execution
+
+Beads-BV can participate in multi-epic parallel orchestration the same way as the base Beads tracker:
+
+```bash
+ralph-tui run --tracker beads-bv --parallel --epic beads-ui --epic beads-backend
+```
+
+Ralph wraps the tracker so children from each selected epic are fetched and combined into one scoped task set. The global parallel scheduler then analyzes dependencies across all selected epics.
+
+<Callout type="info">
+BV's graph-based ranking still applies through the underlying tracker, but the multi-epic scheduler is global. Worker count is shared across all selected epics, and merges remain sequential in one queue.
 </Callout>
 
 ## How BV Selects Tasks

--- a/website/content/docs/plugins/trackers/beads-rust.mdx
+++ b/website/content/docs/plugins/trackers/beads-rust.mdx
@@ -77,6 +77,13 @@ Run with epic and tracker:
 ralph-tui run --tracker beads-rust --epic ralph-tui-abc123
 ```
 
+Run one parallel session across multiple epics:
+
+```bash
+ralph-tui run --tracker beads-rust --parallel --epic ui-epic --epic backend-epic
+ralph-tui run --tracker beads-rust --parallel --epics ui-epic,backend-epic
+```
+
 ### Config File
 
 Set defaults in TOML:
@@ -102,6 +109,20 @@ beadsDir = ".beads"
 <Callout type="info">
 The `epicId` should be set via `--epic` flag rather than config, since you'll likely work on different epics.
 </Callout>
+
+## Multi-Epic Parallel Execution
+
+Beads-Rust supports running one Ralph parallel session across multiple selected epics:
+
+```bash
+ralph-tui run --tracker beads-rust --parallel --epic ui-epic --epic backend-epic
+```
+
+This is one orchestration session with one scheduler and one merge queue. Ralph fetches child tasks for every selected epic with `br`, annotates each task with its execution scope, and builds a single dependency graph across the combined task set.
+
+Cross-epic dependencies are respected when both tasks are in the selected epic set. If a dependency points outside the selected set, Ralph checks the external task with `br show`; unresolved or missing external dependencies block the dependent task for that run.
+
+When launched without `--epic` in the TUI, the epic picker supports multi-select with `Space`, `a` to toggle all visible epics, and `Enter` to accept.
 
 ## PRD Context Injection
 

--- a/website/content/docs/plugins/trackers/beads.mdx
+++ b/website/content/docs/plugins/trackers/beads.mdx
@@ -77,6 +77,13 @@ Run with epic and tracker:
 ralph-tui run --tracker beads --epic beads-abc123
 ```
 
+Run one parallel session across multiple epics:
+
+```bash
+ralph-tui run --tracker beads --parallel --epic beads-ui --epic beads-backend
+ralph-tui run --tracker beads --parallel --epics beads-ui,beads-backend
+```
+
 ### Config File
 
 Set defaults in TOML:
@@ -102,6 +109,18 @@ beadsDir = ".beads"
 <Callout type="info">
 The `epicId` should be set via `--epic` flag rather than config, since you'll likely work on different epics.
 </Callout>
+
+## Multi-Epic Parallel Execution
+
+The Beads tracker supports multi-epic parallel runs when tasks are organized as children of epics:
+
+```bash
+ralph-tui run --tracker beads --parallel --epic beads-ui --epic beads-backend
+```
+
+Ralph fetches children for each selected epic, annotates each task with its source epic, builds one dependency graph, and schedules ready tasks across all selected epics with one worker pool. The first selected epic remains the compatibility `epicId`; the full selected set is saved as `epicIds` for resume.
+
+Cross-epic dependencies are honored when both tasks are inside the selected epic set. Dependencies outside the selected set must already be closed/cancelled, otherwise the dependent task is shown as blocked and excluded from scheduling.
 
 ## Beads Concepts
 
@@ -237,11 +256,12 @@ When Ralph TUI runs with the Beads tracker:
 
 ## Switching Epics
 
-Change epics mid-session by pressing `l` in the TUI:
+Change epics while execution is idle by pressing `l` in the TUI:
 
 1. Press `l` to open epic selector
-2. Choose from available epics
-3. Task list updates to show new epic's tasks
+2. Use `Space` to select one or more epics
+3. Press `Enter` to accept the selected epic set
+4. Task list updates to show the selected epic scope
 
 Or restart with a different `--epic` flag.
 


### PR DESCRIPTION
## Summary

- Adds repeatable `--epic` and comma-separated `--epics` support so one Ralph session can run across multiple selected epics while preserving single-epic compatibility.
- Introduces execution scopes and `MultiScopeTrackerPlugin` to combine hierarchy tracker tasks, annotate tasks with their scope, dedupe duplicate task IDs, preserve cross-epic dependencies, and exclude tasks blocked by unresolved external dependencies.
- Keeps parallel execution as one global scheduler, one session branch, one merge queue, and task-scoped worktrees with scoped branch names.
- Adds multi-select epic picking, TUI scope filtering with `g`/`G`, per-scope labels/counts, and scope-aware parallel/merge/worker displays.
- Persists and resumes selected epic sets, includes scopes in remote orchestration state, and documents the public CLI/TUI/remote/tracker behavior across the website docs and README.
- Adds focused tests for config parsing, multi-scope tracker behavior, engine tracker injection, parallel scope state, session persistence, remote scope counts, and coverage-sensitive runtime paths.

## Testing

- `bun run typecheck && bun run build`
- `bun test src/commands/run.test.ts`
- `bun test tests/tui`
- `bun test src/config/index.test.ts src/engine/ src/parallel/ src/session/ src/remote/server.test.ts src/plugins/trackers/multi-scope.test.ts tests/remote/remote.test.ts --coverage --coverage-reporter=lcov`
- `bun test src/plugins/trackers/builtin/beads-rust/index.test.ts`
- `bun test src/plugins/trackers/builtin/beads-bv/index.test.ts`
- `git diff --check`

Note: `bun test src/plugins/trackers` as a single process still hits the existing Bun `mock.module()` isolation issue between beads-rust and beads-bv tests. The CI workflow already runs those files in isolated batches, and the isolated runs above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-epic parallel execution: repeatable --epic and comma-separated --epics, multi-select epic picker, persisted epicIds/executionScopes, scope-aware TUI (g/G), per-scope counts/summaries, scope labels in task/worker/merge views, deduplication and cross-epic dependency handling, session-aware branch names

* **Documentation**
  * CLI, TUI, parallel, tracker and resume docs updated with multi-epic examples and behavior notes

* **Tests**
  * Expanded coverage for parsing, tracker wrapper, remote helpers, session persistence, and parallel state reporting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/subsy/ralph-tui/pull/391)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->