### PR TITLE
feat: add built-in Antigravity CLI (agy) agent plugin

### DIFF
--- a/src/plugins/agents/builtin/antigravity.test.ts
+++ b/src/plugins/agents/builtin/antigravity.test.ts
@@ -1,0 +1,405 @@
+/**
+ * ABOUTME: Tests for the Antigravity CLI agent plugin.
+ * Tests configuration, argument building, and stream-json parsing for Google's agy CLI.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import {
+  AntigravityAgentPlugin,
+  parseAntigravityJsonLine,
+  parseAntigravityOutputToEvents,
+} from './antigravity.js';
+
+describe('AntigravityAgentPlugin', () => {
+  let plugin: AntigravityAgentPlugin;
+
+  beforeEach(() => {
+    plugin = new AntigravityAgentPlugin();
+  });
+
+  afterEach(async () => {
+    await plugin.dispose();
+  });
+
+  describe('meta', () => {
+    test('has correct plugin ID', () => {
+      expect(plugin.meta.id).toBe('antigravity');
+    });
+
+    test('has correct name', () => {
+      expect(plugin.meta.name).toBe('Antigravity CLI');
+    });
+
+    test('has correct default command', () => {
+      expect(plugin.meta.defaultCommand).toBe('agy');
+    });
+
+    test('supports streaming', () => {
+      expect(plugin.meta.supportsStreaming).toBe(true);
+    });
+
+    test('supports interrupt', () => {
+      expect(plugin.meta.supportsInterrupt).toBe(true);
+    });
+
+    test('supports subagent tracing', () => {
+      expect(plugin.meta.supportsSubagentTracing).toBe(true);
+    });
+
+    test('has JSONL structured output format', () => {
+      expect(plugin.meta.structuredOutputFormat).toBe('jsonl');
+    });
+
+    test('has skills paths configured', () => {
+      expect(plugin.meta.skillsPaths?.personal).toBe('~/.gemini/antigravity-cli/skills');
+      expect(plugin.meta.skillsPaths?.repo).toBe('.agents/skills');
+    });
+  });
+
+  describe('initialize', () => {
+    test('initializes with default config', async () => {
+      await plugin.initialize({});
+      expect(await plugin.isReady()).toBe(true);
+    });
+
+    test('accepts model configuration', async () => {
+      await plugin.initialize({ model: 'gemini-3.1-pro-low' });
+      expect(await plugin.isReady()).toBe(true);
+    });
+
+    test('accepts skipPermissions configuration', async () => {
+      await plugin.initialize({ skipPermissions: false });
+      expect(await plugin.isReady()).toBe(true);
+    });
+
+    test('accepts timeout configuration', async () => {
+      await plugin.initialize({ timeout: 300000 });
+      expect(await plugin.isReady()).toBe(true);
+    });
+  });
+
+  describe('getSetupQuestions', () => {
+    test('includes model question with choices', () => {
+      const questions = plugin.getSetupQuestions();
+      const modelQuestion = questions.find((q) => q.id === 'model');
+      expect(modelQuestion).toBeDefined();
+      expect(modelQuestion?.type).toBe('select');
+      expect(modelQuestion?.choices?.length).toBeGreaterThan(0);
+    });
+
+    test('includes known antigravity model choices', () => {
+      const questions = plugin.getSetupQuestions();
+      const modelQuestion = questions.find((q) => q.id === 'model');
+      const values = (modelQuestion?.choices ?? []).map((c) => c.value);
+      expect(values).toContain('gemini-3.1-pro-low');
+      expect(values).toContain('claude-sonnet-4-6');
+      expect(values).toContain('gpt-oss-120b-medium');
+    });
+
+    test('includes skipPermissions question', () => {
+      const questions = plugin.getSetupQuestions();
+      const skipQuestion = questions.find((q) => q.id === 'skipPermissions');
+      expect(skipQuestion).toBeDefined();
+      expect(skipQuestion?.type).toBe('boolean');
+      expect(skipQuestion?.default).toBe(true);
+    });
+
+    test('includes base questions (command, timeout)', () => {
+      const questions = plugin.getSetupQuestions();
+      expect(questions.find((q) => q.id === 'command')).toBeDefined();
+      expect(questions.find((q) => q.id === 'timeout')).toBeDefined();
+    });
+  });
+
+  describe('validateSetup', () => {
+    test('accepts valid model', async () => {
+      const result = await plugin.validateSetup({ model: 'gemini-3.1-pro-high' });
+      expect(result).toBeNull();
+    });
+
+    test('accepts empty model', async () => {
+      const result = await plugin.validateSetup({ model: '' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('validateModel', () => {
+    test('accepts known models', () => {
+      expect(plugin.validateModel('gemini-3.1-pro-low')).toBeNull();
+      expect(plugin.validateModel('claude-opus-4-6-thinking')).toBeNull();
+    });
+
+    test('accepts empty model', () => {
+      expect(plugin.validateModel('')).toBeNull();
+    });
+
+    test('accepts unknown model strings (list drifts)', () => {
+      expect(plugin.validateModel('gemini-future-model-high')).toBeNull();
+    });
+  });
+
+  describe('listModels', () => {
+    test('lists known Antigravity models', () => {
+      const models = plugin.listModels();
+      expect(models).toContain('gemini-3.6-flash-low');
+      expect(models).toContain('gemini-3.1-pro-high');
+      expect(models).toContain('claude-sonnet-4-6');
+    });
+  });
+
+  describe('getSandboxRequirements', () => {
+    test('includes gemini auth path', () => {
+      const requirements = plugin.getSandboxRequirements();
+      expect(requirements.authPaths).toContain('~/.gemini');
+      expect(requirements.requiresNetwork).toBe(true);
+    });
+  });
+});
+
+describe('AntigravityAgentPlugin buildArgs', () => {
+  class TestableAntigravityPlugin extends AntigravityAgentPlugin {
+    testBuildArgs(prompt: string): string[] {
+      return (this as unknown as { buildArgs: (p: string) => string[] }).buildArgs(prompt);
+    }
+
+    testGetStdinInput(prompt: string): string | undefined {
+      return (this as unknown as { getStdinInput: (p: string) => string | undefined }).getStdinInput(prompt);
+    }
+  }
+
+  let plugin: TestableAntigravityPlugin;
+
+  beforeEach(() => {
+    plugin = new TestableAntigravityPlugin();
+  });
+
+  afterEach(async () => {
+    await plugin.dispose();
+  });
+
+  test('includes --output-format stream-json', async () => {
+    await plugin.initialize({});
+    const args = plugin.testBuildArgs('test prompt');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('stream-json');
+  });
+
+  test('includes --dangerously-skip-permissions by default', async () => {
+    await plugin.initialize({});
+    const args = plugin.testBuildArgs('test prompt');
+    expect(args).toContain('--dangerously-skip-permissions');
+  });
+
+  test('omits --dangerously-skip-permissions when disabled', async () => {
+    await plugin.initialize({ skipPermissions: false });
+    const args = plugin.testBuildArgs('test prompt');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  test('includes model flag when specified', async () => {
+    await plugin.initialize({ model: 'gemini-3.1-pro-low' });
+    const args = plugin.testBuildArgs('test prompt');
+    expect(args).toContain('--model');
+    expect(args).toContain('gemini-3.1-pro-low');
+  });
+
+  test('omits model flag when not specified', async () => {
+    await plugin.initialize({});
+    const args = plugin.testBuildArgs('test prompt');
+    expect(args).not.toContain('--model');
+  });
+
+  test('does not pass --print (requires prompt arg; stdin is used instead)', async () => {
+    await plugin.initialize({});
+    const args = plugin.testBuildArgs('test prompt');
+    expect(args).not.toContain('--print');
+    expect(args).not.toContain('-p');
+    expect(args).not.toContain('--prompt');
+  });
+
+  test('returns prompt via stdin', async () => {
+    await plugin.initialize({});
+    expect(plugin.testGetStdinInput('my test prompt')).toBe('my test prompt');
+  });
+});
+
+describe('parseAntigravityJsonLine', () => {
+  test('returns empty array for empty input', () => {
+    expect(parseAntigravityJsonLine('')).toEqual([]);
+  });
+
+  test('returns empty array for invalid JSON', () => {
+    expect(parseAntigravityJsonLine('not json')).toEqual([]);
+    expect(parseAntigravityJsonLine('{ invalid')).toEqual([]);
+  });
+
+  test('skips init events', () => {
+    const input = JSON.stringify({
+      event: 'init',
+      init: { model: 'gemini-3.1-pro-low', tools: [] },
+    });
+    expect(parseAntigravityJsonLine(input)).toEqual([]);
+  });
+
+  test('parses agent_response text_delta', () => {
+    const input = JSON.stringify({
+      event: 'step_update',
+      step_update: {
+        step_index: 3,
+        state: 'DONE',
+        step_type: 'agent_response',
+        text_delta: 'Hello to you.\n',
+      },
+    });
+    const events = parseAntigravityJsonLine(input);
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('text');
+    expect((events[0] as { content: string }).content).toBe('Hello to you.\n');
+  });
+
+  test('skips agent_response without text_delta', () => {
+    const input = JSON.stringify({
+      event: 'step_update',
+      step_update: {
+        step_index: 1,
+        state: 'DONE',
+        step_type: 'agent_response',
+      },
+    });
+    expect(parseAntigravityJsonLine(input)).toEqual([]);
+  });
+
+  test('parses tool ACTIVE as tool_use', () => {
+    const input = JSON.stringify({
+      event: 'step_update',
+      step_update: {
+        step_index: 4,
+        state: 'ACTIVE',
+        step_type: 'tool',
+        tool_name: 'list_dir',
+        tool_info: {
+          name: 'list_dir',
+          parameters: { DirectoryPath: '/tmp' },
+        },
+      },
+    });
+    const events = parseAntigravityJsonLine(input);
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('tool_use');
+    expect((events[0] as { name: string }).name).toBe('list_dir');
+    expect((events[0] as { input: unknown }).input).toEqual({ DirectoryPath: '/tmp' });
+  });
+
+  test('parses tool DONE as tool_result', () => {
+    const input = JSON.stringify({
+      event: 'step_update',
+      step_update: {
+        step_index: 4,
+        state: 'DONE',
+        step_type: 'tool',
+        tool_name: 'list_dir',
+        tool_info: { name: 'list_dir', parameters: {} },
+      },
+    });
+    const events = parseAntigravityJsonLine(input);
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('tool_result');
+  });
+
+  test('skips user_input and checkpoint steps', () => {
+    expect(
+      parseAntigravityJsonLine(
+        JSON.stringify({
+          event: 'step_update',
+          step_update: { step_type: 'user_input', state: 'DONE' },
+        })
+      )
+    ).toEqual([]);
+    expect(
+      parseAntigravityJsonLine(
+        JSON.stringify({
+          event: 'step_update',
+          step_update: { step_type: 'checkpoint', state: 'DONE' },
+        })
+      )
+    ).toEqual([]);
+  });
+
+  test('parses result ERROR', () => {
+    const input = JSON.stringify({
+      event: 'result',
+      result: {
+        status: 'ERROR',
+        response: '',
+        error: 'Error: empty prompt',
+      },
+    });
+    const events = parseAntigravityJsonLine(input);
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('error');
+    expect((events[0] as { message: string }).message).toContain('empty prompt');
+  });
+
+  test('skips result SUCCESS', () => {
+    const input = JSON.stringify({
+      event: 'result',
+      result: {
+        status: 'SUCCESS',
+        response: 'Hello to you.\n',
+      },
+    });
+    expect(parseAntigravityJsonLine(input)).toEqual([]);
+  });
+
+  test('handles missing step_update payload', () => {
+    expect(parseAntigravityJsonLine(JSON.stringify({ event: 'step_update' }))).toEqual([]);
+  });
+
+  test('handles tool without tool_name using tool_info.name', () => {
+    const input = JSON.stringify({
+      event: 'step_update',
+      step_update: {
+        state: 'ACTIVE',
+        step_type: 'tool',
+        tool_info: { name: 'grep_search', parameters: { Pattern: 'foo' } },
+      },
+    });
+    const events = parseAntigravityJsonLine(input);
+    expect(events[0]?.type).toBe('tool_use');
+    expect((events[0] as { name: string }).name).toBe('grep_search');
+  });
+});
+
+describe('parseAntigravityOutputToEvents', () => {
+  test('parses multiple JSONL lines', () => {
+    const lines = [
+      JSON.stringify({
+        event: 'step_update',
+        step_update: { step_type: 'agent_response', text_delta: 'Line 1', state: 'DONE' },
+      }),
+      JSON.stringify({
+        event: 'step_update',
+        step_update: { step_type: 'agent_response', text_delta: 'Line 2', state: 'DONE' },
+      }),
+    ].join('\n');
+    const events = parseAntigravityOutputToEvents(lines);
+    expect(events.length).toBe(2);
+    expect((events[0] as { content: string }).content).toBe('Line 1');
+    expect((events[1] as { content: string }).content).toBe('Line 2');
+  });
+
+  test('handles empty and invalid lines', () => {
+    const lines = [
+      '',
+      'not json',
+      JSON.stringify({
+        event: 'step_update',
+        step_update: { step_type: 'agent_response', text_delta: 'Valid', state: 'ACTIVE' },
+      }),
+      JSON.stringify({ event: 'init', init: {} }),
+    ].join('\n');
+    const events = parseAntigravityOutputToEvents(lines);
+    expect(events.length).toBe(1);
+    expect((events[0] as { content: string }).content).toBe('Valid');
+  });
+});

--- a/src/plugins/agents/builtin/antigravity.ts
+++ b/src/plugins/agents/builtin/antigravity.ts
@@ -1,0 +1,479 @@
+/**
+ * ABOUTME: Antigravity CLI agent plugin for Google's agy command.
+ * Integrates with Antigravity CLI for Gemini/Claude/GPT-OSS models.
+ * Supports: stream-json output, stdin prompt, model selection, auto-approve permissions.
+ */
+
+import { spawn } from 'node:child_process';
+import { BaseAgentPlugin, findCommandPath, quoteForWindowsShell } from '../base.js';
+import { processAgentEvents, processAgentEventsToSegments, type AgentDisplayEvent } from '../output-formatting.js';
+import { extractErrorMessage } from '../utils.js';
+import type {
+  AgentPluginMeta,
+  AgentPluginFactory,
+  AgentFileContext,
+  AgentExecuteOptions,
+  AgentSetupQuestion,
+  AgentDetectResult,
+  AgentExecutionHandle,
+} from '../types.js';
+
+/**
+ * Known Antigravity model IDs from `agy models`.
+ * Model strings already encode effort (e.g. gemini-3.1-pro-high).
+ */
+const ANTIGRAVITY_MODELS = [
+  'gemini-3.6-flash-high',
+  'gemini-3.6-flash-medium',
+  'gemini-3.6-flash-low',
+  'gemini-3.5-flash-high',
+  'gemini-3.5-flash-medium',
+  'gemini-3.5-flash-low',
+  'gemini-3.1-pro-high',
+  'gemini-3.1-pro-low',
+  'claude-sonnet-4-6',
+  'claude-opus-4-6-thinking',
+  'gpt-oss-120b-medium',
+] as const;
+
+/**
+ * Parse an Antigravity stream-json line into standardized display events.
+ *
+ * Event shapes (agy --output-format stream-json):
+ * - {"event":"init","init":{...}} — session start (skip)
+ * - {"event":"step_update","step_update":{"step_type":"agent_response","text_delta":"..."}}
+ * - {"event":"step_update","step_update":{"step_type":"tool","state":"ACTIVE"|"DONE","tool_name":"...","tool_info":{...}}}
+ * - {"event":"result","result":{"status":"SUCCESS"|"ERROR","response":"...","error":"..."}}
+ *
+ * @internal Exported for testing only.
+ */
+export function parseAntigravityJsonLine(jsonLine: string): AgentDisplayEvent[] {
+  if (!jsonLine || jsonLine.length === 0) return [];
+
+  try {
+    const event = JSON.parse(jsonLine) as Record<string, unknown>;
+    const events: AgentDisplayEvent[] = [];
+    const eventType = event.event;
+
+    if (eventType === 'step_update') {
+      const stepUpdate = event.step_update;
+      if (stepUpdate == null || typeof stepUpdate !== 'object' || Array.isArray(stepUpdate)) {
+        return [];
+      }
+      const step = stepUpdate as Record<string, unknown>;
+      const stepType = step.step_type;
+      const state = step.state;
+
+      if (stepType === 'agent_response') {
+        if (typeof step.text_delta === 'string' && step.text_delta.length > 0) {
+          events.push({ type: 'text', content: step.text_delta });
+        }
+      } else if (stepType === 'tool') {
+        if (state === 'ACTIVE') {
+          const toolName =
+            (typeof step.tool_name === 'string' && step.tool_name) ||
+            (step.tool_info != null &&
+            typeof step.tool_info === 'object' &&
+            !Array.isArray(step.tool_info) &&
+            typeof (step.tool_info as Record<string, unknown>).name === 'string'
+              ? ((step.tool_info as Record<string, unknown>).name as string)
+              : 'unknown');
+          let toolInput: Record<string, unknown> | undefined;
+          if (
+            step.tool_info != null &&
+            typeof step.tool_info === 'object' &&
+            !Array.isArray(step.tool_info)
+          ) {
+            const info = step.tool_info as Record<string, unknown>;
+            if (info.parameters != null && typeof info.parameters === 'object' && !Array.isArray(info.parameters)) {
+              toolInput = info.parameters as Record<string, unknown>;
+            } else {
+              toolInput = info;
+            }
+          }
+          events.push({ type: 'tool_use', name: toolName, input: toolInput });
+        } else if (state === 'DONE') {
+          events.push({ type: 'tool_result' });
+        }
+      }
+      // Skip: user_input, checkpoint, unknown, and other non-display steps
+    } else if (eventType === 'result') {
+      const result = event.result;
+      if (result != null && typeof result === 'object' && !Array.isArray(result)) {
+        const resultObj = result as Record<string, unknown>;
+        if (resultObj.status === 'ERROR') {
+          const errorMsg =
+            extractErrorMessage(resultObj.error) ||
+            extractErrorMessage(resultObj.response) ||
+            'Unknown error';
+          events.push({ type: 'error', message: errorMsg });
+        }
+      }
+    }
+    // Skip: init and other non-content events
+
+    return events;
+  } catch {
+    // Not valid JSON - skip silently
+    return [];
+  }
+}
+
+/**
+ * Parse Antigravity stream-json output into display events.
+ * @internal Exported for testing only.
+ */
+export function parseAntigravityOutputToEvents(data: string): AgentDisplayEvent[] {
+  const allEvents: AgentDisplayEvent[] = [];
+  for (const line of data.split('\n')) {
+    const events = parseAntigravityJsonLine(line.trim());
+    allEvents.push(...events);
+  }
+  return allEvents;
+}
+
+/**
+ * Antigravity CLI agent plugin implementation.
+ * Uses the `agy` CLI with stream-json output for non-interactive AI coding tasks.
+ * Prompt is delivered via stdin (do not pass --print; that flag requires a prompt arg).
+ */
+export class AntigravityAgentPlugin extends BaseAgentPlugin {
+  readonly meta: AgentPluginMeta = {
+    id: 'antigravity',
+    name: 'Antigravity CLI',
+    description: "Google's Antigravity CLI (agy) for Gemini, Claude, and GPT-OSS models",
+    version: '1.0.0',
+    author: 'Google',
+    defaultCommand: 'agy',
+    supportsStreaming: true,
+    supportsInterrupt: true,
+    supportsFileContext: false,
+    supportsSubagentTracing: true,
+    structuredOutputFormat: 'jsonl',
+    skillsPaths: {
+      personal: '~/.gemini/antigravity-cli/skills',
+      repo: '.agents/skills',
+    },
+  };
+
+  private model?: string;
+  private skipPermissions = true;
+  protected override defaultTimeout = 0;
+
+  override async initialize(config: Record<string, unknown>): Promise<void> {
+    await super.initialize(config);
+
+    if (typeof config.model === 'string' && config.model.length > 0) {
+      this.model = config.model;
+    }
+
+    if (typeof config.skipPermissions === 'boolean') {
+      this.skipPermissions = config.skipPermissions;
+    }
+
+    if (typeof config.timeout === 'number' && config.timeout > 0) {
+      this.defaultTimeout = config.timeout;
+    }
+  }
+
+  override async detect(): Promise<AgentDetectResult> {
+    const command = this.commandPath ?? this.meta.defaultCommand;
+    const findResult = await findCommandPath(command);
+
+    if (!findResult.found) {
+      return {
+        available: false,
+        error:
+          'Antigravity CLI (agy) not found in PATH. Install the Antigravity CLI and ensure `agy` is available.',
+      };
+    }
+
+    const versionResult = await this.runVersion(findResult.path);
+
+    if (!versionResult.success) {
+      return {
+        available: false,
+        executablePath: findResult.path,
+        error: versionResult.error,
+      };
+    }
+
+    this.commandPath = findResult.path;
+
+    return {
+      available: true,
+      version: versionResult.version,
+      executablePath: findResult.path,
+    };
+  }
+
+  private runVersion(
+    command: string
+  ): Promise<{ success: boolean; version?: string; error?: string }> {
+    return new Promise((resolve) => {
+      const useShell = process.platform === 'win32';
+      const proc = spawn(useShell ? quoteForWindowsShell(command) : command, ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: useShell,
+      });
+
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+
+      const safeResolve = (result: { success: boolean; version?: string; error?: string }) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      };
+
+      proc.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      proc.on('error', (error) => {
+        safeResolve({ success: false, error: `Failed to execute: ${error.message}` });
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          const versionMatch = stdout.match(/(\d+\.\d+\.\d+)/);
+          if (!versionMatch?.[1]) {
+            safeResolve({
+              success: false,
+              error: `Unable to parse agy version output: ${stdout}`,
+            });
+            return;
+          }
+          safeResolve({ success: true, version: versionMatch[1] });
+        } else {
+          safeResolve({ success: false, error: stderr || `Exited with code ${code}` });
+        }
+      });
+
+      const timer = setTimeout(() => {
+        proc.kill();
+        safeResolve({ success: false, error: 'Timeout waiting for --version' });
+      }, 15000);
+    });
+  }
+
+  override getSandboxRequirements() {
+    return {
+      authPaths: ['~/.gemini'],
+      binaryPaths: ['/usr/local/bin', '/opt/homebrew/bin', '~/.local/bin'],
+      runtimePaths: [],
+      requiresNetwork: true,
+    };
+  }
+
+  override getSetupQuestions(): AgentSetupQuestion[] {
+    return [
+      ...super.getSetupQuestions(),
+      {
+        id: 'model',
+        prompt: 'Model to use:',
+        type: 'select',
+        choices: [
+          { value: '', label: 'Default', description: 'Use CLI configured default' },
+          ...ANTIGRAVITY_MODELS.map((model) => ({
+            value: model,
+            label: model,
+            description: model,
+          })),
+        ],
+        default: '',
+        required: false,
+        help: 'Model ID from `agy models` (effort is part of the model string)',
+      },
+      {
+        id: 'skipPermissions',
+        prompt: 'Auto-approve tool permissions?',
+        type: 'boolean',
+        default: true,
+        required: false,
+        help: 'Passes --dangerously-skip-permissions for autonomous Ralph TUI runs',
+      },
+    ];
+  }
+
+  protected buildArgs(
+    _prompt: string,
+    _files?: AgentFileContext[],
+    _options?: AgentExecuteOptions
+  ): string[] {
+    const args: string[] = [];
+
+    // stream-json triggers non-interactive print-style output when stdin provides the prompt.
+    // Do not pass --print/--prompt: those flags require a prompt argument and will not read stdin.
+    args.push('--output-format', 'stream-json');
+
+    if (this.skipPermissions) {
+      args.push('--dangerously-skip-permissions');
+    }
+
+    if (this.model) {
+      args.push('--model', this.model);
+    }
+
+    return args;
+  }
+
+  /**
+   * Provide the prompt via stdin.
+   * agy reads stdin when --print/--prompt is omitted (verified with --output-format stream-json).
+   */
+  protected override getStdinInput(
+    prompt: string,
+    _files?: AgentFileContext[],
+    _options?: AgentExecuteOptions
+  ): string {
+    return prompt;
+  }
+
+  /**
+   * Override execute to parse Antigravity stream-json output into display events.
+   */
+  override execute(
+    prompt: string,
+    files?: AgentFileContext[],
+    options?: AgentExecuteOptions
+  ): AgentExecutionHandle {
+    let jsonlBuffer = '';
+
+    const flushBuffer = () => {
+      if (!jsonlBuffer) return;
+      const trimmed = jsonlBuffer.trim();
+      if (!trimmed) return;
+
+      if (options?.onJsonlMessage && trimmed.startsWith('{')) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          options.onJsonlMessage(parsed);
+        } catch {
+          // Not valid JSON, skip
+        }
+      }
+
+      const events = parseAntigravityOutputToEvents(trimmed);
+      if (events.length > 0) {
+        if (options?.onStdoutSegments) {
+          const segments = processAgentEventsToSegments(events);
+          if (segments.length > 0) {
+            options.onStdoutSegments(segments);
+          }
+        }
+        if (options?.onStdout) {
+          const formatted = processAgentEvents(events);
+          if (formatted.length > 0) {
+            options.onStdout(formatted);
+          }
+        }
+      }
+
+      jsonlBuffer = '';
+    };
+
+    const parsedOptions: AgentExecuteOptions = {
+      ...options,
+      onStdout:
+        options?.onStdout || options?.onStdoutSegments || options?.onJsonlMessage
+          ? (data: string) => {
+              const combined = jsonlBuffer + data;
+              const lines = combined.split('\n');
+
+              if (!data.endsWith('\n')) {
+                jsonlBuffer = lines.pop() || '';
+              } else {
+                jsonlBuffer = '';
+              }
+
+              const completeData = lines.join('\n');
+
+              if (options?.onJsonlMessage) {
+                for (const line of lines) {
+                  const trimmed = line.trim();
+                  if (trimmed && trimmed.startsWith('{')) {
+                    try {
+                      const parsed = JSON.parse(trimmed);
+                      options.onJsonlMessage(parsed);
+                    } catch {
+                      // Not valid JSON, skip
+                    }
+                  }
+                }
+              }
+
+              const events = parseAntigravityOutputToEvents(completeData);
+              if (events.length > 0) {
+                if (options?.onStdoutSegments) {
+                  const segments = processAgentEventsToSegments(events);
+                  if (segments.length > 0) {
+                    options.onStdoutSegments(segments);
+                  }
+                }
+                if (options?.onStdout) {
+                  const formatted = processAgentEvents(events);
+                  if (formatted.length > 0) {
+                    options.onStdout(formatted);
+                  }
+                }
+              }
+            }
+          : undefined,
+      onEnd: (result) => {
+        flushBuffer();
+        options?.onEnd?.(result);
+      },
+    };
+
+    return super.execute(prompt, files, parsedOptions);
+  }
+
+  override async validateSetup(answers: Record<string, unknown>): Promise<string | null> {
+    const model = answers.model;
+    if (model !== undefined && model !== '' && typeof model === 'string') {
+      const err = this.validateModel(model);
+      if (err) return err;
+    }
+    return null;
+  }
+
+  override validateModel(model: string): string | null {
+    if (model === '' || model === undefined) {
+      return null;
+    }
+    // Accept any non-empty model string — `agy models` list drifts over time.
+    // Known IDs are offered in setup; custom/newer IDs should still work.
+    if (model.trim().length === 0) {
+      return null;
+    }
+    return null;
+  }
+
+  override listModels(): string[] {
+    return [...ANTIGRAVITY_MODELS];
+  }
+
+  protected override getPreflightSuggestion(): string {
+    return (
+      'Common fixes for Antigravity CLI:\n' +
+      '  1. Test agy directly: printf "hello" | agy --output-format text --dangerously-skip-permissions\n' +
+      '  2. Check install: agy --version\n' +
+      '  3. List models: agy models\n' +
+      '  4. Confirm auth under ~/.gemini (oauth_creds.json)'
+    );
+  }
+}
+
+/**
+ * Factory function for the Antigravity CLI agent plugin.
+ */
+const createAntigravityAgent: AgentPluginFactory = () => new AntigravityAgentPlugin();
+
+export default createAntigravityAgent;

