### PR TITLE
feat: add built-in Grok CLI (xAI) agent plugin

### DIFF
--- a/src/plugins/agents/builtin/grok.test.ts
+++ b/src/plugins/agents/builtin/grok.test.ts
@@ -1,0 +1,404 @@
+/**
+ * ABOUTME: Tests for the xAI Grok CLI agent plugin.
+ * Tests configuration, argument building, and streaming-json parsing for Grok Build TUI.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import {
+  GrokAgentPlugin,
+  parseGrokJsonLine,
+  parseGrokOutputToEvents,
+} from './grok.js';
+
+describe('GrokAgentPlugin', () => {
+  let plugin: GrokAgentPlugin;
+
+  beforeEach(() => {
+    plugin = new GrokAgentPlugin();
+  });
+
+  afterEach(async () => {
+    await plugin.dispose();
+  });
+
+  describe('meta', () => {
+    test('has correct plugin ID', () => {
+      expect(plugin.meta.id).toBe('grok');
+    });
+
+    test('has correct name', () => {
+      expect(plugin.meta.name).toBe('Grok CLI');
+    });
+
+    test('has correct default command', () => {
+      expect(plugin.meta.defaultCommand).toBe('grok');
+    });
+
+    test('supports streaming', () => {
+      expect(plugin.meta.supportsStreaming).toBe(true);
+    });
+
+    test('supports interrupt', () => {
+      expect(plugin.meta.supportsInterrupt).toBe(true);
+    });
+
+    test('does not support file context', () => {
+      expect(plugin.meta.supportsFileContext).toBe(false);
+    });
+
+    test('supports subagent tracing', () => {
+      expect(plugin.meta.supportsSubagentTracing).toBe(true);
+    });
+
+    test('has JSONL structured output format', () => {
+      expect(plugin.meta.structuredOutputFormat).toBe('jsonl');
+    });
+
+    test('has skills paths configured', () => {
+      expect(plugin.meta.skillsPaths?.personal).toBe('~/.grok/skills');
+      expect(plugin.meta.skillsPaths?.repo).toBe('.grok/skills');
+    });
+  });
+
+  describe('initialize', () => {
+    test('initializes with default config', async () => {
+      await plugin.initialize({});
+      expect(await plugin.isReady()).toBe(true);
+    });
+
+    test('accepts model configuration', async () => {
+      await plugin.initialize({ model: 'grok-4.5' });
+      expect(await plugin.isReady()).toBe(true);
+    });
+
+    test('accepts timeout configuration', async () => {
+      await plugin.initialize({ timeout: 300000 });
+      expect(await plugin.isReady()).toBe(true);
+    });
+  });
+
+  describe('getSetupQuestions', () => {
+    test('includes model question', () => {
+      const questions = plugin.getSetupQuestions();
+      const modelQuestion = questions.find((q) => q.id === 'model');
+      expect(modelQuestion).toBeDefined();
+      expect(modelQuestion?.type).toBe('text');
+      expect(modelQuestion?.required).toBe(false);
+    });
+
+    test('includes base questions (command, timeout)', () => {
+      const questions = plugin.getSetupQuestions();
+      expect(questions.find((q) => q.id === 'command')).toBeDefined();
+      expect(questions.find((q) => q.id === 'timeout')).toBeDefined();
+    });
+  });
+
+  describe('validateSetup', () => {
+    test('accepts valid grok model', async () => {
+      const result = await plugin.validateSetup({ model: 'grok-4.5' });
+      expect(result).toBeNull();
+    });
+
+    test('accepts empty model', async () => {
+      const result = await plugin.validateSetup({ model: '' });
+      expect(result).toBeNull();
+    });
+
+    test('accepts any model name (no strict validation)', async () => {
+      const result = await plugin.validateSetup({ model: 'any-model-name' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getSandboxRequirements', () => {
+    test('includes ~/.grok auth path', () => {
+      const reqs = plugin.getSandboxRequirements();
+      expect(reqs.authPaths).toContain('~/.grok');
+    });
+
+    test('includes grok binary paths', () => {
+      const reqs = plugin.getSandboxRequirements();
+      expect(reqs.binaryPaths).toContain('~/.grok/bin');
+    });
+
+    test('requires network', () => {
+      const reqs = plugin.getSandboxRequirements();
+      expect(reqs.requiresNetwork).toBe(true);
+    });
+  });
+});
+
+describe('GrokAgentPlugin buildArgs', () => {
+  let plugin: GrokAgentPlugin;
+
+  class TestableGrokPlugin extends GrokAgentPlugin {
+    testBuildArgs(prompt: string): string[] {
+      return (this as unknown as { buildArgs: (p: string) => string[] }).buildArgs(prompt);
+    }
+
+    testGetStdinInput(prompt: string): string | undefined {
+      return (this as unknown as { getStdinInput: (p: string) => string | undefined }).getStdinInput(
+        prompt
+      );
+    }
+  }
+
+  beforeEach(() => {
+    plugin = new TestableGrokPlugin();
+  });
+
+  afterEach(async () => {
+    await plugin.dispose();
+  });
+
+  test('includes --always-approve', async () => {
+    await plugin.initialize({});
+    const args = (plugin as TestableGrokPlugin).testBuildArgs('test prompt');
+    expect(args).toContain('--always-approve');
+  });
+
+  test('includes --output-format streaming-json', async () => {
+    await plugin.initialize({});
+    const args = (plugin as TestableGrokPlugin).testBuildArgs('test prompt');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('streaming-json');
+  });
+
+  test('does not use stream-json or dangerously-skip-permissions', async () => {
+    await plugin.initialize({});
+    const args = (plugin as TestableGrokPlugin).testBuildArgs('test prompt');
+    expect(args).not.toContain('stream-json');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  test('includes model flag when specified', async () => {
+    await plugin.initialize({ model: 'grok-4.5' });
+    const args = (plugin as TestableGrokPlugin).testBuildArgs('test prompt');
+    expect(args).toContain('--model');
+    expect(args).toContain('grok-4.5');
+  });
+
+  test('omits model flag when not specified', async () => {
+    await plugin.initialize({});
+    const args = (plugin as TestableGrokPlugin).testBuildArgs('test prompt');
+    expect(args).not.toContain('--model');
+  });
+
+  test('uses stdin prompt delivery on non-Windows', async () => {
+    await plugin.initialize({});
+    const args = (plugin as TestableGrokPlugin).testBuildArgs('my test prompt');
+    const stdinInput = (plugin as TestableGrokPlugin).testGetStdinInput('my test prompt');
+
+    if (process.platform === 'win32') {
+      expect(args).toContain('-p');
+      expect(args).toContain('my test prompt');
+      expect(stdinInput).toBeUndefined();
+    } else {
+      expect(args).toContain('--prompt-file');
+      expect(args).toContain('/dev/stdin');
+      expect(stdinInput).toBe('my test prompt');
+    }
+  });
+});
+
+describe('parseGrokJsonLine', () => {
+  test('returns empty array for empty input', () => {
+    expect(parseGrokJsonLine('')).toEqual([]);
+    expect(parseGrokJsonLine('   ')).toEqual([]);
+  });
+
+  test('returns empty array for invalid JSON', () => {
+    expect(parseGrokJsonLine('not json')).toEqual([]);
+    expect(parseGrokJsonLine('{ invalid')).toEqual([]);
+  });
+
+  test('parses text delta events', () => {
+    const input = JSON.stringify({ type: 'text', data: 'Hello from Grok' });
+    const events = parseGrokJsonLine(input);
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('text');
+    expect((events[0] as { content: string }).content).toBe('Hello from Grok');
+  });
+
+  test('skips empty text data', () => {
+    const input = JSON.stringify({ type: 'text', data: '' });
+    expect(parseGrokJsonLine(input)).toEqual([]);
+  });
+
+  test('skips thought events', () => {
+    const input = JSON.stringify({ type: 'thought', data: 'internal reasoning...' });
+    expect(parseGrokJsonLine(input)).toEqual([]);
+  });
+
+  test('skips available_commands events', () => {
+    const input = JSON.stringify({ type: 'available_commands', tools: ['read_file'] });
+    expect(parseGrokJsonLine(input)).toEqual([]);
+  });
+
+  test('skips usage events', () => {
+    const input = JSON.stringify({
+      type: 'usage',
+      usage: { input_tokens: 100, output_tokens: 10 },
+    });
+    expect(parseGrokJsonLine(input)).toEqual([]);
+  });
+
+  test('skips end events', () => {
+    const input = JSON.stringify({
+      type: 'end',
+      stopReason: 'end_turn',
+      sessionId: 'abc',
+    });
+    expect(parseGrokJsonLine(input)).toEqual([]);
+  });
+
+  test('parses tool_call event', () => {
+    const input = JSON.stringify({
+      type: 'tool_call',
+      toolCallId: 'call-1',
+      title: 'list_dir',
+      kind: 'list',
+      status: 'pending',
+      toolName: 'list_dir',
+      rawInput: { target_directory: '.' },
+      content: [],
+      locations: [],
+    });
+    const events = parseGrokJsonLine(input);
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('tool_use');
+    expect((events[0] as { name: string }).name).toBe('list_dir');
+    expect((events[0] as { input: Record<string, unknown> }).input).toEqual({
+      target_directory: '.',
+    });
+  });
+
+  test('uses title as tool name fallback', () => {
+    const input = JSON.stringify({
+      type: 'tool_call',
+      title: 'read_file',
+      status: 'pending',
+    });
+    const events = parseGrokJsonLine(input);
+    expect(events.length).toBe(1);
+    expect((events[0] as { name: string }).name).toBe('read_file');
+  });
+
+  test('parses tool_call_update completed as tool_result', () => {
+    const input = JSON.stringify({
+      type: 'tool_call_update',
+      toolCallId: 'call-1',
+      status: 'completed',
+      content: [],
+      rawOutput: { type: 'ListDir', Content: { content: 'files...' } },
+    });
+    const events = parseGrokJsonLine(input);
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('tool_result');
+  });
+
+  test('skips tool_call_update with null status', () => {
+    const input = JSON.stringify({
+      type: 'tool_call_update',
+      toolCallId: 'call-1',
+      status: null,
+      content: [],
+      rawOutput: null,
+    });
+    expect(parseGrokJsonLine(input)).toEqual([]);
+  });
+
+  test('parses failed tool_call_update as error + tool_result', () => {
+    const input = JSON.stringify({
+      type: 'tool_call_update',
+      status: 'failed',
+      error: { message: 'Permission denied' },
+    });
+    const events = parseGrokJsonLine(input);
+    expect(events.length).toBe(2);
+    expect(events[0]?.type).toBe('error');
+    expect((events[0] as { message: string }).message).toBe('Permission denied');
+    expect(events[1]?.type).toBe('tool_result');
+  });
+
+  test('parses top-level error event', () => {
+    const input = JSON.stringify({
+      type: 'error',
+      error: { message: 'API rate limit' },
+    });
+    const events = parseGrokJsonLine(input);
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('error');
+    expect((events[0] as { message: string }).message).toBe('API rate limit');
+  });
+
+  test('parses error with string error field', () => {
+    const input = JSON.stringify({
+      type: 'error',
+      error: 'Something went wrong',
+    });
+    const events = parseGrokJsonLine(input);
+    expect(events.length).toBe(1);
+    expect((events[0] as { message: string }).message).toBe('Something went wrong');
+  });
+});
+
+describe('parseGrokOutputToEvents', () => {
+  test('parses multiple JSONL lines', () => {
+    const lines = [
+      JSON.stringify({ type: 'text', data: 'Hi' }),
+      JSON.stringify({ type: 'text', data: ' there' }),
+    ].join('\n');
+    const events = parseGrokOutputToEvents(lines);
+    expect(events.length).toBe(2);
+    expect((events[0] as { content: string }).content).toBe('Hi');
+    expect((events[1] as { content: string }).content).toBe(' there');
+  });
+
+  test('handles empty lines', () => {
+    const lines =
+      '\n\n' + JSON.stringify({ type: 'text', data: 'Hello' }) + '\n\n';
+    const events = parseGrokOutputToEvents(lines);
+    expect(events.length).toBe(1);
+  });
+
+  test('handles mixed valid and invalid lines', () => {
+    const lines = [
+      'some status text',
+      JSON.stringify({ type: 'text', data: 'Valid' }),
+      'another status line',
+      JSON.stringify({ type: 'thought', data: 'skip me' }),
+    ].join('\n');
+    const events = parseGrokOutputToEvents(lines);
+    expect(events.length).toBe(1);
+    expect((events[0] as { content: string }).content).toBe('Valid');
+  });
+
+  test('returns empty array for empty input', () => {
+    expect(parseGrokOutputToEvents('')).toEqual([]);
+  });
+
+  test('parses realistic tool flow', () => {
+    const lines = [
+      JSON.stringify({ type: 'available_commands', tools: ['list_dir'] }),
+      JSON.stringify({ type: 'thought', data: 'I should list' }),
+      JSON.stringify({
+        type: 'tool_call',
+        toolName: 'list_dir',
+        rawInput: { target_directory: '.' },
+        status: 'pending',
+      }),
+      JSON.stringify({
+        type: 'tool_call_update',
+        status: 'completed',
+        rawOutput: { type: 'ListDir' },
+      }),
+      JSON.stringify({ type: 'text', data: 'DONE' }),
+      JSON.stringify({ type: 'end', stopReason: 'end_turn' }),
+    ].join('\n');
+    const events = parseGrokOutputToEvents(lines);
+    expect(events.map((e) => e.type)).toEqual(['tool_use', 'tool_result', 'text']);
+    expect((events[0] as { name: string }).name).toBe('list_dir');
+    expect((events[2] as { content: string }).content).toBe('DONE');
+  });
+});

--- a/src/plugins/agents/builtin/grok.ts
+++ b/src/plugins/agents/builtin/grok.ts
@@ -1,0 +1,435 @@
+/**
+ * ABOUTME: xAI Grok CLI agent plugin for the official grok command.
+ * Integrates with Grok Build TUI (xAI) for AI-assisted coding.
+ * Supports: single-turn (-p) mode, streaming-json output, stdin prompt via --prompt-file, model selection.
+ */
+
+import { spawn } from 'node:child_process';
+import { platform } from 'node:os';
+import { BaseAgentPlugin, findCommandPath, quoteForWindowsShell } from '../base.js';
+import { processAgentEvents, processAgentEventsToSegments, type AgentDisplayEvent } from '../output-formatting.js';
+import { extractErrorMessage } from '../utils.js';
+import type {
+  AgentPluginMeta,
+  AgentPluginFactory,
+  AgentFileContext,
+  AgentExecuteOptions,
+  AgentSetupQuestion,
+  AgentDetectResult,
+  AgentExecutionHandle,
+} from '../types.js';
+
+/**
+ * Parse a Grok streaming-json line into standardized display events.
+ *
+ * Grok CLI `--output-format streaming-json` emits NDJSON events:
+ * - {"type":"text","data":"..."} — response text deltas
+ * - {"type":"thought","data":"..."} — internal reasoning (skip)
+ * - {"type":"tool_call","toolName":"...","rawInput":{...},...} — tool invocation
+ * - {"type":"tool_call_update","status":"completed","rawOutput":...} — tool result
+ * - {"type":"available_commands",...} / {"type":"usage",...} / {"type":"end",...} — skip
+ * - {"type":"error",...} — error events
+ *
+ * @internal Exported for testing only.
+ */
+export function parseGrokJsonLine(jsonLine: string): AgentDisplayEvent[] {
+  if (!jsonLine) return [];
+
+  try {
+    const event = JSON.parse(jsonLine) as Record<string, unknown>;
+    const events: AgentDisplayEvent[] = [];
+    const type = event.type;
+
+    if (type === 'text' && typeof event.data === 'string' && event.data.length > 0) {
+      events.push({ type: 'text', content: event.data });
+    } else if (type === 'tool_call') {
+      const toolName =
+        (typeof event.toolName === 'string' && event.toolName) ||
+        (typeof event.title === 'string' && event.title) ||
+        'unknown';
+      const toolInput =
+        event.rawInput != null && typeof event.rawInput === 'object' && !Array.isArray(event.rawInput)
+          ? (event.rawInput as Record<string, unknown>)
+          : undefined;
+      events.push({ type: 'tool_use', name: toolName, input: toolInput });
+    } else if (type === 'tool_call_update') {
+      const status = event.status;
+      if (status === 'completed' || status === 'failed' || status === 'error') {
+        if (status === 'failed' || status === 'error') {
+          const errMsg =
+            extractErrorMessage(event.rawOutput) ||
+            extractErrorMessage(event.error) ||
+            extractErrorMessage(event.message) ||
+            'Tool call failed';
+          events.push({ type: 'error', message: errMsg.slice(0, 200) });
+        }
+        events.push({ type: 'tool_result' });
+      }
+    } else if (type === 'error') {
+      const msg =
+        extractErrorMessage(event.error) ||
+        extractErrorMessage(event.message) ||
+        extractErrorMessage(event.data) ||
+        'Unknown error';
+      events.push({ type: 'error', message: msg });
+    }
+    // Skip: thought, available_commands, usage, end, and other non-content events
+
+    return events;
+  } catch {
+    // Not valid JSON - skip
+    return [];
+  }
+}
+
+/**
+ * Parse Grok streaming-json output into display events.
+ * @internal Exported for testing only.
+ */
+export function parseGrokOutputToEvents(data: string): AgentDisplayEvent[] {
+  const allEvents: AgentDisplayEvent[] = [];
+  for (const line of data.split('\n')) {
+    const events = parseGrokJsonLine(line.trim());
+    allEvents.push(...events);
+  }
+  return allEvents;
+}
+
+/**
+ * xAI Grok CLI agent plugin implementation.
+ * Uses `grok -p` (single-turn) with `--output-format streaming-json` and `--always-approve`.
+ * Prompt is delivered via stdin using `--prompt-file /dev/stdin` on Unix-like systems
+ * (Grok does not read bare stdin; Windows falls back to `-p` with the prompt arg).
+ */
+export class GrokAgentPlugin extends BaseAgentPlugin {
+  readonly meta: AgentPluginMeta = {
+    id: 'grok',
+    name: 'Grok CLI',
+    description: 'xAI Grok Build TUI for AI-assisted coding',
+    version: '1.0.0',
+    author: 'xAI',
+    defaultCommand: 'grok',
+    supportsStreaming: true,
+    supportsInterrupt: true,
+    supportsFileContext: false,
+    supportsSubagentTracing: true,
+    structuredOutputFormat: 'jsonl',
+    skillsPaths: {
+      personal: '~/.grok/skills',
+      repo: '.grok/skills',
+    },
+  };
+
+  private model?: string;
+  protected override defaultTimeout = 0;
+
+  override async initialize(config: Record<string, unknown>): Promise<void> {
+    await super.initialize(config);
+
+    if (typeof config.model === 'string' && config.model.length > 0) {
+      this.model = config.model;
+    }
+
+    if (typeof config.timeout === 'number' && config.timeout > 0) {
+      this.defaultTimeout = config.timeout;
+    }
+  }
+
+  override async detect(): Promise<AgentDetectResult> {
+    const command = this.commandPath ?? this.meta.defaultCommand;
+    const findResult = await findCommandPath(command);
+
+    if (!findResult.found) {
+      return {
+        available: false,
+        error:
+          'Grok CLI not found in PATH. Install from: https://docs.x.ai/docs/cli (or run the official installer to place grok on PATH)',
+      };
+    }
+
+    const versionResult = await this.runVersion(findResult.path);
+
+    if (!versionResult.success) {
+      return {
+        available: false,
+        executablePath: findResult.path,
+        error: versionResult.error,
+      };
+    }
+
+    // Store the detected path for use in execute()
+    this.commandPath = findResult.path;
+
+    return {
+      available: true,
+      version: versionResult.version,
+      executablePath: findResult.path,
+    };
+  }
+
+  private runVersion(
+    command: string
+  ): Promise<{ success: boolean; version?: string; error?: string }> {
+    return new Promise((resolve) => {
+      const useShell = process.platform === 'win32';
+      const proc = spawn(useShell ? quoteForWindowsShell(command) : command, ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: useShell,
+      });
+
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+
+      const safeResolve = (result: { success: boolean; version?: string; error?: string }) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      };
+
+      proc.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      proc.on('error', (error) => {
+        safeResolve({ success: false, error: `Failed to execute: ${error.message}` });
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          // e.g. "grok 0.2.118 (1e1687c1cf6a) [stable]"
+          const versionMatch = stdout.match(/(\d+\.\d+\.\d+)/);
+          if (!versionMatch?.[1]) {
+            safeResolve({
+              success: false,
+              error: `Unable to parse grok version output: ${stdout}`,
+            });
+            return;
+          }
+          safeResolve({ success: true, version: versionMatch[1] });
+        } else {
+          safeResolve({ success: false, error: stderr || `Exited with code ${code}` });
+        }
+      });
+
+      const timer = setTimeout(() => {
+        proc.kill();
+        safeResolve({ success: false, error: 'Timeout waiting for --version' });
+      }, 15000);
+    });
+  }
+
+  override getSandboxRequirements() {
+    return {
+      authPaths: ['~/.grok'],
+      binaryPaths: ['~/.grok/bin', '~/.local/bin', '/usr/local/bin'],
+      runtimePaths: [],
+      requiresNetwork: true,
+    };
+  }
+
+  override getSetupQuestions(): AgentSetupQuestion[] {
+    return [
+      ...super.getSetupQuestions(),
+      {
+        id: 'model',
+        prompt: 'Model to use:',
+        type: 'text',
+        default: '',
+        required: false,
+        help: 'Grok model ID (e.g., grok-4.5). Leave empty for default. List with: grok models',
+      },
+    ];
+  }
+
+  protected buildArgs(
+    prompt: string,
+    _files?: AgentFileContext[],
+    _options?: AgentExecuteOptions
+  ): string[] {
+    const args: string[] = [];
+
+    // Auto-approve tool executions (required for unattended ralph-tui loops)
+    args.push('--always-approve');
+
+    // Structured NDJSON stream for subagent tracing and display parsing
+    args.push('--output-format', 'streaming-json');
+
+    // Prompt delivery:
+    // Grok does not read bare stdin. On Unix we use --prompt-file /dev/stdin so the
+    // prompt is still provided via the process stdin pipe (avoids arg length / shell issues).
+    // On Windows /dev/stdin is unavailable, so fall back to -p with the prompt argument.
+    if (platform() === 'win32') {
+      args.push('-p', prompt);
+    } else {
+      args.push('--prompt-file', '/dev/stdin');
+    }
+
+    // Model selection
+    if (this.model) {
+      args.push('--model', this.model);
+    }
+
+    return args;
+  }
+
+  /**
+   * Provide the prompt via stdin when using --prompt-file /dev/stdin.
+   * On Windows, prompt is already in -p args so no stdin content is needed.
+   */
+  protected override getStdinInput(
+    prompt: string,
+    _files?: AgentFileContext[],
+    _options?: AgentExecuteOptions
+  ): string | undefined {
+    if (platform() === 'win32') {
+      return undefined;
+    }
+    return prompt;
+  }
+
+  /**
+   * Override execute to parse Grok streaming-json output into structured display events.
+   * Wraps onStdout/onStdoutSegments callbacks to parse JSON lines and extract
+   * displayable content (text, tool calls, errors).
+   */
+  override execute(
+    prompt: string,
+    files?: AgentFileContext[],
+    options?: AgentExecuteOptions
+  ): AgentExecutionHandle {
+    // Buffer for incomplete JSON lines split across chunks
+    let jsonlBuffer = '';
+
+    const flushBuffer = () => {
+      if (!jsonlBuffer) return;
+      const trimmed = jsonlBuffer.trim();
+      if (!trimmed) return;
+
+      if (options?.onJsonlMessage && trimmed.startsWith('{')) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          options.onJsonlMessage(parsed);
+        } catch {
+          // Not valid JSON, skip
+        }
+      }
+
+      const events = parseGrokOutputToEvents(trimmed);
+      if (events.length > 0) {
+        if (options?.onStdoutSegments) {
+          const segments = processAgentEventsToSegments(events);
+          if (segments.length > 0) {
+            options.onStdoutSegments(segments);
+          }
+        }
+        if (options?.onStdout) {
+          const formatted = processAgentEvents(events);
+          if (formatted.length > 0) {
+            options.onStdout(formatted);
+          }
+        }
+      }
+
+      jsonlBuffer = '';
+    };
+
+    const parsedOptions: AgentExecuteOptions = {
+      ...options,
+      onStdout:
+        options?.onStdout || options?.onStdoutSegments || options?.onJsonlMessage
+          ? (data: string) => {
+              const combined = jsonlBuffer + data;
+              const lines = combined.split('\n');
+
+              if (!data.endsWith('\n')) {
+                jsonlBuffer = lines.pop() || '';
+              } else {
+                jsonlBuffer = '';
+              }
+
+              const completeData = lines.join('\n');
+
+              if (options?.onJsonlMessage) {
+                for (const line of lines) {
+                  const trimmed = line.trim();
+                  if (trimmed && trimmed.startsWith('{')) {
+                    try {
+                      const parsed = JSON.parse(trimmed);
+                      options.onJsonlMessage(parsed);
+                    } catch {
+                      // Not valid JSON, skip
+                    }
+                  }
+                }
+              }
+
+              const events = parseGrokOutputToEvents(completeData);
+              if (events.length > 0) {
+                if (options?.onStdoutSegments) {
+                  const segments = processAgentEventsToSegments(events);
+                  if (segments.length > 0) {
+                    options.onStdoutSegments(segments);
+                  }
+                }
+                if (options?.onStdout) {
+                  const formatted = processAgentEvents(events);
+                  if (formatted.length > 0) {
+                    options.onStdout(formatted);
+                  }
+                }
+              }
+            }
+          : undefined,
+      onEnd: (result) => {
+        flushBuffer();
+        options?.onEnd?.(result);
+      },
+    };
+
+    return super.execute(prompt, files, parsedOptions);
+  }
+
+  override async validateSetup(answers: Record<string, unknown>): Promise<string | null> {
+    const model = answers.model;
+    if (model !== undefined && model !== '' && typeof model === 'string') {
+      const err = this.validateModel(model);
+      if (err) return err;
+    }
+    return null;
+  }
+
+  override validateModel(model: string): string | null {
+    if (model === '' || model.trim().length === 0) {
+      return null;
+    }
+    // Grok accepts model IDs flexibly; list with `grok models`
+    return null;
+  }
+
+  /**
+   * Get Grok-specific suggestions for preflight failures.
+   */
+  protected override getPreflightSuggestion(): string {
+    return (
+      'Common fixes for Grok CLI:\n' +
+      '  1. Test Grok directly: grok -p "hello" --always-approve\n' +
+      '  2. Check Grok is installed: grok --version\n' +
+      '  3. Ensure you are logged in: grok login (OAuth via SuperGrok / xAI)\n' +
+      '  4. Auth is stored at ~/.grok/auth.json\n' +
+      '  5. List available models: grok models'
+    );
+  }
+}
+
+/**
+ * Factory function for the Grok CLI agent plugin.
+ */
+const createGrokAgent: AgentPluginFactory = () => new GrokAgentPlugin();
+
+export default createGrokAgent;

