### PR TITLE
[codex] Fix settings model selection

### DIFF
--- a/src/tui/components/RunApp.tsx
+++ b/src/tui/components/RunApp.tsx
@@ -23,9 +23,10 @@ import type { HistoricExecutionContext } from './IterationDetailView.js';
 import { ProgressDashboard } from './ProgressDashboard.js';
 import { ConfirmationDialog } from './ConfirmationDialog.js';
 import { HelpOverlay } from './HelpOverlay.js';
-import { SettingsView } from './SettingsView.js';
+import { SettingsView, getConfiguredAgentName } from './SettingsView.js';
 import {
   AgentModelPicker,
+  normalizeModelValue,
   resolveAgentConfigForSelection,
   type AgentModelSelection,
 } from './AgentModelPicker.js';
@@ -1149,6 +1150,25 @@ export function RunApp({
   // Compute display tracker and model for local vs remote
   const displayTrackerName = isViewingRemote ? (remoteTrackerName ?? trackerName) : trackerName;
   const displayModel = isViewingRemote ? (remoteModel ?? currentModel) : localModel;
+
+  const handleSettingsSave = useCallback(
+    async (newConfig: StoredConfig): Promise<void> => {
+      if (!onSaveSettings) {
+        throw new Error('Settings save is not available');
+      }
+
+      const previousAgent = getConfiguredAgentName(storedConfig);
+      const nextAgent = getConfiguredAgentName(newConfig);
+      const previousModel = normalizeModelValue(storedConfig?.model);
+      const nextModel = normalizeModelValue(newConfig.model);
+
+      await onSaveSettings(newConfig);
+      if (previousAgent !== nextAgent || previousModel !== nextModel) {
+        setDetectedModel(nextModel ?? '');
+      }
+    },
+    [onSaveSettings, storedConfig]
+  );
 
   const handleAgentModelConfirm = useCallback(
     async (selection: AgentModelSelection): Promise<void> => {
@@ -3976,8 +3996,9 @@ export function RunApp({
           visible={showSettings}
           config={storedConfig}
           agents={availableAgents}
+          agentConfigs={storedConfig.agents}
           trackers={availableTrackers}
-          onSave={onSaveSettings}
+          onSave={handleSettingsSave}
           onClose={() => setShowSettings(false)}
         />
       )}

--- a/src/tui/components/SettingsView.test.ts
+++ b/src/tui/components/SettingsView.test.ts
@@ -1,0 +1,61 @@
+/**
+ * ABOUTME: Tests for SettingsView helper behavior.
+ * Verifies model setting choices are derived from selected agent metadata.
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { registerBuiltinAgents } from '../../plugins/agents/builtin/index.js';
+import {
+  buildModelOptionsForAgent,
+  buildSettingDefinitions,
+} from './SettingsView.js';
+
+beforeAll(() => {
+  registerBuiltinAgents();
+});
+
+describe('SettingsView helpers', () => {
+  test('shows known Claude models as select choices', () => {
+    const settings = buildSettingDefinitions(['claude'], [], { agent: 'claude' });
+    const modelSetting = settings.find((setting) => setting.key === 'model');
+
+    expect(modelSetting?.type).toBe('select');
+    expect(modelSetting?.options).toEqual(['', 'sonnet', 'opus', 'haiku']);
+  });
+
+  test('resolves configured agent aliases for model choices', () => {
+    const options = buildModelOptionsForAgent(
+      'work-claude',
+      [
+        {
+          name: 'work-claude',
+          plugin: 'claude',
+          options: {},
+        },
+      ],
+      undefined
+    );
+
+    expect(options).toEqual(['', 'sonnet', 'opus', 'haiku']);
+  });
+
+  test('keeps open-ended agents as free text', () => {
+    const settings = buildSettingDefinitions(['codex'], [], { agent: 'codex' });
+    const modelSetting = settings.find((setting) => setting.key === 'model');
+
+    expect(modelSetting?.type).toBe('text');
+    expect(modelSetting?.options).toBeUndefined();
+  });
+
+  test('clears model override when the default choice is selected', () => {
+    const settings = buildSettingDefinitions(['claude'], [], {
+      agent: 'claude',
+      model: 'opus',
+    });
+    const modelSetting = settings.find((setting) => setting.key === 'model');
+
+    expect(modelSetting?.setValue({ agent: 'claude', model: 'opus' }, '')).toEqual({
+      agent: 'claude',
+    });
+  });
+});

--- a/src/tui/components/SettingsView.tsx
+++ b/src/tui/components/SettingsView.tsx
@@ -9,17 +9,22 @@ import { useState, useCallback, useEffect } from 'react';
 import { useKeyboard } from '@opentui/react';
 import { colors } from '../theme.js';
 import type { StoredConfig, SubagentDetailLevel, NotificationSoundMode } from '../../config/types.js';
+import type { AgentPluginConfig } from '../../plugins/agents/types.js';
 import type { TrackerPluginMeta } from '../../plugins/trackers/types.js';
+import {
+  listModelsForAgent,
+  normalizeModelValue,
+} from './AgentModelPicker.js';
 
 /**
  * Setting item types for different field kinds
  */
-type SettingType = 'select' | 'number' | 'boolean' | 'text';
+export type SettingType = 'select' | 'number' | 'boolean' | 'text';
 
 /**
  * Individual setting definition
  */
-interface SettingDefinition {
+export interface SettingDefinition {
   key: string;
   label: string;
   type: SettingType;
@@ -42,6 +47,8 @@ export interface SettingsViewProps {
   config: StoredConfig;
   /** Available agent names for selection */
   agents: string[];
+  /** Configured agent instances used to resolve agent aliases */
+  agentConfigs?: AgentPluginConfig[];
   /** Available tracker plugins */
   trackers: TrackerPluginMeta[];
   /** Callback when settings should be saved */
@@ -51,12 +58,77 @@ export interface SettingsViewProps {
 }
 
 /**
+ * Resolve the active agent name from stored config using runtime precedence.
+ */
+export function getConfiguredAgentName(config: StoredConfig | undefined): string | undefined {
+  return (
+    config?.agent ??
+    config?.defaultAgent ??
+    config?.agents?.find((agent) => agent.default)?.name ??
+    config?.agents?.[0]?.name
+  );
+}
+
+/**
+ * Build model choices for agents that expose known model names.
+ */
+export function buildModelOptionsForAgent(
+  agentName: string | undefined,
+  agentConfigs: AgentPluginConfig[],
+  currentModel: string | undefined
+): string[] | undefined {
+  if (!agentName) {
+    return undefined;
+  }
+
+  const knownModels = listModelsForAgent(agentName, agentConfigs);
+  if (knownModels.length === 0) {
+    return undefined;
+  }
+
+  const normalizedCurrent = normalizeModelValue(currentModel);
+  return [
+    '',
+    ...(normalizedCurrent && !knownModels.includes(normalizedCurrent)
+      ? [normalizedCurrent]
+      : []),
+    ...knownModels,
+  ];
+}
+
+/**
+ * Apply a model value to stored config, removing the field for the default model.
+ */
+function setModelValue(
+  config: StoredConfig,
+  value: string | number | boolean
+): StoredConfig {
+  const nextConfig = { ...config };
+  const normalized = normalizeModelValue(String(value));
+  if (normalized) {
+    nextConfig.model = normalized;
+  } else {
+    delete nextConfig.model;
+  }
+  return nextConfig;
+}
+
+/**
  * Build setting definitions based on available plugins
  */
-function buildSettingDefinitions(
+export function buildSettingDefinitions(
   agents: string[],
-  trackers: TrackerPluginMeta[]
+  trackers: TrackerPluginMeta[],
+  config: StoredConfig,
+  agentConfigs: AgentPluginConfig[] = []
 ): SettingDefinition[] {
+  const selectedAgent = getConfiguredAgentName(config);
+  const modelOptions = buildModelOptionsForAgent(
+    selectedAgent,
+    agentConfigs,
+    config.model
+  );
+
   return [
     {
       key: 'tracker',
@@ -78,7 +150,7 @@ function buildSettingDefinitions(
       type: 'select',
       description: 'AI agent plugin to use',
       options: agents,
-      getValue: (config) => config.agent ?? config.defaultAgent ?? config.agents?.[0]?.name,
+      getValue: (config) => getConfiguredAgentName(config),
       setValue: (config, value) => ({
         ...config,
         agent: value as string,
@@ -89,13 +161,11 @@ function buildSettingDefinitions(
     {
       key: 'model',
       label: 'Model',
-      type: 'text',
+      type: modelOptions ? 'select' : 'text',
       description: 'Model override for the selected agent',
-      getValue: (config) => config.model,
-      setValue: (config, value) => ({
-        ...config,
-        model: value as string,
-      }),
+      options: modelOptions,
+      getValue: (config) => normalizeModelValue(config.model) ?? '',
+      setValue: setModelValue,
       requiresRestart: false,
     },
     {
@@ -189,7 +259,7 @@ function buildSettingDefinitions(
  * Format a setting value for display
  */
 function formatValue(value: string | number | boolean | undefined): string {
-  if (value === undefined) return '(not set)';
+  if (value === undefined || value === '') return '(not set)';
   if (typeof value === 'boolean') return value ? 'Yes' : 'No';
   return String(value);
 }
@@ -201,6 +271,7 @@ export function SettingsView({
   visible,
   config,
   agents,
+  agentConfigs = [],
   trackers,
   onSave,
   onClose,
@@ -213,7 +284,12 @@ export function SettingsView({
   const [error, setError] = useState<string | null>(null);
   const [hasChanges, setHasChanges] = useState(false);
 
-  const settings = buildSettingDefinitions(agents, trackers);
+  const settings = buildSettingDefinitions(
+    agents,
+    trackers,
+    editingConfig,
+    agentConfigs
+  );
 
   // Reset state when config changes externally
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes the TUI settings model field so agents with enumerated models, such as Claude, show selectable model choices instead of only free text. The settings save path also refreshes the dashboard/header model display after a model change, matching the behavior of the dedicated agent/model picker.

## Root Cause

The settings dialog always defined the model setting as text, even though agent plugins already expose `listModels()`. Saving through settings propagated the config to the engine, but did not update RunApp's local `detectedModel` display state, so the dashboard could continue showing the previous model.

## Changes

- Derive settings model options from the selected agent's `listModels()` metadata.
- Preserve free-text input for agents with open-ended model identifiers.
- Clear the stored model override when the default model option is selected.
- Refresh local model display state after saving settings.
- Add focused helper coverage for Claude model options, aliases, open-ended agents, and clearing overrides.

## Validation

- `bun test src/tui/components/SettingsView.test.ts src/tui/components/AgentModelPicker.test.ts`
- `bun test tests/commands/run.test.ts --grep propagateSettingsToEngine`
- `bun run typecheck && bun run build`
- `bun run lint` (passes with existing unrelated warnings in test files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model selection options now dynamically update based on the selected agent
  * Enhanced handling of agent and model configuration settings

* **Tests**
  * Added test coverage for settings view helper behavior and agent configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/subsy/ralph-tui/pull/392)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->