### PR TITLE
fix: stream agent output in `resume --headless` via a shared event handler

### DIFF
--- a/src/commands/headless-events.ts
+++ b/src/commands/headless-events.ts
@@ -1,0 +1,179 @@
+/**
+ * ABOUTME: Shared headless-mode engine event handling for the run and resume commands.
+ * Translates engine events into structured log lines and keeps the persisted session
+ * state current, so every headless entry point emits the same output.
+ */
+
+import type { EngineEvent, EngineEventListener } from '../engine/types.js';
+import type { StructuredLogger } from '../logs/index.js';
+import {
+  addActiveTask,
+  removeActiveTask,
+  pauseSession,
+  updateSessionAfterIteration,
+  savePersistedSession,
+  type PersistedSessionState,
+} from '../session/index.js';
+
+/**
+ * Options for creating a headless event handler.
+ */
+export interface HeadlessEventHandlerOptions {
+  /** Logger used for all headless output */
+  logger: StructuredLogger;
+  /** Iteration cap shown in progress lines (0 means unlimited) */
+  maxIterations: number;
+  /** Session state to track and persist as iterations complete */
+  initialState: PersistedSessionState;
+}
+
+/**
+ * Engine listener plus accessors for the session state it maintains.
+ */
+export interface HeadlessEventHandler {
+  /** Engine listener that logs events and persists session state */
+  handleEvent: EngineEventListener;
+  /** Read the currently tracked session state */
+  getState: () => PersistedSessionState;
+  /** Replace the tracked session state (used by shutdown paths) */
+  setState: (next: PersistedSessionState) => void;
+}
+
+/**
+ * Create the headless engine event handler.
+ *
+ * The returned listener owns a mutable copy of the session state: it records
+ * active tasks, applies iteration results, and persists after each change.
+ * Callers that mutate state outside the engine loop (signal handlers, for
+ * example) should go through `setState` so the tracked copy stays in sync.
+ *
+ * Command-specific concerns (desktop notifications, lock release, remote
+ * servers) stay in the calling command; register a second engine listener for
+ * those instead of extending this one.
+ */
+export function createHeadlessEventHandler(
+  options: HeadlessEventHandlerOptions
+): HeadlessEventHandler {
+  const { logger, maxIterations } = options;
+  let currentState = options.initialState;
+
+  const persist = (): void => {
+    savePersistedSession(currentState).catch(() => {
+      // Silently continue on save errors
+    });
+  };
+
+  const handleEvent: EngineEventListener = (event: EngineEvent): void => {
+    switch (event.type) {
+      case 'engine:started':
+        logger.engineStarted(event.totalTasks);
+        break;
+
+      case 'engine:warning':
+        logger.warn('engine', event.message);
+        break;
+
+      case 'iteration:started':
+        // Progress update in required format
+        logger.progress(event.iteration, maxIterations, event.task.id, event.task.title);
+        break;
+
+      case 'iteration:completed':
+        logger.iterationComplete(
+          event.result.iteration,
+          event.result.task.id,
+          event.result.taskCompleted,
+          event.result.durationMs
+        );
+
+        // Log task completion if applicable
+        if (event.result.taskCompleted) {
+          logger.taskCompleted(event.result.task.id, event.result.iteration);
+          // Remove from active tasks
+          currentState = removeActiveTask(currentState, event.result.task.id);
+        }
+
+        // Save state after each iteration
+        currentState = updateSessionAfterIteration(currentState, event.result);
+        persist();
+        break;
+
+      case 'task:activated':
+        // Track task as active when set to in_progress
+        currentState = addActiveTask(currentState, event.task.id);
+        persist();
+        break;
+
+      case 'iteration:failed':
+        logger.iterationFailed(event.iteration, event.task.id, event.error, event.action);
+        break;
+
+      case 'iteration:retrying':
+        logger.iterationRetrying(
+          event.iteration,
+          event.task.id,
+          event.retryAttempt,
+          event.maxRetries,
+          event.delayMs
+        );
+        break;
+
+      case 'iteration:skipped':
+        logger.iterationSkipped(event.iteration, event.task.id, event.reason);
+        break;
+
+      case 'agent:output':
+        // Stream agent output with [AGENT] prefix
+        if (event.stream === 'stdout') {
+          logger.agentOutput(event.data);
+        } else {
+          logger.agentError(event.data);
+        }
+        break;
+
+      case 'task:selected':
+        logger.taskSelected(event.task.id, event.task.title, event.iteration);
+        break;
+
+      case 'engine:paused':
+        logger.enginePaused(event.currentIteration);
+        currentState = pauseSession(currentState);
+        persist();
+        break;
+
+      case 'engine:resumed':
+        logger.engineResumed(event.fromIteration);
+        currentState = {
+          ...currentState,
+          status: 'running',
+          isPaused: false,
+          pausedAt: undefined,
+        };
+        persist();
+        break;
+
+      case 'engine:stopped':
+        logger.engineStopped(event.reason, event.totalIterations, event.tasksCompleted);
+        break;
+
+      case 'all:complete':
+        logger.allComplete(event.totalCompleted, event.totalIterations);
+        break;
+
+      case 'task:completed':
+        // Already logged in the iteration:completed handler.
+        // Remove from active tasks (redundant with iteration:completed but safe)
+        currentState = removeActiveTask(currentState, event.task.id);
+        persist();
+        break;
+    }
+  };
+
+  return {
+    handleEvent,
+    getState: () => currentState,
+    setState: (next: PersistedSessionState): void => {
+      currentState = next;
+    },
+  };
+}