--- a/src/plugins/agents/builtin/index.ts
+++ b/src/plugins/agents/builtin/index.ts
@@ -14,6 +14,7 @@ import createCursorAgent from './cursor.js';
 import createGithubCopilotAgent from './github-copilot.js';
 import createKimiAgent from './kimi.js';
 import createPiAgent from './pi.js';
+import createGrokAgent from './grok.js';
 
 /**
  * Register all built-in agent plugins with the registry.
@@ -33,6 +34,7 @@ export function registerBuiltinAgents(): void {
   registry.registerBuiltin(createGithubCopilotAgent);
   registry.registerBuiltin(createKimiAgent);
   registry.registerBuiltin(createPiAgent);
+  registry.registerBuiltin(createGrokAgent);
 }
 
 // Export the factory functions for direct use
@@ -47,6 +49,7 @@ export {
   createGithubCopilotAgent,
   createKimiAgent,
   createPiAgent,
+  createGrokAgent,
 };
 
 // Export Claude JSONL parsing types and utilities
@@ -61,3 +64,4 @@ export { CursorAgentPlugin } from './cursor.js';
 export { GithubCopilotAgentPlugin } from './github-copilot.js';
 export { KimiAgentPlugin } from './kimi.js';
 export { PiAgentPlugin, parsePiJsonLine } from './pi.js';
+export { GrokAgentPlugin, parseGrokJsonLine, parseGrokOutputToEvents } from './grok.js';

--- a/src/setup/skill-installer.ts
+++ b/src/setup/skill-installer.ts
@@ -23,6 +23,7 @@ export const AGENT_ID_MAP: Record<string, string> = {
   cursor: 'cursor',
   'github-copilot': 'github-copilot',
   pi: 'pi',
+  grok: 'grok',
 };
 
 /**

--- a/website/content/docs/plugins/agents/grok.mdx
+++ b/website/content/docs/plugins/agents/grok.mdx
@@ -1,0 +1,173 @@
+---
+title: Grok Agent
+description: Integrate xAI's Grok CLI with Ralph TUI for AI-assisted coding.
+---
+
+## Grok Agent
+
+The Grok agent plugin integrates with xAI's official `grok` CLI (Grok Build TUI) to execute AI coding tasks. It supports streaming JSONL output for subagent tracing and uses single-turn mode for non-interactive operation.
+
+<Callout type="tip">
+Grok supports **subagent tracing** via `streaming-json` output — Ralph TUI can show tool calls in real-time as Grok works.
+</Callout>
+
+## Prerequisites
+
+Install the official Grok CLI from xAI and ensure it is on your `PATH` (typically `~/.grok/bin` or `~/.local/bin`):
+
+```bash
+# Verify installation
+grok --version
+# e.g. grok 0.2.118 (...) [stable]
+```
+
+Authenticate via OAuth (SuperGrok / xAI account) — no API key is required:
+
+```bash
+grok login
+# Auth is stored at ~/.grok/auth.json
+```
+
+## Basic Usage
+
+<Steps>
+  <Step title="Run with Grok">
+    Use the `--agent grok` flag:
+
+    ```bash
+    ralph-tui run --prd ./prd.json --agent grok
+    ```
+  </Step>
+
+  <Step title="Select a Model">
+    Override the model with `--model` or agent options:
+
+    ```bash
+    ralph-tui run --prd ./prd.json --agent grok --model grok-4.5
+    ```
+
+    List available models:
+
+    ```bash
+    grok models
+    ```
+  </Step>
+
+  <Step title="Verify with Doctor">
+    ```bash
+    ralph-tui doctor --agent grok
+    # Should report HEALTHY
+    ```
+  </Step>
+</Steps>
+
+## Configuration
+
+### Shorthand Config
+
+The simplest configuration:
+
+```toml
+# .ralph-tui/config.toml
+agent = "grok"
+
+[agentOptions]
+model = "grok-4.5"
+```
+
+### Full Config
+
+For advanced control:
+
+```toml
+[[agents]]
+name = "my-grok"
+plugin = "grok"
+default = true
+command = "grok"
+timeout = 300000
+
+[agents.options]
+model = "grok-4.5"
+```
+
+### Options Reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `model` | string | - | Grok model ID (e.g., `grok-4.5`). Leave empty for default. |
+| `timeout` | number | `0` | Execution timeout in ms (0 = no timeout) |
+| `command` | string | `"grok"` | Path to Grok CLI executable |
+
+## Subagent Tracing
+
+Grok emits structured NDJSON via `--output-format streaming-json` (always enabled). Ralph TUI parses this to display:
+
+- Text response deltas from the model
+- Tool invocations (`tool_call` with name and input)
+- Tool completions (`tool_call_update` with status completed/failed)
+- Error messages from failed operations
+
+### Enabling Tracing
+
+```toml
+subagentTracingDetail = "full"
+```
+
+Or toggle in TUI:
+- Press `t` to cycle through detail levels
+- Press `T` (Shift+T) to toggle the subagent tree panel
+
+## How It Works
+
+When Ralph TUI executes a task with Grok:
+
+1. **Build command**: Constructs `grok --always-approve --output-format streaming-json --prompt-file /dev/stdin [options]`
+2. **Pass prompt via stdin**: Uses `--prompt-file /dev/stdin` (Grok does not read bare stdin) so the prompt is not shell-escaped
+3. **Stream output**: Captures stdout/stderr in real-time
+4. **Parse JSONL**: Extracts structured tool call data and text deltas
+5. **Detect completion**: Watches for process exit
+6. **Handle exit**: Reports success, failure, or timeout
+
+### CLI Arguments
+
+Ralph TUI builds these arguments:
+
+```bash
+grok \
+  --always-approve \                 # Auto-approve tool executions
+  --output-format streaming-json \   # Structured NDJSON for parsing
+  --prompt-file /dev/stdin \         # Read prompt from stdin (Unix)
+  --model grok-4.5 \                 # If model specified
+  < prompt.txt
+```
+
+On Windows, the prompt is passed with `-p` instead of `--prompt-file /dev/stdin`.
+
+<Callout type="info">
+`--always-approve` is required for Ralph TUI's autonomous workflow. Do not confuse this with other CLIs' `--dangerously-skip-permissions` flag — Grok uses its own flag name.
+</Callout>
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `Grok CLI not found in PATH` | Install the official CLI and add `~/.grok/bin` to PATH |
+| Preflight fails / no output | Run `grok -p "hello" --always-approve` and check auth with `grok login` |
+| Auth errors | Ensure `~/.grok/auth.json` exists; re-run `grok login` |
+| Wrong output format errors | Must use `streaming-json` (not `stream-json`) |
+| Model not found | Run `grok models` and set a listed model ID |
+
+```bash
+# Manual smoke tests
+grok --version
+grok -p "hello" --always-approve
+grok -p "hello" --output-format streaming-json --always-approve
+ralph-tui doctor --agent grok
+```
+
+## Next Steps
+
+- [Plugins Overview](/docs/plugins/overview) — How agent plugins work
+- [Configuration](/docs/configuration) — Full config reference
+- [Running Ralph](/docs/getting-started) — Start an agent loop

--- a/website/lib/navigation.ts
+++ b/website/lib/navigation.ts
@@ -85,6 +85,7 @@ export const docsNavigation: NavItem[] = [
           { title: 'Cursor', href: '/docs/plugins/agents/cursor', label: 'New' },
           { title: 'Gemini', href: '/docs/plugins/agents/gemini', label: 'New' },
           { title: 'GitHub Copilot', href: '/docs/plugins/agents/github-copilot', label: 'New' },
+          { title: 'Grok', href: '/docs/plugins/agents/grok', label: 'New' },
           { title: 'Kimi', href: '/docs/plugins/agents/kimi', label: 'New' },
           { title: 'Kiro', href: '/docs/plugins/agents/kiro', label: 'New' },
           { title: 'Pi', href: '/docs/plugins/agents/pi', label: 'New' },


### PR DESCRIPTION
## Summary
Closes #402. Adds a built-in agent plugin for xAI's official `grok` CLI, following the project's own "Adding a New Agent Plugin" checklist in CONTRIBUTING.md.

- `src/plugins/agents/builtin/grok.ts` — modeled on `pi.ts`/`kimi.ts`
- Registered in `builtin/index.ts`, `AGENT_ID_MAP` in `setup/skill-installer.ts`
- Docs (`website/content/docs/plugins/agents/grok.mdx`) + nav entry
- 46 unit tests

Authenticates via the `grok` CLI's own OAuth session (SuperGrok subscription) — no separate API key required.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] `bun test src/plugins/agents/builtin/grok.test.ts` — 46 pass
- [x] `bun run dist/cli.js doctor --agent grok` — HEALTHY (real preflight round-trip, not mocked)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Grok CLI agent, including model selection, streaming output, tool calls, and platform-specific prompt handling.
  * Added Grok to built-in agent registration and skill installation.
* **Documentation**
  * Added setup, authentication, configuration, usage, troubleshooting, and testing guidance for Grok.
  * Added the Grok agent page to the Plugins → Agents navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->