### PR TITLE
fix(beads-rust): recursively fetch all descendant tasks for epic hierarchy

### DIFF
--- a/src/chat/engine.ts
+++ b/src/chat/engine.ts
@@ -13,8 +13,11 @@ import type {
   PrdDetectionResult,
   ChatEvent,
   ChatEventListener,
+  TimeoutConfig,
+  TimeoutState,
 } from './types.js';
-import type { AgentPlugin, AgentExecuteOptions } from '../plugins/agents/types.js';
+import type { AgentPlugin, AgentExecuteOptions, AgentExecutionHandle } from '../plugins/agents/types.js';
+import { DEFAULT_TIMEOUT_CONFIG } from './types.js';
 
 /**
  * Default system prompt for PRD generation.
@@ -46,7 +49,7 @@ const PRD_COMPATIBILITY_GUIDANCE = `
 - Include a "## Quality Gates" section listing required commands.
 - Include a "## User Stories" section with entries like:
   - "### US-001: Title"
-  - Plain text description on the next line: "As a user, I want to ... so that ..."
+  - Plain text description on the next line: "As a user, I want ... so that ..."
   - "**Acceptance Criteria:**" followed by checklist bullets ("- [ ] ...").
 - IMPORTANT: User story descriptions must be plain text (no **Description:** prefix).
 - Use markdown formatting suitable for conversion tools.
@@ -73,9 +76,19 @@ export class ChatEngine {
   private messages: ChatMessage[] = [];
   private status: ChatStatus = 'idle';
   private listeners: Set<ChatEventListener> = new Set();
-  private readonly config: Required<ChatEngineConfig>;
+  private readonly config: Required<ChatEngineConfig> & { timeoutConfig: TimeoutConfig };
+  private timeoutState: TimeoutState;
+  private currentExecution: AgentExecutionHandle | null = null;
+  private pendingUserMessage: string | null = null;
+  private pendingOptions: SendMessageOptions | null = null;
 
   constructor(config: ChatEngineConfig) {
+    // Merge timeout config with defaults
+    const timeoutConfig: TimeoutConfig = {
+      ...DEFAULT_TIMEOUT_CONFIG,
+      ...config.timeoutConfig,
+    };
+
     this.config = {
       agent: config.agent,
       systemPrompt: config.systemPrompt,
@@ -83,6 +96,16 @@ export class ChatEngine {
       timeout: config.timeout ?? 0, // 0 = no timeout by default
       cwd: config.cwd ?? process.cwd(),
       agentOptions: config.agentOptions ?? {},
+      timeoutConfig,
+    };
+
+    // Initialize timeout state
+    this.timeoutState = {
+      retryCount: 0,
+      currentTimeout: this.config.timeout > 0
+        ? this.config.timeout
+        : timeoutConfig.initialTimeout,
+      retryPending: false,
     };
   }
 
@@ -138,6 +161,130 @@ export class ChatEngine {
   }
 
   /**
+   * Get the current timeout state.
+   */
+  getTimeoutState(): Readonly<TimeoutState> {
+    return { ...this.timeoutState };
+  }
+
+  /**
+   * Continue with a retry after a timeout.
+   */
+  retry(): void {
+    if (this.status !== 'timeout') {
+      return;
+    }
+    void this.doRetry();
+  }
+
+  /**
+   * Cancel after a timeout - don't retry.
+   */
+  cancelTimeout(): void {
+    if (this.status !== 'timeout') {
+      return;
+    }
+
+    // Reset state
+    this.timeoutState.retryPending = false;
+    this.timeoutState.retryCount = 0;
+    this.timeoutState.currentTimeout = this.config.timeout > 0
+      ? this.config.timeout
+      : this.config.timeoutConfig.initialTimeout;
+    this.pendingUserMessage = null;
+    this.pendingOptions = null;
+
+    this.setStatus('idle');
+  }
+
+  /**
+   * Continue waiting indefinitely after a timeout.
+   * Re-sends the request with no timeout.
+   */
+  continueIndefinitely(): void {
+    if (this.status !== 'timeout' || !this.pendingUserMessage || !this.pendingOptions) {
+      return;
+    }
+
+    void this.doContinueIndefinitely();
+  }
+
+  /**
+   * Interrupt the current execution.
+   */
+  interrupt(): void {
+    if (this.currentExecution?.isRunning()) {
+      this.currentExecution.interrupt();
+    }
+  }
+
+  /**
+   * Execute the continue-indefinitely logic.
+   */
+  private async doContinueIndefinitely(): Promise<void> {
+    if (!this.pendingUserMessage || !this.pendingOptions) {
+      this.setStatus('idle');
+      return;
+    }
+
+    // Reset retry state for the indefinite wait
+    this.timeoutState.retryPending = false;
+    this.timeoutState.currentTimeout = 0; // 0 = no timeout
+
+    // Emit retry started event
+    this.emit({
+      type: 'retry:started',
+      timestamp: new Date(),
+      timeoutState: { ...this.timeoutState },
+    });
+
+    this.setStatus('retrying');
+
+    // Retry the message with no timeout
+    const userMsg = this.pendingUserMessage;
+    const options = this.pendingOptions;
+    this.pendingUserMessage = null;
+    this.pendingOptions = null;
+
+    await this._sendMessageInternal(userMsg, options, true, true);
+  }
+
+  /**
+   * Execute the retry logic.
+   */
+  private async doRetry(): Promise<void> {
+    if (!this.pendingUserMessage || !this.pendingOptions) {
+      this.setStatus('idle');
+      return;
+    }
+
+    // Increment retry count and update timeout
+    this.timeoutState.retryCount++;
+    this.timeoutState.currentTimeout = Math.min(
+      this.timeoutState.currentTimeout * this.config.timeoutConfig.timeoutMultiplier,
+      this.config.timeoutConfig.maxTimeout
+    );
+    this.timeoutState.retryPending = false;
+
+    // Emit retry started event
+    this.emit({
+      type: 'retry:started',
+      timestamp: new Date(),
+      timeoutState: { ...this.timeoutState },
+    });
+
+    this.setStatus('retrying');
+
+    // Retry the message
+    const userMsg = this.pendingUserMessage;
+    const options = this.pendingOptions;
+    this.pendingUserMessage = null;
+    this.pendingOptions = null;
+
+    await this._sendMessageInternal(userMsg, options, true);
+  }
+
+  /**
    * Build the prompt for the agent including conversation history.
    * Uses markdown formatting (not XML tags) for compatibility with CLI agents
    * that may interpret angle-bracket tags as protocol markers.
@@ -179,6 +326,14 @@ export class ChatEngine {
     content: string,
     options: SendMessageOptions = {}
   ): Promise<SendMessageResult> {
+    // If we're in timeout state, don't allow sending
+    if (this.status === 'timeout' || this.status === 'retrying') {
+      return {
+        success: false,
+        error: 'Cannot send message while in timeout state',
+      };
+    }
+
     if (this.status === 'processing') {
       return {
         success: false,
@@ -186,24 +341,44 @@ export class ChatEngine {
       };
     }
 
-    // Create and store the user message
-    const userMessage: ChatMessage = {
-      role: 'user',
-      content,
-      timestamp: new Date(),
-    };
+    // Reset retry state for new messages
+    this.timeoutState.retryCount = 0;
+    this.timeoutState.currentTimeout = this.config.timeout > 0
+      ? this.config.timeout
+      : this.config.timeoutConfig.initialTimeout;
 
-    this.messages.push(userMessage);
-    this.emit({
-      type: 'message:sent',
-      timestamp: new Date(),
-      message: userMessage,
-    });
+    return await this._sendMessageInternal(content, options, false);
+  }
+
+  /**
+   * Internal implementation of sendMessage that handles retries.
+   */
+  private async _sendMessageInternal(
+    content: string,
+    options: SendMessageOptions,
+    isRetry: boolean,
+    noTimeout: boolean = false,
+  ): Promise<SendMessageResult> {
+    // Create and store the user message if this isn't a retry
+    if (!isRetry) {
+      const userMessage: ChatMessage = {
+        role: 'user',
+        content,
+        timestamp: new Date(),
+      };
+      this.messages.push(userMessage);
+      this.emit({
+        type: 'message:sent',
+        timestamp: new Date(),
+        message: userMessage,
+      });
+    }
 
     this.setStatus('processing');
     options.onStatus?.('Sending to agent...');
 
     const startTime = Date.now();
+    this.timeoutState.requestStartTime = startTime;
 
     try {
       // Build the full prompt with history
@@ -212,11 +387,14 @@ export class ChatEngine {
       // Collect streaming output
       let fullOutput = '';
 
+      // Determine timeout to use for this attempt
+      const attemptTimeout = noTimeout ? 0 : this.timeoutState.currentTimeout;
+
       // Execute the agent
       const agentOptions: AgentExecuteOptions = {
         ...this.config.agentOptions,
         cwd: this.config.cwd,
-        timeout: this.config.timeout,
+        timeout: attemptTimeout,
         onStdout: (data: string) => {
           fullOutput += data;
           options.onChunk?.(data);
@@ -229,9 +407,17 @@ export class ChatEngine {
       };
 
       const handle = this.config.agent.execute(prompt, [], agentOptions);
+      this.currentExecution = handle;
+
       const result = await handle.promise;
+      this.currentExecution = null;
 
       const durationMs = Date.now() - startTime;
+
+      if (result.status === 'timeout') {
+        // Handle timeout
+        return await this.handleTimeout(content, options, durationMs);
+      }
 
       if (result.status !== 'completed') {
         this.setStatus('error');
@@ -252,6 +438,12 @@ export class ChatEngine {
 
       // Use collected streaming output or fallback to result stdout
       const responseContent = fullOutput || result.stdout;
+
+      // Reset retry state on success
+      this.timeoutState.retryCount = 0;
+      this.timeoutState.currentTimeout = this.config.timeout > 0
+        ? this.config.timeout
+        : this.config.timeoutConfig.initialTimeout;
 
       // Create and store the assistant message
       const assistantMessage: ChatMessage = {
@@ -288,6 +480,7 @@ export class ChatEngine {
         durationMs,
       };
     } catch (error) {
+      this.currentExecution = null;
       const durationMs = Date.now() - startTime;
       const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -304,6 +497,43 @@ export class ChatEngine {
         durationMs,
       };
     }
+  }
+
+  /**
+   * Handle a timeout - interrupt and ask user what to do.
+   */
+  private async handleTimeout(
+    content: string,
+    options: SendMessageOptions,
+    durationMs: number,
+  ): Promise<SendMessageResult> {
+    // First, interrupt the running process (like Ctrl+C)
+    if (this.currentExecution?.isRunning()) {
+      this.currentExecution.interrupt();
+    }
+
+    // Update state
+    this.timeoutState.retryPending = true;
+
+    // Emit timeout event
+    this.emit({
+      type: 'timeout:occurred',
+      timestamp: new Date(),
+      timeoutState: { ...this.timeoutState },
+    });
+
+    this.setStatus('timeout');
+
+    // Store for potential retry
+    this.pendingUserMessage = content;
+    this.pendingOptions = options;
+
+    // Return a special result indicating we're waiting for user decision
+    return {
+      success: false,
+      error: `Request timed out after ${durationMs}ms - interrupted`,
+      durationMs,
+    };
   }
 
   /**
@@ -362,6 +592,16 @@ export class ChatEngine {
    */
   reset(): void {
     this.messages = [];
+    this.timeoutState = {
+      retryCount: 0,
+      currentTimeout: this.config.timeout > 0
+        ? this.config.timeout
+        : this.config.timeoutConfig.initialTimeout,
+      retryPending: false,
+    };
+    this.pendingUserMessage = null;
+    this.pendingOptions = null;
+    this.currentExecution = null;
     this.setStatus('idle');
   }
 
@@ -393,6 +633,7 @@ export function createPrdChatEngine(
     prdSkill?: string;
     prdSkillSource?: string;
     model?: string;
+    timeoutConfig?: Partial<TimeoutConfig>;
   } = {}
 ): ChatEngine {
   const systemPrompt = options.prdSkillSource
@@ -407,7 +648,8 @@ export function createPrdChatEngine(
     agent,
     systemPrompt,
     cwd: options.cwd,
-    timeout: options.timeout ?? 0,
+    timeout: options.timeout ?? 60000, // Default 1 minute timeout
+    timeoutConfig: options.timeoutConfig,
     ...(flags ? { agentOptions: { flags } } : {}),
   });
 }
@@ -418,6 +660,7 @@ export function createTaskChatEngine(
     cwd?: string;
     timeout?: number;
     model?: string;
+    timeoutConfig?: Partial<TimeoutConfig>;
   } = {}
 ): ChatEngine {
   const flags = buildAgentFlags(options);
@@ -426,7 +669,8 @@ export function createTaskChatEngine(
     agent,
     systemPrompt: TASK_SYSTEM_PROMPT,
     cwd: options.cwd,
-    timeout: options.timeout ?? 0,
+    timeout: options.timeout ?? 60000, // Default 1 minute timeout
+    timeoutConfig: options.timeoutConfig,
     ...(flags ? { agentOptions: { flags } } : {}),
   });
 }

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -36,7 +36,50 @@ export type ChatStatus =
   | 'idle' // Ready for user input
   | 'processing' // Waiting for agent response
   | 'error' // An error occurred
-  | 'completed'; // Conversation has reached a terminal state
+  | 'completed' // Conversation has reached a terminal state
+  | 'timeout' // Request timed out, waiting for user action
+  | 'retrying'; // Retrying the request after timeout
+
+/**
+ * Timeout configuration for chat engine.
+ */
+export interface TimeoutConfig {
+  /** Initial timeout in milliseconds (default: 60000 = 1 minute) */
+  initialTimeout: number;
+  /** Maximum timeout in milliseconds (default: 300000 = 5 minutes) */
+  maxTimeout: number;
+  /** Timeout multiplier for each retry (default: 1.5) */
+  timeoutMultiplier: number;
+  /** Maximum number of retries (default: 3) */
+  maxRetries: number;
+  /** Whether retries are enabled (default: true) */
+  enableRetries: boolean;
+}
+
+/**
+ * Default timeout configuration.
+ */
+export const DEFAULT_TIMEOUT_CONFIG: TimeoutConfig = {
+  initialTimeout: 60000, // 1 minute
+  maxTimeout: 300000, // 5 minutes
+  timeoutMultiplier: 1.5,
+  maxRetries: 3,
+  enableRetries: true,
+};
+
+/**
+ * Timeout state for tracking retry progress.
+ */
+export interface TimeoutState {
+  /** Current retry count (0 = first attempt) */
+  retryCount: number;
+  /** Current timeout in milliseconds */
+  currentTimeout: number;
+  /** Whether a retry decision is pending (waiting for user input) */
+  retryPending: boolean;
+  /** Time when the current request started */
+  requestStartTime?: number;
+}
 
 /**
  * Configuration for the chat engine.
@@ -53,6 +96,9 @@ export interface ChatEngineConfig {
 
   /** Timeout for agent execution in milliseconds */
   timeout?: number;
+
+  /** Timeout configuration for retry behavior */
+  timeoutConfig?: Partial<TimeoutConfig>;
 
   /** Working directory for agent execution */
   cwd?: string;
@@ -73,6 +119,9 @@ export interface SendMessageOptions {
 
   /** Callback for progress status updates */
   onStatus?: (status: string) => void;
+
+  /** Callback when a timeout occurs, return true to retry, false to cancel */
+  onTimeout?: (state: TimeoutState) => Promise<boolean> | boolean;
 }
 
 /**
@@ -157,7 +206,9 @@ export type ChatEventType =
   | 'message:received' // Assistant message was received
   | 'status:changed' // Status changed
   | 'error:occurred' // An error occurred
-  | 'prd:detected'; // A complete PRD was detected in response
+  | 'prd:detected' // A complete PRD was detected in response
+  | 'timeout:occurred' // A timeout occurred
+  | 'retry:started'; // A retry has started
 
 /**
  * Base interface for chat events.
@@ -230,6 +281,26 @@ export interface ChatPrdDetectedEvent extends ChatEventBase {
 }
 
 /**
+ * Event emitted when a timeout occurs.
+ */
+export interface ChatTimeoutEvent extends ChatEventBase {
+  type: 'timeout:occurred';
+
+  /** Current timeout state */
+  timeoutState: TimeoutState;
+}
+
+/**
+ * Event emitted when a retry starts.
+ */
+export interface ChatRetryStartedEvent extends ChatEventBase {
+  type: 'retry:started';
+
+  /** Current timeout state */
+  timeoutState: TimeoutState;
+}
+
+/**
  * Union type of all chat events.
  */
 export type ChatEvent =
@@ -237,7 +308,9 @@ export type ChatEvent =
   | ChatMessageReceivedEvent
   | ChatStatusChangedEvent
   | ChatErrorEvent
-  | ChatPrdDetectedEvent;
+  | ChatPrdDetectedEvent
+  | ChatTimeoutEvent
+  | ChatRetryStartedEvent;
 
 /**
  * Listener function for chat events.

--- a/src/plugins/trackers/builtin/beads-rust/index.test.ts
+++ b/src/plugins/trackers/builtin/beads-rust/index.test.ts
@@ -576,6 +576,11 @@ describe('BeadsRustTrackerPlugin', () => {
             { issue_id: 'epic.1', depends_on_id: 'epic', type: 'parent-child', title: 'Child', status: 'open', priority: 0 },
           ]),
         },
+        // getChildIds recursively fetches descendants; epic.1 has no children
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([]),
+        },
         {
           exitCode: 0,
           stdout: JSON.stringify([
@@ -597,8 +602,73 @@ describe('BeadsRustTrackerPlugin', () => {
       expect(mockSpawnArgs.map((c) => c.args)).toEqual([
         ['list', '--json', '--all', '--limit', '0'],
         ['dep', 'list', 'epic', '--direction', 'up', '--json'],
+        ['dep', 'list', 'epic.1', '--direction', 'up', '--json'],
         ['dep', 'list', 'epic.1', '--json'],
       ]);
+    });
+
+    test('recursively fetches all descendants for multi-level hierarchy', async () => {
+      mockSpawnResponses = [
+        { exitCode: 0, stdout: 'br version 0.4.1\n' },
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { id: 'epic', title: 'Epic', status: 'open', priority: 0, issue_type: 'epic' },
+            { id: 'epic.1', title: 'User story', status: 'open', priority: 0, issue_type: 'user-story', dependencies: [{ id: 'epic', dependency_type: 'parent-child' }], dependents: [{ id: 'epic.1.1', dependency_type: 'parent-child' }, { id: 'epic.1.2', dependency_type: 'parent-child' }] },
+            { id: 'epic.1.1', title: 'Task A', status: 'open', priority: 0, issue_type: 'task', dependencies: [{ id: 'epic.1', dependency_type: 'parent-child' }], dependency_count: 1 },
+            { id: 'epic.1.2', title: 'Task B', status: 'open', priority: 0, issue_type: 'task', dependencies: [{ id: 'epic.1', dependency_type: 'parent-child' }], dependency_count: 1 },
+          ]),
+        },
+        // dep list epic -> returns epic.1
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { issue_id: 'epic.1', depends_on_id: 'epic', type: 'parent-child' },
+          ]),
+        },
+        // dep list epic.1 -> returns epic.1.1 and epic.1.2
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { issue_id: 'epic.1.1', depends_on_id: 'epic.1', type: 'parent-child' },
+            { issue_id: 'epic.1.2', depends_on_id: 'epic.1', type: 'parent-child' },
+          ]),
+        },
+        // dep list epic.1.1 -> no children
+        { exitCode: 0, stdout: JSON.stringify([]) },
+        // dep list epic.1.2 -> no children
+        { exitCode: 0, stdout: JSON.stringify([]) },
+        // dep list epic.1 for dependency enrichment
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { issue_id: 'epic.1', depends_on_id: 'epic', type: 'parent-child' },
+          ]),
+        },
+        // dep list epic.1.1 for dependency enrichment
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { issue_id: 'epic.1.1', depends_on_id: 'epic.1', type: 'parent-child' },
+          ]),
+        },
+        // dep list epic.1.2 for dependency enrichment
+        {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { issue_id: 'epic.1.2', depends_on_id: 'epic.1', type: 'parent-child' },
+          ]),
+        },
+      ];
+
+      const plugin = new BeadsRustTrackerPlugin();
+      await plugin.initialize({ workingDir: '/test' });
+      mockSpawnArgs = [];
+
+      const tasks = await plugin.getTasks({ parentId: 'epic' });
+
+      expect(tasks.length).toBe(3);
+      expect(tasks.map((t) => t.id).sort()).toEqual(['epic.1', 'epic.1.1', 'epic.1.2']);
     });
 
     test('merges enriched dependencies with existing list dependencies and deduplicates', async () => {

--- a/src/plugins/trackers/builtin/beads-rust/index.ts
+++ b/src/plugins/trackers/builtin/beads-rust/index.ts
@@ -577,34 +577,44 @@ export class BeadsRustTrackerPlugin extends BaseTrackerPlugin {
   }
 
   /**
-   * Get child IDs for a parent epic/task.
+   * Get child IDs for a parent epic/task, recursively including all descendants.
    * Uses br dep list --direction up to get issues that depend on the parent
-   * with a parent-child relationship (i.e., children of the epic).
+   * with a parent-child relationship (i.e., children of the epic), then
+   * recursively fetches grandchildren.
    */
   private async getChildIds(parentId: string): Promise<Set<string>> {
-    const { stdout, exitCode } = await execBr(
-      ['dep', 'list', parentId, '--direction', 'up', '--json'],
-      this.workingDir
-    );
+    const allDescendants = new Set<string>();
+    const toProcess: string[] = [parentId];
 
-    if (exitCode !== 0) {
-      return new Set();
-    }
+    while (toProcess.length > 0) {
+      const current = toProcess.shift()!;
 
-    try {
-      const deps = JSON.parse(stdout) as BrDepListItem[];
-      const childIds = new Set<string>();
+      const { stdout, exitCode } = await execBr(
+        ['dep', 'list', current, '--direction', 'up', '--json'],
+        this.workingDir
+      );
 
-      for (const dep of deps) {
-        if (dep.type === 'parent-child') {
-          childIds.add(dep.issue_id);
-        }
+      if (exitCode !== 0) {
+        continue;
       }
 
-      return childIds;
-    } catch {
-      return new Set();
+      try {
+        const deps = JSON.parse(stdout) as BrDepListItem[];
+        for (const dep of deps) {
+          if (dep.type === 'parent-child') {
+            // Only add if not already processed to avoid infinite loops
+            if (!allDescendants.has(dep.issue_id)) {
+              allDescendants.add(dep.issue_id);
+              toProcess.push(dep.issue_id);
+            }
+          }
+        }
+      } catch {
+        // Skip this parent if parsing fails
+      }
     }
+
+    return allDescendants;
   }
 
   /**

--- a/src/tui/components/PrdChatApp.tsx
+++ b/src/tui/components/PrdChatApp.tsx
@@ -22,7 +22,7 @@ import {
   createTaskChatEngine,
   slugify,
 } from '../../chat/engine.js';
-import type { ChatMessage, ChatEvent } from '../../chat/types.js';
+import type { ChatMessage, ChatEvent, TimeoutState } from '../../chat/types.js';
 import type { AgentPlugin } from '../../plugins/agents/types.js';
 import { stripAnsiCodes, type FormattedSegment } from '../../plugins/agents/output-formatting.js';
 import { parsePrdMarkdown } from '../../prd/parser.js';
@@ -347,6 +347,78 @@ function PrdPreview({
 }
 
 /**
+ * Timeout Dialog component for retry/continue decision
+ */
+function TimeoutDialog({
+  timeoutState,
+}: {
+  timeoutState: TimeoutState;
+}): ReactNode {
+  const formatMs = (ms: number): string => {
+    const seconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    if (minutes > 0) {
+      return `${minutes}m ${remainingSeconds}s`;
+    }
+    return `${seconds}s`;
+  };
+
+  return (
+    <box
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: colors.bg.overlay,
+      }}
+    >
+      <box
+        style={{
+          width: 60,
+          backgroundColor: colors.bg.secondary,
+          border: true,
+          borderColor: colors.status.warning,
+          flexDirection: 'column',
+          padding: 1,
+        }}
+      >
+        {/* Title */}
+        <text fg={colors.status.warning}>⚠ Request Timed Out</text>
+        <text fg={colors.fg.muted} style={{ marginTop: 1 }}>
+          The request was interrupted after {formatMs(timeoutState.currentTimeout)}.
+        </text>
+
+        {/* Retry info */}
+        {timeoutState.retryCount > 0 && (
+          <box style={{ marginTop: 1 }}>
+            <text fg={colors.fg.primary}>
+              Previous retries: {timeoutState.retryCount}
+            </text>
+          </box>
+        )}
+
+        {/* Options */}
+        <box style={{ marginTop: 2, flexDirection: 'column' }}>
+          <text fg={colors.status.success}>[r] Retry with longer timeout</text>
+          <text fg={colors.fg.primary}>[c] Continue waiting indefinitely</text>
+          <text fg={colors.status.error}>[Esc] Cancel request</text>
+        </box>
+
+        {/* Hint */}
+        <text fg={colors.fg.muted} style={{ marginTop: 1 }}>
+          Press a key to choose
+        </text>
+      </box>
+    </box>
+  );
+}
+
+/**
  * PrdChatApp component - Main application for PRD chat generation
  */
 export function PrdChatApp({
@@ -388,6 +460,10 @@ export function PrdChatApp({
 
   // Quit confirmation dialog state
   const [showQuitConfirm, setShowQuitConfirm] = useState(false);
+
+  // Timeout dialog state
+  const [showTimeoutDialog, setShowTimeoutDialog] = useState(false);
+  const [timeoutState, setTimeoutState] = useState<TimeoutState | null>(null);
 
   // Track which tracker format was selected for tasks
   const [selectedTrackerFormat, setSelectedTrackerFormat] = useState<
@@ -458,6 +534,24 @@ export function PrdChatApp({
             setError(event.error);
           }
           onError?.(event.error);
+          break;
+
+        case 'timeout:occurred':
+          if (isMountedRef.current) {
+            // Stop showing loading indicator
+            setIsLoading(false);
+            setTimeoutState(event.timeoutState);
+            setShowTimeoutDialog(true);
+          }
+          break;
+
+        case 'retry:started':
+          if (isMountedRef.current) {
+            setShowTimeoutDialog(false);
+            setTimeoutState(event.timeoutState);
+            setIsLoading(true);
+            setLoadingStatus(`Retrying request (attempt ${event.timeoutState.retryCount})...`);
+          }
           break;
       }
     });
@@ -782,6 +876,47 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
   );
 
   /**
+   * Handle timeout dialog retry action
+   */
+  const handleTimeoutRetry = useCallback(() => {
+    if (!engineRef.current) return;
+
+    setShowTimeoutDialog(false);
+    // Reset timeout-related state
+    setTimeoutState(null);
+    // Retry using the engine's built-in retry mechanism
+    engineRef.current.retry();
+  }, []);
+
+  /**
+   * Handle timeout dialog cancel action
+   */
+  const handleTimeoutCancel = useCallback(() => {
+    if (!engineRef.current) return;
+
+    setShowTimeoutDialog(false);
+    setTimeoutState(null);
+    setIsLoading(false);
+    setLoadingStatus('');
+    // Tell the engine to cancel the timeout state
+    engineRef.current.cancelTimeout();
+  }, []);
+
+  /**
+   * Handle continue waiting indefinitely - re-send with no timeout
+   */
+  const handleTimeoutContinue = useCallback(() => {
+    if (!engineRef.current) return;
+
+    setShowTimeoutDialog(false);
+    setTimeoutState(null);
+    setIsLoading(true);
+    setLoadingStatus('Continuing to wait for agent response (no timeout)...');
+    // Tell the engine to continue indefinitely
+    engineRef.current.continueIndefinitely();
+  }, []);
+
+  /**
    * Clipboard fallback for terminals that don't emit OpenTUI paste events.
    * Triggered by paste keyboard shortcuts when no paste event follows shortly after.
    */
@@ -889,6 +1024,18 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
         return;
       }
 
+      // Handle timeout dialog
+      if (showTimeoutDialog && timeoutState) {
+        if (key.name === 'r' || key.sequence === 'r' || key.sequence === 'R') {
+          handleTimeoutRetry();
+        } else if (key.name === 'c' || key.sequence === 'c' || key.sequence === 'C') {
+          handleTimeoutContinue();
+        } else if (key.name === 'escape') {
+          handleTimeoutCancel();
+        }
+        return;
+      }
+
       // Don't process keys while loading
       if (isLoading) {
         return;
@@ -942,6 +1089,11 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
       featureName,
       selectedTrackerFormat,
       renderer,
+      showTimeoutDialog,
+      timeoutState,
+      handleTimeoutRetry,
+      handleTimeoutCancel,
+      handleTimeoutContinue,
     ],
   );
 
@@ -1123,7 +1275,7 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
         streamingSegments={streamingSegments}
         inputPlaceholder="Describe your feature..."
         error={error}
-        inputEnabled={!isLoading && !showQuitConfirm}
+        inputEnabled={!isLoading && !showQuitConfirm && !showTimeoutDialog}
         hint={hint}
         agentName={agent.meta.name}
         onSubmit={sendMessage}
@@ -1138,6 +1290,13 @@ Read the PRD and create the appropriate tasks.${labelsInstruction}`;
         message="Your progress will be lost."
         hint="[y] Yes, cancel  [n/Esc] No, continue"
       />
+
+      {/* Timeout dialog */}
+      {showTimeoutDialog && timeoutState && (
+        <TimeoutDialog
+          timeoutState={timeoutState}
+        />
+      )}
 
       {/* Copy feedback toast - positioned at bottom right */}
       {copyFeedback && (

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -18,6 +18,7 @@ export interface ThemeColors {
     secondary: string;
     tertiary: string;
     highlight: string;
+    overlay: string;
   };
   fg: {
     primary: string;
@@ -63,6 +64,7 @@ export const defaultColors: ThemeColors = {
     secondary: '#24283b',
     tertiary: '#2f3449',
     highlight: '#3d4259',
+    overlay: '#0f0f12',
   },
   fg: {
     primary: '#c0caf5',


### PR DESCRIPTION
## Summary
- `getChildIds` previously only returned direct children of an epic, missing grandchild tasks (e.g., epic -> user-story -> tasks)
- Now recursively traverses parent-child relationships to include all descendants
- Also includes rebase onto main which pulled in timeout/retry changes

## Test plan
- [ ] Run `bun test src/plugins/trackers/builtin/beads-rust/index.test.ts` — all 50 tests pass
- [ ] Run `ralph-tui run` in a project with multi-level hierarchy (epic -> user-story -> tasks) — all tasks should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat requests now support configurable timeout and retry behavior with a dedicated UI dialog.
  * New timeout dialog UI allowing users to retry with extended timeout, continue indefinitely, or cancel requests.
  * Improved recursive task and issue hierarchy fetching for better data retrieval.
  * Added overlay background color support to the theme system.

* **Configuration Changes**
  * Default request timeout updated to 60 seconds (previously unlimited).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/subsy/ralph-tui/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->