--- a/src/plugins/agents/builtin/index.ts
+++ b/src/plugins/agents/builtin/index.ts
@@ -14,6 +14,7 @@ import createCursorAgent from './cursor.js';
 import createGithubCopilotAgent from './github-copilot.js';
 import createKimiAgent from './kimi.js';
 import createPiAgent from './pi.js';
+import createAntigravityAgent from './antigravity.js';
 
 /**
  * Register all built-in agent plugins with the registry.
@@ -33,6 +34,7 @@ export function registerBuiltinAgents(): void {
   registry.registerBuiltin(createGithubCopilotAgent);
   registry.registerBuiltin(createKimiAgent);
   registry.registerBuiltin(createPiAgent);
+  registry.registerBuiltin(createAntigravityAgent);
 }
 
 // Export the factory functions for direct use
@@ -47,6 +49,7 @@ export {
   createGithubCopilotAgent,
   createKimiAgent,
   createPiAgent,
+  createAntigravityAgent,
 };
 
 // Export Claude JSONL parsing types and utilities
@@ -61,3 +64,4 @@ export { CursorAgentPlugin } from './cursor.js';
 export { GithubCopilotAgentPlugin } from './github-copilot.js';
 export { KimiAgentPlugin } from './kimi.js';
 export { PiAgentPlugin, parsePiJsonLine } from './pi.js';
+export { AntigravityAgentPlugin, parseAntigravityJsonLine, parseAntigravityOutputToEvents } from './antigravity.js';

--- a/src/setup/skill-installer.ts
+++ b/src/setup/skill-installer.ts
@@ -23,6 +23,7 @@ export const AGENT_ID_MAP: Record<string, string> = {
   cursor: 'cursor',
   'github-copilot': 'github-copilot',
   pi: 'pi',
+  antigravity: 'antigravity',
 };
 
 /**

--- a/website/content/docs/plugins/agents/antigravity.mdx
+++ b/website/content/docs/plugins/agents/antigravity.mdx
@@ -1,0 +1,174 @@
+---
+title: Antigravity Agent
+description: Integrate Google's Antigravity CLI (agy) with Ralph TUI for Gemini, Claude, and GPT-OSS models.
+---
+
+## Antigravity Agent
+
+The Antigravity agent plugin integrates with Google's `agy` CLI (Antigravity suite). Use this when the standalone Gemini CLI is unavailable for your account — Antigravity is the working path to Gemini, Claude, and GPT-OSS models via a Google AI Pro subscription.
+
+<Callout type="tip">
+Antigravity supports **subagent tracing** via `--output-format stream-json` — Ralph TUI shows tool calls and text deltas in real time.
+</Callout>
+
+## Prerequisites
+
+Install the Antigravity CLI and ensure `agy` is on your `PATH`:
+
+```bash
+agy --version
+agy models
+```
+
+Authenticate with your Google account so credentials exist under `~/.gemini` (for example `oauth_creds.json`).
+
+## Basic Usage
+
+<Steps>
+  <Step title="Run with Antigravity">
+    Use the `--agent antigravity` flag:
+
+    ```bash
+    ralph-tui run --prd ./prd.json --agent antigravity
+    ```
+  </Step>
+
+  <Step title="Select a Model">
+    Override the model with `--model`. Use an ID from `agy models` (effort is part of the string):
+
+    ```bash
+    ralph-tui run --prd ./prd.json --agent antigravity --model gemini-3.1-pro-high
+    ```
+  </Step>
+</Steps>
+
+## Configuration
+
+### Shorthand Config
+
+```toml
+# .ralph-tui/config.toml
+agent = "antigravity"
+
+[agentOptions]
+model = "gemini-3.1-pro-low"
+skipPermissions = true
+```
+
+### Full Config
+
+```toml
+[[agents]]
+name = "my-antigravity"
+plugin = "antigravity"
+default = true
+command = "agy"
+timeout = 300000
+
+[agents.options]
+model = "gemini-3.1-pro-high"
+skipPermissions = true
+```
+
+### Options Reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `model` | string | - | Model ID from `agy models` (e.g. `gemini-3.1-pro-high`). Leave empty for CLI default. |
+| `skipPermissions` | boolean | `true` | Pass `--dangerously-skip-permissions` to auto-approve tools |
+| `timeout` | number | `0` | Execution timeout in ms (0 = no timeout) |
+| `command` | string | `"agy"` | Path to Antigravity CLI executable |
+
+## Models
+
+List accepted IDs with:
+
+```bash
+agy models
+```
+
+Examples (list may drift):
+
+- `gemini-3.6-flash-high` / `medium` / `low`
+- `gemini-3.5-flash-high` / `medium` / `low`
+- `gemini-3.1-pro-high` / `low`
+- `claude-sonnet-4-6`
+- `claude-opus-4-6-thinking`
+- `gpt-oss-120b-medium`
+
+## Subagent Tracing
+
+Antigravity emits JSONL events via `--output-format stream-json`. Ralph TUI parses:
+
+- Text deltas from `step_update` / `agent_response`
+- Tool start/finish from `step_update` / `tool`
+- Errors from `result` with `status: ERROR`
+
+### Enabling Tracing
+
+```toml
+subagentTracingDetail = "full"
+```
+
+Or toggle in TUI:
+- Press `t` to cycle through detail levels
+- Press `T` (Shift+T) to toggle the subagent tree panel
+
+## How It Works
+
+When Ralph TUI executes a task with Antigravity:
+
+1. **Build command**: `agy --output-format stream-json [--dangerously-skip-permissions] [--model …]`
+2. **Pass prompt via stdin**: Avoids shell escaping; `--print` is omitted because that flag requires a prompt argument
+3. **Stream output**: Captures stdout JSONL in real time
+4. **Parse events**: Maps step updates and results into display events
+5. **Detect completion**: Watches for process exit
+
+### CLI Arguments
+
+```bash
+agy \
+  --output-format stream-json \
+  --dangerously-skip-permissions \
+  --model gemini-3.1-pro-low \
+  < prompt.txt
+```
+
+<Callout type="info">
+Do not pass `--print` / `-p` when using stdin. Those flags take the prompt as an argument; with `--output-format stream-json`, `agy` reads the prompt from stdin and runs non-interactively.
+</Callout>
+
+## Troubleshooting
+
+### "Antigravity CLI (agy) not found"
+
+```bash
+agy --version
+which agy
+```
+
+Install the Antigravity CLI and ensure Homebrew (or your install path) is on `PATH`.
+
+### Auth / permission errors
+
+Confirm credentials under `~/.gemini` and re-authenticate if needed. For autonomous runs, keep `skipPermissions = true` so Ralph TUI passes `--dangerously-skip-permissions`.
+
+### Invalid model
+
+```bash
+agy models
+```
+
+Use an exact ID from that list (effort is included in the model string).
+
+### Doctor check
+
+```bash
+ralph-tui doctor --agent antigravity
+```
+
+## Next Steps
+
+- **[Gemini Agent](/docs/plugins/agents/gemini)** - Legacy standalone Gemini CLI
+- **[Claude Agent](/docs/plugins/agents/claude)** - Anthropic's Claude Code
+- **[Configuration](/docs/configuration/options)** - Full options reference

--- a/website/lib/navigation.ts
+++ b/website/lib/navigation.ts
@@ -78,6 +78,7 @@ export const docsNavigation: NavItem[] = [
       {
         title: 'Agents',
         items: [
+          { title: 'Antigravity', href: '/docs/plugins/agents/antigravity', label: 'New' },
           { title: 'Claude', href: '/docs/plugins/agents/claude' },
           { title: 'OpenCode', href: '/docs/plugins/agents/opencode' },
           { title: 'Factory Droid', href: '/docs/plugins/agents/droid' },


### PR DESCRIPTION
## Summary
Adds a built-in agent plugin for Google's Antigravity CLI (`agy`) — the multi-model (Gemini/Claude/GPT-OSS) CLI under a Google AI Pro subscription.

Not a fix to the existing `gemini` plugin — that one wraps Google's separate standalone `gemini-cli`, which as of 2026-08-02 returns `IneligibleTierError` for individual-account OAuth ("migrate to the Antigravity suite of products"). Antigravity is the actual working path to these models now.

- `src/plugins/agents/builtin/antigravity.ts` — modeled on `pi.ts`/`gemini.ts`, stdin prompt input, `--output-format stream-json` event parsing, `--dangerously-skip-permissions`
- Registered in `builtin/index.ts`, `AGENT_ID_MAP` in `setup/skill-installer.ts`
- Docs (`website/content/docs/plugins/agents/antigravity.mdx`) + nav entry
- 44 unit tests

Built as a proper built-in (relative imports within the package) rather than an external user plugin — an earlier attempt at the latter hit a real bug where importing the published `ralph-tui` package from outside triggers a duplicate `@opentui/core` environment-variable registration crash.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] `bun test src/plugins/agents/builtin/antigravity.test.ts` — 44 pass
- [x] `bun run dist/cli.js doctor --agent antigravity` — HEALTHY (real preflight round-trip, not mocked)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Antigravity (`agy`) CLI agent.
  * Added model selection, sandbox configuration, setup validation, streaming output, tool events, and error handling.
  * Registered Antigravity for built-in use and skill installation.

* **Documentation**
  * Added setup, usage, configuration, troubleshooting, and model selection guidance.
  * Added Antigravity to the agent documentation navigation.

* **Tests**
  * Added comprehensive coverage for configuration, validation, output parsing, arguments, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->