### PR TITLE
fix: doctor command never discovers user agent plugins

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -66,6 +66,7 @@ mock.module('../plugins/agents/registry.js', () => ({
     },
     hasPlugin: (name: string) => name === 'claude' || name === 'opencode',
     registerBuiltin: () => {},
+    initialize: () => Promise.resolve([]),
     getRegisteredPlugins: () => [
       { id: 'claude', name: 'Claude Code', description: 'Claude AI', version: '1.0.0' },
       { id: 'opencode', name: 'OpenCode', description: 'OpenCode AI', version: '1.0.0' },

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -54,6 +54,19 @@ async function runDiagnostics(
   // Get agent registry
   const registry = getAgentRegistry();
 
+  // Discover user plugins (~/.config/ralph-tui/plugins/agents/) — run.tsx's
+  // initializePlugins() already does this before actually running an agent;
+  // doctor was missing it, so `doctor --agent <custom-plugin>` always
+  // reported "Unknown agent plugin" even for a plugin that `run` could
+  // load fine.
+  const userPluginResults = await registry.initialize();
+  if (process.env.RALPH_TUI_DEBUG_PLUGINS) {
+    // User plugin load failures are otherwise silent — registry.initialize()
+    // swallows the real error into a PluginLoadResult array that nothing
+    // prints. Opt-in dump for diagnosing why a custom plugin didn't register.
+    console.error('DEBUG user plugin load results:', JSON.stringify(userPluginResults, null, 2));
+  }
+
   // Determine which agent to check using centralized logic
   const agentConfig = getDefaultAgentConfig(storedConfig, { agent: agentOverride });
 


### PR DESCRIPTION
## Summary
- \`ralph-tui doctor --agent <custom-plugin>\` always reports "Unknown agent plugin", even for a custom plugin under \`~/.config/ralph-tui/plugins/agents/\` that \`ralph-tui run\` loads and executes fine.
- Root cause: \`run.tsx\`'s \`initializePlugins()\` correctly calls \`registry.initialize()\` (which internally calls \`discoverUserPlugins()\`) before running, but \`doctor.ts\`'s \`runDiagnostics()\` only ever called \`registerBuiltinAgents()\` — so `doctor`'s view of the world never includes user plugins.
- Also adds an opt-in \`RALPH_TUI_DEBUG_PLUGINS=1\` env var to doctor's output. Right now a user plugin load failure (bad import, thrown error in the factory, etc.) is silently swallowed into a \`PluginLoadResult[]\` that nothing in the CLI ever surfaces — this makes debugging a broken custom plugin very hard. Confirmed by direct testing while building a custom plugin locally.

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run build\`
- [x] Manually verified against a local custom user plugin: before the fix, \`doctor --agent <name>\` reported "Unknown agent plugin"; after, it correctly loads and runs detection/preflight against it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The `doctor` command now recognizes user-installed agent plugins.
  * Added optional diagnostic output for plugin loading when debug mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->