--- a/src/commands/resume.tsx
+++ b/src/commands/resume.tsx
@@ -37,8 +37,10 @@ import {
   type SessionRegistryEntry,
 } from '../session/index.js';
 import { buildConfig, validateConfig } from '../config/index.js';
-import type { RuntimeOptions } from '../config/types.js';
+import type { RalphConfig, RuntimeOptions } from '../config/types.js';
 import { ExecutionEngine } from '../engine/index.js';
+import { createStructuredLogger } from '../logs/index.js';
+import { createHeadlessEventHandler } from './headless-events.js';
 import { registerBuiltinAgents } from '../plugins/agents/builtin/index.js';
 import { registerBuiltinTrackers } from '../plugins/trackers/builtin/index.js';
 import { getAgentRegistry } from '../plugins/agents/registry.js';
@@ -478,70 +480,26 @@ async function runWithTui(
 async function runHeadless(
   engine: ExecutionEngine,
   cwd: string,
-  initialState: PersistedSessionState
+  initialState: PersistedSessionState,
+  config: RalphConfig
 ): Promise<PersistedSessionState> {
-  let currentState = initialState;
+  // Create structured logger for headless output
+  const logger = createStructuredLogger();
 
-  engine.on((event) => {
-    switch (event.type) {
-      case 'engine:started':
-        console.log(`\nResumed Ralph. Total tasks: ${event.totalTasks}`);
-        break;
-
-      case 'iteration:started':
-        console.log(`\n--- Iteration ${event.iteration}: ${event.task.title} ---`);
-        break;
-
-      case 'iteration:completed':
-        console.log(
-          `Iteration ${event.result.iteration} completed. ` +
-            `Task ${event.result.taskCompleted ? 'DONE' : 'in progress'}. ` +
-            `Duration: ${Math.round(event.result.durationMs / 1000)}s`
-        );
-        // Save state after each iteration
-        currentState = updateSessionAfterIteration(currentState, event.result);
-        savePersistedSession(currentState).catch(() => {
-          // Log but don't fail on save errors
-        });
-        break;
-
-      case 'iteration:failed':
-        console.error(`Iteration ${event.iteration} FAILED: ${event.error}`);
-        break;
-
-      case 'engine:paused':
-        console.log('\nPaused. Use "ralph-tui resume" to continue.');
-        currentState = pauseSession(currentState);
-        savePersistedSession(currentState).catch(() => {
-          // Log but don't fail on save errors
-        });
-        break;
-
-      case 'engine:resumed':
-        console.log('\nResumed...');
-        currentState = { ...currentState, status: 'running', isPaused: false, pausedAt: undefined };
-        savePersistedSession(currentState).catch(() => {
-          // Log but don't fail on save errors
-        });
-        break;
-
-      case 'engine:stopped':
-        console.log(`\nRalph stopped. Reason: ${event.reason}`);
-        console.log(`Total iterations: ${event.totalIterations}`);
-        console.log(`Tasks completed: ${event.tasksCompleted}`);
-        break;
-
-      case 'all:complete':
-        console.log('\nAll tasks complete!');
-        break;
-    }
+  // Shared handler: same structured output and state persistence as `run --headless`,
+  // including streamed agent output during long iterations.
+  const headlessEvents = createHeadlessEventHandler({
+    logger,
+    maxIterations: config.maxIterations,
+    initialState,
   });
+  engine.on(headlessEvents.handleEvent);
 
   const handleSignal = async (): Promise<void> => {
-    console.log('\nInterrupted, stopping...');
+    logger.info('system', 'Interrupted, stopping...');
     // Save interrupted state
-    currentState = { ...currentState, status: 'interrupted' };
-    await savePersistedSession(currentState);
+    headlessEvents.setState({ ...headlessEvents.getState(), status: 'interrupted' });
+    await savePersistedSession(headlessEvents.getState());
     await engine.dispose();
     await releaseLock(cwd);
     process.exit(0);
@@ -550,10 +508,13 @@ async function runHeadless(
   process.on('SIGINT', handleSignal);
   process.on('SIGTERM', handleSignal);
 
+  // Log session resume
+  logger.sessionResumed(headlessEvents.getState().sessionId);
+
   await engine.start();
   await engine.dispose();
   await releaseLock(cwd);
-  return currentState;
+  return headlessEvents.getState();
 }
 
 /**
@@ -773,7 +734,7 @@ export async function executeResumeCommand(args: string[]): Promise<void> {
         executionScopes
       );
     } else {
-      finalState = await runHeadless(engine, cwd, resumedState);
+      finalState = await runHeadless(engine, cwd, resumedState, config);
     }
   } catch (error) {
     console.error(

--- a/src/commands/run.tsx
+++ b/src/commands/run.tsx
@@ -76,6 +76,7 @@ import { projectConfigExists, runSetupWizard, checkAndMigrate } from '../setup/i
 import { createInterruptHandler } from '../interruption/index.js';
 import type { InterruptHandler } from '../interruption/types.js';
 import { createStructuredLogger, clearProgress } from '../logs/index.js';
+import { createHeadlessEventHandler } from './headless-events.js';
 import { sendCompletionNotification, sendMaxIterationsNotification, sendErrorNotification, resolveNotificationsEnabled } from '../notifications.js';
 import type { NotificationSoundMode } from '../config/types.js';
 import { detectSandboxMode } from '../sandbox/index.js';
@@ -3176,7 +3177,6 @@ async function runHeadless(
   const notificationOptions = headlessOptions?.notificationOptions;
   const listenMode = headlessOptions?.listenMode ?? false;
   const remoteServer = headlessOptions?.remoteServer;
-  let currentState = persistedState;
   let lastSigintTime = 0;
   const DOUBLE_PRESS_WINDOW_MS = 1000;
   // Track when engine starts for duration calculation
@@ -3187,118 +3187,30 @@ async function runHeadless(
   // Create structured logger for headless output
   const logger = createStructuredLogger();
 
-  // Subscribe to events for structured log output and state persistence
+  // Shared handler: structured log output and session state persistence
+  const headlessEvents = createHeadlessEventHandler({
+    logger,
+    maxIterations: config.maxIterations,
+    initialState: persistedState,
+  });
+  engine.on(headlessEvents.handleEvent);
+
+  // Subscribe to events for run-specific concerns (notifications, remote server)
   engine.on((event) => {
     switch (event.type) {
       case 'engine:started':
-        logger.engineStarted(event.totalTasks);
         // Track when engine started for duration calculation
         engineStartTime = new Date();
         break;
 
-      case 'engine:warning':
-        logger.warn('engine', event.message);
-        break;
-
-      case 'iteration:started':
-        // Progress update in required format
-        logger.progress(
-          event.iteration,
-          config.maxIterations,
-          event.task.id,
-          event.task.title
-        );
-        break;
-
-      case 'iteration:completed':
-        // Log iteration completion
-        logger.iterationComplete(
-          event.result.iteration,
-          event.result.task.id,
-          event.result.taskCompleted,
-          event.result.durationMs
-        );
-
-        // Log task completion if applicable
-        if (event.result.taskCompleted) {
-          logger.taskCompleted(event.result.task.id, event.result.iteration);
-          // Remove from active tasks
-          currentState = removeActiveTask(currentState, event.result.task.id);
-        }
-
-        // Save state after each iteration
-        currentState = updateSessionAfterIteration(currentState, event.result);
-        savePersistedSession(currentState).catch(() => {
-          // Silently continue on save errors
-        });
-        break;
-
-      case 'task:activated':
-        // Track task as active when set to in_progress
-        currentState = addActiveTask(currentState, event.task.id);
-        savePersistedSession(currentState).catch(() => {
-          // Silently continue on save errors
-        });
-        break;
-
       case 'iteration:failed':
-        logger.iterationFailed(
-          event.iteration,
-          event.task.id,
-          event.error,
-          event.action
-        );
         // Track error for notification if this will abort
         if (event.action === 'abort') {
           lastError = event.error;
         }
         break;
 
-      case 'iteration:retrying':
-        logger.iterationRetrying(
-          event.iteration,
-          event.task.id,
-          event.retryAttempt,
-          event.maxRetries,
-          event.delayMs
-        );
-        break;
-
-      case 'iteration:skipped':
-        logger.iterationSkipped(event.iteration, event.task.id, event.reason);
-        break;
-
-      case 'agent:output':
-        // Stream agent output with [AGENT] prefix
-        if (event.stream === 'stdout') {
-          logger.agentOutput(event.data);
-        } else {
-          logger.agentError(event.data);
-        }
-        break;
-
-      case 'task:selected':
-        logger.taskSelected(event.task.id, event.task.title, event.iteration);
-        break;
-
-      case 'engine:paused':
-        logger.enginePaused(event.currentIteration);
-        currentState = pauseSession(currentState);
-        savePersistedSession(currentState).catch(() => {
-          // Silently continue on save errors
-        });
-        break;
-
-      case 'engine:resumed':
-        logger.engineResumed(event.fromIteration);
-        currentState = { ...currentState, status: 'running', isPaused: false, pausedAt: undefined };
-        savePersistedSession(currentState).catch(() => {
-          // Silently continue on save errors
-        });
-        break;
-
       case 'engine:stopped':
-        logger.engineStopped(event.reason, event.totalIterations, event.tasksCompleted);
         // Send max iterations notification if enabled
         if (event.reason === 'max_iterations' && notificationOptions?.notificationsEnabled && engineStartTime) {
           const durationMs = Date.now() - engineStartTime.getTime();
@@ -3325,7 +3237,6 @@ async function runHeadless(
         break;
 
       case 'all:complete':
-        logger.allComplete(event.totalCompleted, event.totalIterations);
         // Send completion notification if enabled
         if (notificationOptions?.notificationsEnabled && engineStartTime) {
           const durationMs = Date.now() - engineStartTime.getTime();
@@ -3336,15 +3247,6 @@ async function runHeadless(
           });
         }
         break;
-
-      case 'task:completed':
-        // Already logged in iteration:completed handler
-        // Remove from active tasks (redundant with iteration:completed but safe)
-        currentState = removeActiveTask(currentState, event.task.id);
-        savePersistedSession(currentState).catch(() => {
-          // Silently continue on save errors
-        });
-        break;
     }
   });
 
@@ -3354,18 +3256,18 @@ async function runHeadless(
     logger.info('system', '(Press Ctrl+C again within 1s to force quit)');
 
     // Reset any active (in_progress) tasks back to open
-    const activeTasks = getActiveTasks(currentState);
+    const activeTasks = getActiveTasks(headlessEvents.getState());
     if (activeTasks.length > 0) {
       logger.info('system', `Resetting ${activeTasks.length} in_progress task(s) to open...`);
       const resetCount = await engine.resetTasksToOpen(activeTasks);
       if (resetCount > 0) {
-        currentState = clearActiveTasks(currentState);
+        headlessEvents.setState(clearActiveTasks(headlessEvents.getState()));
       }
     }
 
     // Save interrupted state
-    currentState = { ...currentState, status: 'interrupted' };
-    await savePersistedSession(currentState);
+    headlessEvents.setState({ ...headlessEvents.getState(), status: 'interrupted' });
+    await savePersistedSession(headlessEvents.getState());
 
     // Stop remote server if running
     if (remoteServer) {
@@ -3397,17 +3299,17 @@ async function runHeadless(
     logger.info('system', 'Received SIGTERM, stopping gracefully...');
 
     // Reset any active (in_progress) tasks back to open
-    const activeTasks = getActiveTasks(currentState);
+    const activeTasks = getActiveTasks(headlessEvents.getState());
     if (activeTasks.length > 0) {
       logger.info('system', `Resetting ${activeTasks.length} in_progress task(s) to open...`);
       const resetCount = await engine.resetTasksToOpen(activeTasks);
       if (resetCount > 0) {
-        currentState = clearActiveTasks(currentState);
+        headlessEvents.setState(clearActiveTasks(headlessEvents.getState()));
       }
     }
 
-    currentState = { ...currentState, status: 'interrupted' };
-    await savePersistedSession(currentState);
+    headlessEvents.setState({ ...headlessEvents.getState(), status: 'interrupted' });
+    await savePersistedSession(headlessEvents.getState());
 
     // Stop remote server if running
     if (remoteServer) {
@@ -3423,7 +3325,7 @@ async function runHeadless(
 
   // Log session start
   logger.sessionCreated(
-    currentState.sessionId,
+    headlessEvents.getState().sessionId,
     config.agent.plugin,
     config.tracker.plugin
   );
@@ -3444,7 +3346,7 @@ async function runHeadless(
 
   await engine.dispose();
 
-  return currentState;
+  return headlessEvents.getState();
 }
 
 /**

--- a/tests/commands/headless-events.test.ts
+++ b/tests/commands/headless-events.test.ts
@@ -1,0 +1,330 @@
+/**
+ * ABOUTME: Tests for the shared headless engine event handler.
+ * Verifies that engine events produce structured log output (including streamed
+ * agent output) and that session state is tracked across iterations.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Writable } from 'node:stream';
+import { createHeadlessEventHandler } from '../../src/commands/headless-events.js';
+import { createStructuredLogger } from '../../src/logs/index.js';
+import type { PersistedSessionState } from '../../src/session/index.js';
+import type { EngineEvent, IterationResult } from '../../src/engine/types.js';
+import { createTrackerTask } from '../factories/tracker-task.js';
+
+/**
+ * Collect everything written to a stream so log output can be asserted on.
+ */
+function createCapturingStream(): { stream: Writable; lines: () => string[] } {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  return {
+    stream,
+    lines: () =>
+      chunks
+        .join('')
+        .split('\n')
+        .filter((line) => line.length > 0),
+  };
+}
+
+function createPersistedState(cwd: string): PersistedSessionState {
+  return {
+    version: 1,
+    sessionId: 'test-session-001',
+    status: 'running',
+    startedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    currentIteration: 6,
+    maxIterations: 0,
+    tasksCompleted: 0,
+    isPaused: false,
+    agentPlugin: 'opencode',
+    trackerState: {
+      plugin: 'beads',
+      totalTasks: 10,
+      tasks: [{ id: 'task-001', status: 'open' }],
+    },
+    iterations: [],
+    skippedTaskIds: [],
+    cwd,
+    activeTaskIds: [],
+  };
+}
+
+function createIterationResult(overrides: Partial<IterationResult> = {}): IterationResult {
+  return {
+    iteration: 1,
+    status: 'completed',
+    task: createTrackerTask(),
+    taskCompleted: false,
+    promiseComplete: false,
+    durationMs: 624_000,
+    startedAt: new Date().toISOString(),
+    endedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('createHeadlessEventHandler', () => {
+  let cwd: string;
+  let out: ReturnType<typeof createCapturingStream>;
+  let err: ReturnType<typeof createCapturingStream>;
+  let handler: ReturnType<typeof createHeadlessEventHandler>;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'ralph-headless-events-'));
+    out = createCapturingStream();
+    err = createCapturingStream();
+    handler = createHeadlessEventHandler({
+      logger: createStructuredLogger({
+        showTimestamp: false,
+        stream: out.stream,
+        errorStream: err.stream,
+      }),
+      maxIterations: 20,
+      initialState: createPersistedState(cwd),
+    });
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  describe('agent output streaming', () => {
+    test('streams agent stdout so long iterations are not silent', () => {
+      handler.handleEvent({
+        type: 'agent:output',
+        timestamp: new Date().toISOString(),
+        stream: 'stdout',
+        data: 'Reading src/index.ts\nEditing src/index.ts\n',
+      } as EngineEvent);
+
+      expect(out.lines()).toEqual([
+        '[INFO] [agent] Reading src/index.ts',
+        '[INFO] [agent] Editing src/index.ts',
+      ]);
+    });
+
+    test('routes agent stderr to the error stream as warnings', () => {
+      handler.handleEvent({
+        type: 'agent:output',
+        timestamp: new Date().toISOString(),
+        stream: 'stderr',
+        data: 'rate limit reached\n',
+      } as EngineEvent);
+
+      expect(err.lines()).toEqual(['[WARN] [agent] rate limit reached']);
+      expect(out.lines()).toEqual([]);
+    });
+
+    test('skips blank lines to reduce noise', () => {
+      handler.handleEvent({
+        type: 'agent:output',
+        timestamp: new Date().toISOString(),
+        stream: 'stdout',
+        data: 'first\n\n   \nsecond\n',
+      } as EngineEvent);
+
+      expect(out.lines()).toEqual(['[INFO] [agent] first', '[INFO] [agent] second']);
+    });
+  });
+
+  describe('progress logging', () => {
+    test('logs iteration start with the configured iteration cap', () => {
+      handler.handleEvent({
+        type: 'iteration:started',
+        timestamp: new Date().toISOString(),
+        iteration: 3,
+        task: createTrackerTask({ id: 'task-042', title: 'Fix the poll loop' }),
+      } as EngineEvent);
+
+      expect(out.lines()).toEqual([
+        '[INFO] [progress] Iteration 3/20: Working on task-042 - Fix the poll loop',
+      ]);
+    });
+
+    test('logs iteration completion with duration', () => {
+      handler.handleEvent({
+        type: 'iteration:completed',
+        timestamp: new Date().toISOString(),
+        result: createIterationResult({ task: createTrackerTask({ id: 'task-042' }) }),
+      } as EngineEvent);
+
+      expect(out.lines()[0]).toBe(
+        '[INFO] [progress] Iteration 1 finished. Task task-042: in progress. Duration: 624s'
+      );
+    });
+
+    test('logs retries, skips, and failures', () => {
+      const task = createTrackerTask({ id: 'task-042' });
+
+      handler.handleEvent({
+        type: 'iteration:retrying',
+        timestamp: new Date().toISOString(),
+        iteration: 2,
+        retryAttempt: 1,
+        maxRetries: 3,
+        task,
+        previousError: 'boom',
+        delayMs: 5_000,
+      } as EngineEvent);
+
+      handler.handleEvent({
+        type: 'iteration:skipped',
+        timestamp: new Date().toISOString(),
+        iteration: 2,
+        task,
+        reason: 'too many failures',
+      } as EngineEvent);
+
+      handler.handleEvent({
+        type: 'iteration:failed',
+        timestamp: new Date().toISOString(),
+        iteration: 2,
+        error: 'agent exited non-zero',
+        task,
+        action: 'abort',
+      } as EngineEvent);
+
+      expect(err.lines()).toEqual([
+        '[WARN] [progress] Retrying iteration 2 on task-042: attempt 1/3, waiting 5s',
+        '[WARN] [progress] Skipping task-042 in iteration 2: too many failures',
+        '[ERROR] [progress] Iteration 2 FAILED on task-042: agent exited non-zero (action: abort)',
+      ]);
+    });
+
+    test('logs engine warnings', () => {
+      handler.handleEvent({
+        type: 'engine:warning',
+        timestamp: new Date().toISOString(),
+        message: 'tracker returned no tasks',
+      } as EngineEvent);
+
+      expect(err.lines()).toEqual(['[WARN] [engine] tracker returned no tasks']);
+    });
+  });
+
+  describe('session state tracking', () => {
+    test('records activated tasks and clears them on completion', () => {
+      const task = createTrackerTask({ id: 'task-042' });
+
+      handler.handleEvent({
+        type: 'task:activated',
+        timestamp: new Date().toISOString(),
+        task,
+        iteration: 1,
+      } as EngineEvent);
+
+      expect(handler.getState().activeTaskIds).toEqual(['task-042']);
+
+      handler.handleEvent({
+        type: 'iteration:completed',
+        timestamp: new Date().toISOString(),
+        result: createIterationResult({ task, taskCompleted: true }),
+      } as EngineEvent);
+
+      expect(handler.getState().activeTaskIds).toEqual([]);
+    });
+
+    test('applies iteration results to the tracked state', () => {
+      handler.handleEvent({
+        type: 'iteration:completed',
+        timestamp: new Date().toISOString(),
+        result: createIterationResult({ iteration: 7, taskCompleted: true }),
+      } as EngineEvent);
+
+      const state = handler.getState();
+      expect(state.iterations).toHaveLength(1);
+      expect(state.tasksCompleted).toBe(1);
+    });
+
+    test('marks the state paused on engine:paused', () => {
+      handler.handleEvent({
+        type: 'engine:paused',
+        timestamp: new Date().toISOString(),
+        currentIteration: 7,
+      } as EngineEvent);
+
+      expect(handler.getState().isPaused).toBe(true);
+      expect(out.lines()).toEqual([
+        '[INFO] [engine] Paused at iteration 7. Use "ralph-tui resume" to continue.',
+      ]);
+    });
+
+    test('clears the paused flag on engine:resumed', () => {
+      handler.handleEvent({
+        type: 'engine:paused',
+        timestamp: new Date().toISOString(),
+        currentIteration: 7,
+      } as EngineEvent);
+      handler.handleEvent({
+        type: 'engine:resumed',
+        timestamp: new Date().toISOString(),
+        fromIteration: 7,
+      } as EngineEvent);
+
+      const state = handler.getState();
+      expect(state.isPaused).toBe(false);
+      expect(state.status).toBe('running');
+      expect(state.pausedAt).toBeUndefined();
+    });
+
+    test('setState replaces the tracked state for shutdown paths', () => {
+      handler.setState({ ...handler.getState(), status: 'interrupted' });
+
+      expect(handler.getState().status).toBe('interrupted');
+    });
+  });
+
+  describe('lifecycle logging', () => {
+    test('logs engine start, stop, and completion', () => {
+      handler.handleEvent({
+        type: 'engine:started',
+        timestamp: new Date().toISOString(),
+        sessionId: 'test-session-001',
+        totalTasks: 17,
+        tasks: [],
+      } as EngineEvent);
+
+      handler.handleEvent({
+        type: 'all:complete',
+        timestamp: new Date().toISOString(),
+        totalCompleted: 17,
+        totalIterations: 21,
+      } as EngineEvent);
+
+      handler.handleEvent({
+        type: 'engine:stopped',
+        timestamp: new Date().toISOString(),
+        reason: 'all_complete',
+        totalIterations: 21,
+        tasksCompleted: 17,
+      } as EngineEvent);
+
+      expect(out.lines()).toEqual([
+        '[INFO] [engine] Ralph started. Total tasks: 17',
+        '[INFO] [engine] All tasks complete! Total: 17 tasks in 21 iterations.',
+        '[INFO] [engine] Ralph stopped. Reason: all_complete. Iterations: 21, Tasks completed: 17',
+      ]);
+    });
+
+    test('ignores events it does not handle', () => {
+      handler.handleEvent({
+        type: 'agent:usage',
+        timestamp: new Date().toISOString(),
+      } as unknown as EngineEvent);
+
+      expect(out.lines()).toEqual([]);
+      expect(err.lines()).toEqual([]);
+    });
+  });
+});

--- a/website/content/docs/cli/resume.mdx
+++ b/website/content/docs/cli/resume.mdx
@@ -113,6 +113,21 @@ ralph-tui resume --force
 Only use `--force` when you're certain no other Ralph instance is running. Using it while another instance is active can cause conflicts.
 </Callout>
 
+## Headless Output
+
+With `--headless`, `resume` emits the same structured log stream as [`run --headless`](/docs/cli/run):
+
+```
+[10:32:18] [INFO] [session] Session a3c96cf6 resumed
+[10:32:18] [INFO] [engine] Ralph started. Total tasks: 17
+[10:32:19] [INFO] [progress] Iteration 1/∞: Working on hre-42 - Isolate fixture cases
+[10:32:24] [INFO] [agent] Reading src/fixture.ts
+[10:32:31] [INFO] [agent] Editing src/fixture.ts
+[10:42:42] [INFO] [progress] Iteration 1 finished. Task hre-42: in progress. Duration: 64s
+```
+
+Every line follows the `[timestamp] [level] [component] message` format, so the output is machine-parseable for CI. Agent stdout is streamed under the `agent` component as the iteration runs, which means a long-running iteration keeps reporting progress instead of going silent between iteration boundaries.
+
 ## What Gets Restored
 
 When you resume a session, Ralph restores:


### PR DESCRIPTION
Fixed #399. Wide open to feedback if this approach is incorrect, and I'm happy to keep iterating on a solution!

`resume --headless` produced two plain `console.log` lines per iteration and
nothing in between. Iterations that take many minutes therefore emitted zero
output for the whole iteration, which is indistinguishable from a hang.

The cause is duplication, not configuration. `run --headless` and
`resume --headless` each had their own engine event subscription, and resume's was
a subset:

| Event | `run --headless` | `resume --headless` (before) |
|---|---|---|
| `agent:output` | streamed | **not handled** |
| `engine:warning` | logged | not handled |
| `iteration:retrying` | logged | not handled |
| `iteration:skipped` | logged | not handled |
| `task:selected` | logged | not handled |
| `task:activated` / `task:completed` | tracked in session state | not handled |
| output format | `[timestamp] [level] [component] message` | ad-hoc `console.log` |

The engine emits `agent:output` (`src/engine/index.ts:1182`) regardless; resume
just never subscribed to it.

## Change

Extract run's headless event handler into `src/commands/headless-events.ts`
(`createHeadlessEventHandler`) and use it from both commands. Resume now gets the
full structured log stream, including agent output streamed as the iteration runs.

The handler owns the session state it maintains and exposes `getState()` /
`setState()` so shutdown paths can still mark a session interrupted.
Command-specific concerns stay in their commands: notifications, remote server,
and `engineStartTime`/`lastError` tracking remain in `run` as a second listener;
lock release remains in `resume`.

- `run --headless` output is unchanged — the switch moved verbatim, and the shared
  listener registers first, so log-then-notify ordering is preserved.
- `resume --headless` now also maintains `activeTaskIds` in `session.json` the way
  `run` does, which makes stale-task recovery consistent between the two.
- Resume's iteration lines change format (`--- Iteration 1: title ---` →
  `[INFO] [progress] Iteration 1/20: Working on <id> - <title>`). That's the point
  of the change, but it is a user-visible output change for anyone grepping resume
  stdout.

## Notes

Resume inherits run's verbosity: for agents that emit structured JSONL, every
non-empty line is logged under the `agent` component. That is existing `run`
behavior, now consistent across both commands, but it is more output than resume
used to produce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured logging for headless run and resume sessions, including progress, task activity, agent output, warnings, and lifecycle events.
  * Improved session-state tracking and persistence during interruptions, pauses, resumes, retries, and completions.
  * Headless resume now provides output consistent with headless run.

* **Documentation**
  * Documented the structured output format for `resume --headless`, including streamed agent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->